### PR TITLE
fix(subagent): make timeout a startup-only safeguard

### DIFF
--- a/packages/subagent/src/stream.ts
+++ b/packages/subagent/src/stream.ts
@@ -25,10 +25,29 @@ export function streamEvents(
 ): Promise<SubagentResult> {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
-    const timeout = setTimeout(() => {
+
+    // Startup safeguard: if the child produces no JSON event within
+    // STARTUP_TIMEOUT_MS, kill it. This guards against hangs during pi
+    // initialization (model never loads, auth fails, etc.) and is the only
+    // automatic timeout. Once any event arrives the model is considered
+    // active and runtime is controlled entirely by the user's abort
+    // signal — a model that is REALLY thinking is left alone until the
+    // user explicitly cancels.
+    const STARTUP_TIMEOUT_MS = 2 * 60 * 1000;
+
+    let startupTimer: NodeJS.Timeout | undefined = setTimeout(() => {
       child.kill("SIGKILL");
-      reject(new Error("subagent timed out after 5 minutes"));
-    }, 5 * 60 * 1000);
+      reject(new Error(
+        `subagent timed out: no model output within ${STARTUP_TIMEOUT_MS / 60_000} minutes of startup`,
+      ));
+    }, STARTUP_TIMEOUT_MS);
+
+    const clearStartupTimer = (): void => {
+      if (startupTimer) {
+        clearTimeout(startupTimer);
+        startupTimer = undefined;
+      }
+    };
 
     const state: StreamState = {
       toolCount: 0,
@@ -97,6 +116,10 @@ export function streamEvents(
         return; // Skip non-JSON lines
       }
 
+      // First event received from the child means the model has engaged —
+      // from here on, the user controls lifetime via the abort signal.
+      clearStartupTimer();
+
       switch (event.type) {
         case "tool_execution_start": {
           handleToolStart(state, event);
@@ -131,7 +154,7 @@ export function streamEvents(
 
     // Handle process exit
     child.on("close", (code) => {
-      clearTimeout(timeout);
+      clearStartupTimer();
       clearInterval(heartbeat);
       const durationMs = Date.now() - startTime;
       const exitCode = code ?? 1;
@@ -174,7 +197,7 @@ export function streamEvents(
     });
 
     child.on("error", (err) => {
-      clearTimeout(timeout);
+      clearStartupTimer();
       clearInterval(heartbeat);
       reject(err);
     });


### PR DESCRIPTION
## Problem

The 5-minute `setTimeout` in `streamEvents` was a hard cutoff: it killed subagents whose model was actively working past the mark. That's wrong — a slow model is not a stuck model.

## Fix

Replace the single hard timeout with a 2-minute **startup** timer:

- **0–2 min, no event**: child is killed ("no model output within 2 minutes of startup"). Guards against real failure modes — pi binary missing, model fails to load, auth missing, child crashes silently.
- **First event arrives**: timer cleared. From here, **no automatic timeout**.
- **Model is active (or REALLY thinking)**: runs indefinitely. Cancellation is the user's job, via the existing `AbortSignal` already plumbed through `spawnSubagent` (SIGTERM, then SIGKILL after 3s).

## Behavior table

| Phase | Behavior |
|---|---|
| Spawn → 2 min, no event | Killed. Startup safeguard fires. |
| First event arrives | Startup timer cleared. |
| Model active / thinking | No auto-timeout. User cancels via abort signal. |
| Model finishes normally | Resolves as before. |

## Why no inactivity timer post-startup

A model that goes quiet mid-run is not necessarily stuck — it may be in a long tool call, deep reasoning, or simply slow. The user has the context (how long has this been running? is it actually thinking or stuck?) that no timer can replicate. The right cancellation mechanism is the one they already control.

## Verification

- `npx tsc --noEmit` in `packages/subagent` passes cleanly.
- `git diff main` is 33 lines, single file.

Closes the discussion in the prior session about subagent timeout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream event handling with a faster 2-minute startup timeout. Processes that fail to produce output during startup are now terminated promptly, replacing the previous 5-minute fixed timeout.
  * Added automatic cleanup of startup timers to ensure proper resource management when processes become active or close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->