### PR TITLE
feat: add /agents slash command for agent CRUD

### DIFF
--- a/docs/plans/2026-06-13-agents-command.md
+++ b/docs/plans/2026-06-13-agents-command.md
@@ -6,7 +6,7 @@
 
 ---
 
-### Task 1: Expand AgentConfig and add frontmatter I/O
+## Task 1: Expand AgentConfig and add frontmatter I/O
 
 **Context:**
 The existing `AgentConfig` in `packages/subagent/src/agents.ts` only supports 6 fields (name, description, model, thinking, tools, systemPrompt). The `/agents` command needs the full agentspec v0.5.0 field set plus `extraFields` for unknown fields. We also need a serializer that round-trips frontmatter faithfully. The existing `parseFrontmatter` from `@earendil-works/pi-coding-agent` is used for parsing — we wrap it and add serialization.
@@ -80,7 +80,7 @@ This wraps the existing `discoverAgents` logic but returns separate arrays + dir
 
 ---
 
-### Task 2: Build the agent-manager TUI component
+## Task 2: Build the agent-manager TUI component
 
 **Context:**
 The core of the feature — a TUI overlay component with 5 screens: List, Detail, Edit, Name Input, Confirm Delete. This is the largest task (~600-800 lines). It follows the visual design from pi-subagents' AgentManager: header bar, search bar, 8-item viewport, preview bar, contextual footer. The component implements pi's `Component` interface (`render`, `handleInput`, `invalidate`, `dispose`).
@@ -303,7 +303,7 @@ interface Component {
 
 ---
 
-### Task 3: Register /agents command and wire into meta
+## Task 3: Register /agents command and wire into meta
 
 **Context:**
 The agent-manager component needs to be exposed as a `/agents` slash command. Following the existing pattern in `packages/subagent/src/index.ts` (where `registerSubagent(pi)` calls `pi.registerTool` internally), we add `registerAgentsCommand(pi)` that calls `pi.registerCommand("agents", ...)`. The command handler uses `ctx.ui.custom()` with `{ overlay: true }` to open the TUI.
@@ -324,26 +324,32 @@ export function registerAgentsCommand(pi: ExtensionAPI): void {
     description: "Open the Agents Manager",
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
       const { user, project, userDir, projectDir } = discoverAgentsAll(ctx.cwd);
-      const manager = createAgentManager(user, project, userDir, projectDir);
+
+      const availableModels = ctx.modelRegistry.getAvailable().map((m) => ({
+        id: m.id,
+        provider: m.provider,
+        fullId: `${m.provider}/${m.id}`,
+      }));
+
+      const availableTools = pi.getAllTools().map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+      }));
 
       await ctx.ui.custom<void>(
-        (tui, theme, _keybindings, done) => {
-          // Wrap the manager component to inject tui/theme and provide done callback
-          return {
-            render(width: number): string[] {
-              return manager.render(width);
-            },
-            handleInput(data: string): void {
-              const result = manager.handleInput(data);
-              if (result === "close") {
-                done(undefined);
-              } else {
-                tui.requestRender();
-              }
-            },
-            invalidate(): void { manager.invalidate(); },
-            dispose(): void { manager.dispose(); },
-          };
+        (tui: TUI, theme: Theme, _keybindings, done: () => void) => {
+          // Pass tui, theme, done, and available models/tools to the manager
+          return createAgentManager(
+            user,
+            project,
+            userDir,
+            projectDir,
+            tui,
+            theme,
+            done,
+            availableModels,
+            availableTools,
+          );
         },
         { overlay: true, overlayOptions: { anchor: "center", width: 84, maxHeight: "80%" } },
       );
@@ -379,7 +385,7 @@ Place the call at the top level (not inside `session_start`) to match the AGENTS
 
 ---
 
-### Task 4: Polish — empty state, error handling, visual refinements
+## Task 4: Polish — empty state, error handling, visual refinements
 
 **Context:**
 Several edge cases and UX polish items identified during review need attention: empty list state, cross-scope collision warnings, file write error handling, and visual consistency with pi-archimedes' theme system.
@@ -441,7 +447,7 @@ Several edge cases and UX polish items identified during review need attention: 
 
 ---
 
-### Task 5: Verification and final type-check
+## Task 5: Verification and final type-check
 
 **Context:**
 Final verification pass across all packages to ensure the feature is complete and type-correct. Follows the AGENTS.md verification order: type-check each package independently.

--- a/docs/plans/2026-06-13-agents-command.md
+++ b/docs/plans/2026-06-13-agents-command.md
@@ -1,0 +1,467 @@
+# /agents Command Plan
+
+**Goal:** Add a `/agents` slash command that opens a TUI overlay for full CRUD of agent frontmatter files.
+**Architecture:** Five-screen TUI overlay (List → Detail → Edit, Name Input, Confirm Delete) registered as a slash command in `packages/subagent`, wired through `meta`. Uses pi's `ctx.ui.custom()` overlay API. Follows agentspec v0.5.0 field names; only edits fields pi-archimedes actually consumes (name, description, tools, model, thinking, systemPrompt body). All other frontmatter fields preserved via `extraFields`.
+**Tech Stack:** TypeScript, `@earendil-works/pi-coding-agent` (ExtensionAPI, parseFrontmatter, getAgentDir), `@earendil-works/pi-tui` (Component, Theme, matchesKey, truncateToWidth)
+
+---
+
+### Task 1: Expand AgentConfig and add frontmatter I/O
+
+**Context:**
+The existing `AgentConfig` in `packages/subagent/src/agents.ts` only supports 6 fields (name, description, model, thinking, tools, systemPrompt). The `/agents` command needs the full agentspec v0.5.0 field set plus `extraFields` for unknown fields. We also need a serializer that round-trips frontmatter faithfully. The existing `parseFrontmatter` from `@earendil-works/pi-coding-agent` is used for parsing — we wrap it and add serialization.
+
+**Files:**
+- Modify: `packages/subagent/src/agents.ts`
+- Create: `packages/subagent/src/frontmatter-io.ts`
+
+**What to implement:**
+
+1. In `agents.ts`, expand the `AgentConfig` interface to:
+```typescript
+export interface AgentConfig {
+  name: string;
+  description: string;
+  tools?: string[];
+  model?: string;
+  thinking?: string;
+  systemPrompt: string;
+  source: "user" | "project";
+  filePath: string;
+  // Extra fields preserved from frontmatter but not editable in TUI
+  extraFields?: Record<string, string>;
+}
+```
+Note: We intentionally keep only the fields pi-archimedes actually consumes (name, description, tools, model, thinking, systemPrompt). All other frontmatter keys go into `extraFields`. Do NOT add agentspec fields like `color`, `effort`, `maxTurns` etc. as explicit properties — they go through `extraFields`.
+
+2. In `agents.ts`, update `loadAgentsFromDir` to capture unknown frontmatter fields into `extraFields`. Known fields are: `name`, `description`, `tools`, `model`, `thinking`. Any other key in frontmatter goes into `extraFields`.
+
+3. In `agents.ts`, add a new function `discoverAgentsAll(cwd: string)` that returns:
+```typescript
+interface AgentsDiscoveryResult {
+  user: AgentConfig[];
+  project: AgentConfig[];
+  userDir: string;        // e.g., ~/.pi/agent/agents
+  projectDir: string | null;  // e.g., .pi/agents or null if not found
+}
+```
+This wraps the existing `discoverAgents` logic but returns separate arrays + directory paths (needed by the TUI for create/save).
+
+4. Create `frontmatter-io.ts` with:
+- `serializeAgent(config: AgentConfig): string` — produces the full `.md` file content:
+  - Starts with `---\n`
+  - Writes `name: {name}`, `description: {description}`
+  - If `tools` exists: `tools: {comma-separated}`
+  - If `model` exists: `model: {model}`
+  - If `thinking` exists: `thinking: {thinking}`
+  - Writes any `extraFields` keys (sorted alphabetically)
+  - Ends with `\n---\n\n{systemPrompt}\n`
+  - Must produce valid frontmatter that `parseFrontmatter` can re-parse
+- `AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$/` — validates agentspec name format (lowercase + hyphens, 3-50 chars, alphanumeric start/end). Also allow single char names matching `/^[a-z0-9]$/` for edge case.
+- `validateAgentName(name: string): string | null` — returns error message or null
+
+5. Export from `agents.ts`: re-export `discoverAgentsAll` and keep existing `discoverAgents`, `findAgent`.
+
+**Steps:**
+- [ ] Expand `AgentConfig` interface in `agents.ts`
+- [ ] Update `loadAgentsFromDir` to populate `extraFields` from unknown frontmatter keys
+- [ ] Add `discoverAgentsAll(cwd)` function that returns separated user/project arrays + directory paths
+- [ ] Create `frontmatter-io.ts` with `serializeAgent` and `validateAgentName`
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+  - Did it succeed? If not, fix type errors and re-run.
+- [ ] Commit with message: "feat: expand AgentConfig with extraFields and add frontmatter I/O"
+
+**Acceptance criteria:**
+- [ ] `AgentConfig` has `extraFields?: Record<string, string>`
+- [ ] `discoverAgentsAll(cwd)` returns `{ user, project, userDir, projectDir }`
+- [ ] `serializeAgent(config)` produces valid frontmatter + body
+- [ ] `validateAgentName("scout")` returns null, `validateAgentName("My Agent!")` returns error
+- [ ] `npx tsc --noEmit` passes in `packages/subagent/`
+
+---
+
+### Task 2: Build the agent-manager TUI component
+
+**Context:**
+The core of the feature — a TUI overlay component with 5 screens: List, Detail, Edit, Name Input, Confirm Delete. This is the largest task (~600-800 lines). It follows the visual design from pi-subagents' AgentManager: header bar, search bar, 8-item viewport, preview bar, contextual footer. The component implements pi's `Component` interface (`render`, `handleInput`, `invalidate`, `dispose`).
+
+**Files:**
+- Create: `packages/subagent/src/agent-manager.ts`
+
+**What to implement:**
+
+Create `agent-manager.ts` with the following structure:
+
+1. **Types:**
+```typescript
+interface ManagerState {
+  screen: "list" | "detail" | "edit" | "name-input" | "confirm-delete";
+  agents: AgentConfig[];  // combined user + project
+  userAgents: AgentConfig[];
+  projectAgents: AgentConfig[];
+  userDir: string;
+  projectDir: string | null;
+  // List state
+  listCursor: number;
+  listScroll: number;
+  filterQuery: string;
+  // Detail state
+  detailAgent: AgentConfig | null;
+  detailScroll: number;
+  // Edit state
+  editAgent: AgentConfig | null;  // mutable copy being edited
+  editFieldIndex: number;
+  editInField: boolean;
+  editDirty: boolean;
+  // Name input state
+  nameInputBuffer: string;
+  nameInputScope: "user" | "project";
+  nameInputMode: "new" | "clone";
+  nameInputSource: AgentConfig | null;
+  nameInputError: string | null;
+  // Confirm delete state
+  deleteTarget: AgentConfig | null;
+}
+```
+
+2. **Screen constants:**
+```typescript
+const LIST_VIEWPORT = 8;
+const EDIT_FIELDS = ["name", "description", "tools", "model", "thinking"];
+// systemPrompt (body) is accessed via 'p' key, not in field list
+```
+
+3. **Constructor / factory:**
+```typescript
+export function createAgentManager(
+  userAgents: AgentConfig[],
+  projectAgents: AgentConfig[],
+  userDir: string,
+  projectDir: string | null,
+): Component {
+  // Initialize ManagerState with agents = [...userAgents, ...projectAgents]
+  // Return Component with render, handleInput, invalidate, dispose
+}
+```
+
+4. **List screen render:**
+- Header: ` Agents [N] ` where N = total count
+- Search bar: `◎ type to filter...` or `◎ {query}|` when typing
+- Agent rows (8 visible): `{cursor}{name(16)} {model(12)} [{scope}(8)} {description(rest)}`
+  - cursor: `>` for selected, ` ` otherwise
+  - scope: `[user]` or `[proj]`
+  - model: truncated to 12 chars, or "default" if not set
+  - description: dimmed, truncated to remaining width
+- Preview bar: full description of cursor agent (dimmed)
+- Footer: ` [enter] view  [n] new  [c] clone  [d] delete  [/] search  [esc] close `
+- Use `theme.fg("accent", ...)` for cursor/highlighted items
+- Use `theme.fg("dim", ...)` for descriptions, model, scope badges
+- Fuzzy filter: any typed chars filter by name + description (case-insensitive substring match is fine, no need for full fuzzy)
+
+5. **Detail screen render:**
+- Header: ` Agent: {name} [{scope}] `
+- Frontmatter section: each field on its own line as `{key}: {value}`
+  - name, description, tools (comma-joined), model, thinking
+  - If extraFields exist, show them dimmed below with a separator
+- Body section: `---` separator, then systemPrompt text wrapped to width
+  - Scrollable with ↑↓ (track detailScroll offset, show ~10 lines)
+- Footer: ` [e] edit  [d] delete  [esc] back `
+
+6. **Edit screen render:**
+- Header: ` Edit: {name} * ` (asterisk if dirty)
+- Field list: show current field highlighted with `>` prefix
+  - Fields cycle: name → description → tools → model → thinking
+  - When not in field edit mode: show field name + current value (truncated)
+  - When in field edit mode: show field name + editable text with cursor
+    - For single-line fields (name, tools, model, thinking): single line input
+    - For description: multi-line in a small viewport (3 lines)
+- Hint: ` [↑↓] fields  [enter] edit  [p] prompt  [ctrl+s] save  [esc] back `
+- When on systemPrompt edit (entered via `p`): show full text editor viewport (~8 lines) with wrap
+
+7. **Name Input screen render:**
+- Header: ` New Agent ` or ` Clone Agent `
+- Label: `Name:`
+- Input box: bordered box with single-line text input and cursor
+- Scope indicator: `Scope: [user]  [tab] toggle` (or `[proj]`)
+- Error line: if nameInputError set, show in `theme.fg("error", ...)`
+- Footer: ` [enter] continue  [esc] cancel `
+
+8. **Confirm Delete screen render:**
+- Header: ` Delete "{name}"? `
+- File path: `File: {filePath}`
+- Warning: `This cannot be undone.` (in warning/error color)
+- Footer: ` [y] confirm  [n / esc] cancel `
+
+9. **Input handling — List screen:**
+- `↑↓`: move cursor (clamp to filtered range, adjust scroll)
+- `Enter`: open detail of cursor agent → switch to "detail" screen
+- `n`: switch to "name-input" with mode="new", empty buffer, scope="user"
+- `c`: switch to "name-input" with mode="clone", buffer="{name}-copy", scope=cursor agent's source, source=cursor agent
+- `d`: switch to "confirm-delete" with target=cursor agent
+- `/`: start filter mode — subsequent single chars append to filterQuery
+- `Backspace`: remove last char from filterQuery (if non-empty), reset cursor/scroll
+- `Esc`: if filterQuery non-empty, clear it; otherwise return close signal
+- Single printable char (when filterQuery non-empty or after `/`): append to filterQuery, reset cursor=0, scroll=0
+
+10. **Input handling — Detail screen:**
+- `↑↓`: scroll body (detailScroll ±1, clamp)
+- `e`: switch to "edit" screen — create mutable copy of agent, editDirty=false, editFieldIndex=0
+- `d`: switch to "confirm-delete" with target=detailAgent
+- `Esc`: switch back to "list"
+
+11. **Input handling — Edit screen:**
+- When NOT in field edit mode:
+  - `↑↓`: cycle editFieldIndex (0-4 for the 5 fields)
+  - `Enter`: enter field edit mode (editInField=true)
+  - `p`: enter systemPrompt edit mode — show body text editor
+  - `Ctrl+S`: save agent (see save logic below)
+  - `Esc`: if editDirty → show discard prompt (set a temporary state asking y/n); if not dirty → back to detail
+- When IN field edit mode (single-line):
+  - Normal text input: append char
+  - `Backspace`: remove last char
+  - `Ctrl+A`: move cursor to start
+  - `Ctrl+E`: move cursor to end
+  - Left/Right arrows: move cursor
+  - `Enter`: exit field edit mode, mark dirty
+  - `Esc`: exit field edit mode (keep changes in buffer, mark dirty)
+- When IN systemPrompt edit mode:
+  - Multi-line text editing with wrap
+  - `↑↓`: move cursor in text
+  - `Ctrl+S`: save
+  - `Esc`: exit prompt edit, mark dirty
+- Discard prompt (after Esc with dirty):
+  - `y`: discard changes, back to detail (re-read original from agents list)
+  - `n`/`Esc`: stay on edit screen
+
+12. **Save logic:**
+- Validate name with `validateAgentName` — if fails, set edit error, don't save
+- Check duplicate name within same scope (compare against current agents list, excluding self)
+- If name changed: `fs.renameSync(oldPath, newPath)` then write
+- If new agent (isNew flag): `fs.mkdirSync(dir, {recursive: true})` then `fs.writeFileSync`
+- Write file with `serializeAgent(editAgent)`
+- After save: refresh agents list by re-calling discoverAgentsAll, find the saved agent, switch to detail
+- On write error: show error message in status, stay on edit screen
+
+13. **Input handling — Name Input screen:**
+- `Tab`: toggle nameInputScope between "user" and "project"
+  - If project selected but projectDir is null → show error "No project agents directory found"
+- Single printable char: append to nameInputBuffer
+- `Backspace`: remove last char
+- Left/Right: move cursor in buffer
+- `Enter`: validate name → if valid, create agent config and switch to "edit"
+  - If mode="new": blank config with defaults (name from buffer, description="", systemPrompt="", source=scope)
+  - If mode="clone": deep copy of source agent, override name from buffer, source=scope
+  - Set isNew=true on the new agent, add to agents list
+- `Esc`: back to "list"
+
+14. **Input handling — Confirm Delete screen:**
+- `y`/`Y`: `fs.unlinkSync(deleteTarget.filePath)`, remove from agents list, back to "list"
+- `n`/`N`/`Esc`: back to previous screen (detail or list)
+
+15. **Component interface:**
+```typescript
+interface Component {
+  render(width: number): string[];
+  handleInput(data: string): "close" | void;  // return "close" to close overlay
+  invalidate(): void;
+  dispose(): void;
+}
+```
+
+16. **Helper functions:**
+- `fuzzyFilter(items, query)`: case-insensitive substring match on name + description
+- `wrapText(text, width)`: simple word-wrap
+- `truncateToWidth(text, max)`: use pi-tui's `truncateToWidth`
+- `pad(text, width)`: left-pad with spaces to width
+- `row(text, width, theme)`: apply theme to line, pad to width
+- `renderHeader(text, width, theme)`: themed header bar
+- `renderFooter(text, width, theme)`: themed footer bar
+
+**Steps:**
+- [ ] Create `agent-manager.ts` with types and state interface
+- [ ] Implement List screen render + input handling
+- [ ] Implement Detail screen render + input handling
+- [ ] Implement Edit screen render + input handling (field cycling, inline editing, dirty tracking)
+- [ ] Implement Name Input screen render + input handling (scope toggle, validation)
+- [ ] Implement Confirm Delete screen render + input handling
+- [ ] Implement save logic (validation, duplicate check, file I/O, refresh)
+- [ ] Wire all screens into the Component interface (render dispatches to current screen, handleInput routes by screen)
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+  - Did it succeed? If not, fix type errors and re-run.
+- [ ] Commit with message: "feat: add agent-manager TUI component with CRUD screens"
+
+**Acceptance criteria:**
+- [ ] `createAgentManager()` returns a valid `Component`
+- [ ] List screen shows agents with search, viewport, preview, footer
+- [ ] Detail screen shows frontmatter + scrollable body
+- [ ] Edit screen cycles fields, edits inline, tracks dirty state
+- [ ] Name Input validates names, toggles scope
+- [ ] Confirm Delete asks y/n
+- [ ] Save writes file, handles rename, detects duplicates
+- [ ] Dirty guard prompts on Esc with unsaved changes
+- [ ] `npx tsc --noEmit` passes in `packages/subagent/`
+
+---
+
+### Task 3: Register /agents command and wire into meta
+
+**Context:**
+The agent-manager component needs to be exposed as a `/agents` slash command. Following the existing pattern in `packages/subagent/src/index.ts` (where `registerSubagent(pi)` calls `pi.registerTool` internally), we add `registerAgentsCommand(pi)` that calls `pi.registerCommand("agents", ...)`. The command handler uses `ctx.ui.custom()` with `{ overlay: true }` to open the TUI.
+
+**Files:**
+- Modify: `packages/subagent/src/index.ts`
+- Modify: `meta/src/index.ts`
+
+**What to implement:**
+
+1. In `packages/subagent/src/index.ts`, add:
+```typescript
+import { createAgentManager } from "./agent-manager.js";
+import { discoverAgentsAll } from "./agents.js";
+
+export function registerAgentsCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("agents", {
+    description: "Open the Agents Manager",
+    handler: async (_args: string, ctx: ExtensionCommandContext) => {
+      const { user, project, userDir, projectDir } = discoverAgentsAll(ctx.cwd);
+      const manager = createAgentManager(user, project, userDir, projectDir);
+
+      await ctx.ui.custom<void>(
+        (tui, theme, _keybindings, done) => {
+          // Wrap the manager component to inject tui/theme and provide done callback
+          return {
+            render(width: number): string[] {
+              return manager.render(width);
+            },
+            handleInput(data: string): void {
+              const result = manager.handleInput(data);
+              if (result === "close") {
+                done(undefined);
+              } else {
+                tui.requestRender();
+              }
+            },
+            invalidate(): void { manager.invalidate(); },
+            dispose(): void { manager.dispose(); },
+          };
+        },
+        { overlay: true, overlayOptions: { anchor: "center", width: 84, maxHeight: "80%" } },
+      );
+    },
+  });
+}
+```
+
+2. In `meta/src/index.ts`, add the import and call:
+```typescript
+import { registerSubagent, registerAgentsCommand } from "@pi-archimedes/subagent";
+// ...
+registerAgentsCommand(pi);
+```
+Place the call at the top level (not inside `session_start`) to match the AGENTS.md rule about event handler registration.
+
+**Steps:**
+- [ ] Add `registerAgentsCommand` function to `packages/subagent/src/index.ts`
+- [ ] Export `registerAgentsCommand` from the subagent package
+- [ ] Import and call `registerAgentsCommand(pi)` in `meta/src/index.ts`
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+  - Did it succeed? If not, fix type errors and re-run.
+- [ ] Run `npx tsc --noEmit` in `meta/`
+  - Did it succeed? If not, fix type errors and re-run.
+- [ ] Commit with message: "feat: register /agents command and wire into meta orchestrator"
+
+**Acceptance criteria:**
+- [ ] `registerAgentsCommand` is exported from `@pi-archimedes/subagent`
+- [ ] `meta/src/index.ts` calls `registerAgentsCommand(pi)` at top level
+- [ ] `/agents` command is registered with description "Open the Agents Manager"
+- [ ] Command opens overlay with agent-manager component
+- [ ] `npx tsc --noEmit` passes in both `packages/subagent/` and `meta/`
+
+---
+
+### Task 4: Polish — empty state, error handling, visual refinements
+
+**Context:**
+Several edge cases and UX polish items identified during review need attention: empty list state, cross-scope collision warnings, file write error handling, and visual consistency with pi-archimedes' theme system.
+
+**Files:**
+- Modify: `packages/subagent/src/agent-manager.ts`
+
+**What to implement:**
+
+1. **Empty state:** When no agents exist in the list, show:
+   - Dimmed text: `No agents found`
+   - Below: `Press n to create your first agent`
+   - Still show footer with keybindings
+
+2. **Cross-scope collision warning:** When creating/cloning an agent whose name already exists in the OTHER scope (e.g., creating user `foo` when project `foo` exists), show a warning in the Name Input screen: `Warning: a project agent "foo" exists and will take precedence`. Allow creation but warn.
+
+3. **File write error handling:** On `fs.writeFileSync` failure:
+   - Catch error, show error message in a status line below the edit fields
+   - Stay on Edit screen (don't close)
+   - User can retry with `Ctrl+S` or cancel with `Esc`
+
+4. **Project dir auto-creation:** When saving a project-scope agent and `.pi/agents/` doesn't exist, auto-create it with `fs.mkdirSync(dir, { recursive: true })`.
+
+5. **Theme usage:** Ensure all text uses `theme.fg(...)` for colors:
+   - `theme.fg("accent", ...)` for cursor, selected items, headers
+   - `theme.fg("dim", ...)` for descriptions, hints, secondary info
+   - `theme.fg("error", ...)` or `"warning"` for errors
+   - Border characters should use theme colors if available
+
+6. **Terminal-aware sizing:** Instead of fixed 84 width, use `Math.min(84, Math.max(60, terminalWidth - 4))` or let the overlay handle sizing via percentage.
+
+7. **Scroll indicators:** In Detail screen's body viewport, show `↑ N more` / `↓ M more` when content extends beyond viewport.
+
+8. **Field value display in Edit:** When NOT in edit mode for a field, show:
+   - `> name: scout` (current value, truncated)
+   - For empty/undefined fields: `> model: (not set)` in dim
+
+**Steps:**
+- [ ] Add empty state handling in List render
+- [ ] Add cross-scope collision detection in Name Input (check against agents from other scope)
+- [ ] Add try/catch around file writes in save logic, show error in status
+- [ ] Add `fs.mkdirSync(dir, { recursive: true })` before project saves
+- [ ] Apply theme.fg() consistently across all screens
+- [ ] Add scroll indicators in Detail body viewport
+- [ ] Improve field value display in Edit (show "(not set)" for empty fields)
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+  - Did it succeed? If not, fix type errors and re-run.
+- [ ] Commit with message: "fix: polish agent-manager UX — empty state, errors, theming"
+
+**Acceptance criteria:**
+- [ ] Empty list shows "No agents found. Press n to create..."
+- [ ] Cross-scope collision shows warning but allows creation
+- [ ] File write errors shown in status, stay on Edit screen
+- [ ] Project dir auto-created on save
+- [ ] All text uses theme.fg() for colors
+- [ ] Detail body shows scroll indicators
+- [ ] Edit fields show "(not set)" for empty values
+- [ ] `npx tsc --noEmit` passes in `packages/subagent/`
+
+---
+
+### Task 5: Verification and final type-check
+
+**Context:**
+Final verification pass across all packages to ensure the feature is complete and type-correct. Follows the AGENTS.md verification order: type-check each package independently.
+
+**Files:**
+- No new files. Verification only.
+
+**What to implement:**
+No code changes. Run verification checks.
+
+**Steps:**
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+  - Did it succeed? If not, read errors → fix → re-run (max 2 attempts, then BLOCKED)
+- [ ] Run `npx tsc --noEmit` in `meta/`
+  - Did it succeed? If not, read errors → fix → re-run (max 2 attempts, then BLOCKED)
+- [ ] Verify all new files are listed in `packages/subagent/package.json` `"files"` field (should already include `"src"`)
+- [ ] Verify `registerAgentsCommand` is exported and importable
+- [ ] Commit with message: "chore: verification pass for /agents command"
+
+**Acceptance criteria:**
+- [ ] `npx tsc --noEmit` passes in `packages/subagent/`
+- [ ] `npx tsc --noEmit` passes in `meta/`
+- [ ] No type errors in any package

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -4,12 +4,12 @@
 
 | Plan | Status | Created |
 |------|--------|---------|
-| [/agents command](plans/2026-06-13-agents-command.md) | 🚧 IN PROGRESS | 2026-06-13 |
+| [/agents command](plans/2026-06-13-agents-command.md) | ✅ COMPLETED (PR #6) | 2026-06-13 |
 | [Subagent package](plans/2026-06-04-subagent.md) | ✅ COMPLETED (PR #1) | 2026-06-04 |
 | [Create pi-archimedes](plans/2026-06-04-create-pi-archimedes.md) | ✅ COMPLETED | 2026-06-04 |
 
 ## Quick Stats
 
 - Total Plans: 3
-- In Progress: 1
-- Completed: 2
+- In Progress: 0
+- Completed: 3

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -4,11 +4,12 @@
 
 | Plan | Status | Created |
 |------|--------|---------|
+| [/agents command](plans/2026-06-13-agents-command.md) | 🚧 IN PROGRESS | 2026-06-13 |
 | [Subagent package](plans/2026-06-04-subagent.md) | ✅ COMPLETED (PR #1) | 2026-06-04 |
 | [Create pi-archimedes](plans/2026-06-04-create-pi-archimedes.md) | ✅ COMPLETED | 2026-06-04 |
 
 ## Quick Stats
 
-- Total Plans: 2
-- In Progress: 0
+- Total Plans: 3
+- In Progress: 1
 - Completed: 2

--- a/meta/src/index.ts
+++ b/meta/src/index.ts
@@ -4,7 +4,7 @@ import { registerCore, unpatchConsoleLog } from "@pi-archimedes/core";
 import { registerFooter } from "@pi-archimedes/footer";
 import { registerDiffTools } from "@pi-archimedes/diff";
 import { registerImagePaste, initImagePasteSession, shutdownImagePaste } from "@pi-archimedes/image-paste";
-import { registerSubagent } from "@pi-archimedes/subagent";
+import { registerSubagent, registerAgentsCommand } from "@pi-archimedes/subagent";
 import { loadDiffConfig } from "./config.js";
 import { openSettings } from "./settings.js";
 
@@ -18,6 +18,9 @@ export default function (pi: ExtensionAPI): void {
 
   // Register subagent tool
   registerSubagent(pi);
+
+  // Register /agents command
+  registerAgentsCommand(pi);
 
   // session_shutdown handler (top-level to prevent accumulation on /reload)
   pi.on("session_shutdown", (_event, _ctx) => {

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -180,30 +180,36 @@ function renderList(state: ManagerState, width: number, theme: Theme): string[] 
     lines.push(padEnd(`◎ ${theme.fg("dim", "type to filter...")}`, width));
   }
 
-  // Agent rows
+  // Agent rows or empty state
   const start = state.listScroll;
   const end = Math.min(start + LIST_VIEWPORT, filtered.length);
 
-  for (let i = start; i < end; i++) {
-    const agent = filtered[i];
-    if (!agent) continue;
-    const isCursor = i === state.listCursor;
-    const cursorMark = isCursor ? ">" : " ";
+  if (filtered.length === 0) {
+    lines.push(padEnd("", width));
+    lines.push(padEnd(theme.fg("dim", "No agents found"), width));
+    lines.push(padEnd(theme.fg("dim", "Press n to create your first agent"), width));
+  } else {
+    for (let i = start; i < end; i++) {
+      const agent = filtered[i];
+      if (!agent) continue;
+      const isCursor = i === state.listCursor;
+      const cursorMark = isCursor ? ">" : " ";
 
-    const name = truncateToWidth(agent.name, 16);
-    const model = truncateToWidth(agentModel(agent), 12);
-    const scope = `[${scopeLabel(agent.source)}]`;
-    const desc = truncateToWidth(agent.description, Math.max(1, width - 1 - 16 - 1 - 12 - 1 - 8 - 1));
+      const name = truncateToWidth(agent.name, 16);
+      const model = truncateToWidth(agentModel(agent), 12);
+      const scope = `[${scopeLabel(agent.source)}]`;
+      const desc = truncateToWidth(agent.description, Math.max(1, width - 1 - 16 - 1 - 12 - 1 - 8 - 1));
 
-    const nameCol = isCursor
-      ? theme.fg("accent", padEnd(name, 16))
-      : padEnd(name, 16);
-    const modelCol = theme.fg("dim", padEnd(model, 12));
-    const scopeCol = theme.fg("dim", padEnd(scope, 8));
-    const descCol = theme.fg("dim", desc);
+      const nameCol = isCursor
+        ? theme.fg("accent", padEnd(name, 16))
+        : padEnd(name, 16);
+      const modelCol = theme.fg("dim", padEnd(model, 12));
+      const scopeCol = theme.fg("dim", padEnd(scope, 8));
+      const descCol = theme.fg("dim", desc);
 
-    const line = `${cursorMark} ${nameCol} ${modelCol} ${scopeCol} ${descCol}`;
-    lines.push(padEnd(line, width));
+      const line = `${cursorMark} ${nameCol} ${modelCol} ${scopeCol} ${descCol}`;
+      lines.push(padEnd(line, width));
+    }
   }
 
   // Fill remaining viewport rows
@@ -344,15 +350,15 @@ function renderDetail(state: ManagerState, width: number, theme: Theme): string[
 
   // Frontmatter section
   const fieldLines: string[] = [];
-  fieldLines.push(`name: ${agent.name}`);
-  fieldLines.push(`description: ${agent.description}`);
+  fieldLines.push(theme.fg("accent", `name:`) + ` ${agent.name}`);
+  fieldLines.push(theme.fg("accent", `description:`) + ` ${agent.description}`);
   if (agent.tools && agent.tools.length > 0) {
-    fieldLines.push(`tools: ${agent.tools.join(", ")}`);
+    fieldLines.push(theme.fg("accent", `tools:`) + ` ${agent.tools.join(", ")}`);
   } else {
-    fieldLines.push(`tools: ${theme.fg("dim", "(none)")}`);
+    fieldLines.push(theme.fg("accent", `tools:`) + ` ${theme.fg("dim", "(none)")}`);
   }
-  fieldLines.push(`model: ${agentModel(agent)}`);
-  fieldLines.push(`thinking: ${agent.thinking ?? theme.fg("dim", "(none)")}`);
+  fieldLines.push(theme.fg("accent", `model:`) + ` ${agentModel(agent)}`);
+  fieldLines.push(theme.fg("accent", `thinking:`) + ` ${agent.thinking ?? theme.fg("dim", "(none)")}`);
 
   for (const fl of fieldLines) {
     lines.push(padEnd(fl, width));
@@ -375,9 +381,20 @@ function renderDetail(state: ManagerState, width: number, theme: Theme): string[
   const bodyStart = state.detailScroll;
   const bodyEnd = Math.min(bodyStart + bodyViewport, bodyLines.length);
 
+  // Scroll indicator: more above
+  if (bodyStart > 0) {
+    lines.push(padEnd(theme.fg("dim", `↑ ${bodyStart} more`), width));
+  }
+
   for (let i = bodyStart; i < bodyEnd; i++) {
     const line = bodyLines[i];
     if (line != null) lines.push(padEnd(line, width));
+  }
+
+  // Scroll indicator: more below
+  const remainingBelow = bodyLines.length - bodyEnd;
+  if (remainingBelow > 0) {
+    lines.push(padEnd(theme.fg("dim", `↓ ${remainingBelow} more`), width));
   }
 
   // Footer
@@ -482,32 +499,38 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
   }
 
   // Field list
-  const fields: { key: EditField; value: string }[] = EDIT_FIELDS.map((key) => {
+  const fields: { key: EditField; value: string; empty: boolean }[] = EDIT_FIELDS.map((key) => {
     let value: string;
+    let empty: boolean;
     switch (key) {
       case "name":
         value = agent.name;
+        empty = false;
         break;
       case "description":
         value = agent.description;
+        empty = value.length === 0;
         break;
       case "tools":
         value = agent.tools ? agent.tools.join(", ") : "";
+        empty = value.length === 0;
         break;
       case "model":
         value = agent.model ?? "";
+        empty = value.length === 0;
         break;
       case "thinking":
         value = agent.thinking ?? "";
+        empty = value.length === 0;
         break;
     }
-    return { key, value };
+    return { key, value, empty };
   });
 
   for (let i = 0; i < fields.length; i++) {
     const field = fields[i];
     if (!field) continue;
-    const { key, value } = field;
+    const { key, value, empty } = field;
     const isCurrent = i === state.editFieldIndex;
     const prefix = isCurrent ? "> " : "  ";
 
@@ -539,10 +562,12 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
     } else {
       // Normal field display
       const label = `${key}: `;
-      const truncated = truncateToWidth(value, width - visibleWidth(prefix + label));
+      const displayValue = empty
+        ? theme.fg("dim", "(not set)")
+        : truncateToWidth(value, width - visibleWidth(prefix + label));
       const display = isCurrent
-        ? theme.fg("accent", `${prefix}${label}${truncated}`)
-        : `${prefix}${label}${truncated}`;
+        ? theme.fg("accent", `${prefix}${label}`) + displayValue
+        : `${prefix}${label}${displayValue}`;
       lines.push(padEnd(display, width));
     }
   }
@@ -869,8 +894,13 @@ function renderNameInput(state: ManagerState, width: number, theme: Theme): stri
   const scopeText = `Scope: [${state.nameInputScope}]  [tab] toggle`;
   lines.push(padEnd(theme.fg("dim", scopeText), width));
 
-  // Error line
-  if (state.nameInputError) {
+  // Cross-scope collision warning
+  const otherScope = state.nameInputScope === "user" ? "project" : "user";
+  const otherScopeAgents = otherScope === "user" ? state.userAgents : state.projectAgents;
+  const collisionAgent = otherScopeAgents.find((a) => a.name === state.nameInputBuffer.trim());
+  if (collisionAgent) {
+    lines.push(padEnd(theme.fg("warning", `Warning: a ${otherScope} agent "${collisionAgent.name}" exists and will take precedence`), width));
+  } else if (state.nameInputError) {
     lines.push(padEnd(theme.fg("error", `  ${state.nameInputError}`), width));
   } else {
     lines.push(padEnd("", width));

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -1,0 +1,1184 @@
+/**
+ * Agent Manager TUI component.
+ * Overlay with 5 screens: List, Detail, Edit, Name Input, Confirm Delete.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  matchesKey,
+  Key,
+  truncateToWidth,
+  CURSOR_MARKER,
+} from "@earendil-works/pi-tui";
+import type { AgentConfig } from "./agents.js";
+import { discoverAgentsAll } from "./agents.js";
+import { serializeAgent, validateAgentName } from "./frontmatter-io.js";
+
+// ── Screen constants ────────────────────────────────────────────────────────
+
+const LIST_VIEWPORT = 8;
+const EDIT_FIELDS = ["name", "description", "tools", "model", "thinking"] as const;
+type EditField = (typeof EDIT_FIELDS)[number];
+
+// ── Theme helper type ───────────────────────────────────────────────────────
+
+interface Theme {
+  fg(token: string, text: string): string;
+  bold(text: string): string;
+}
+
+// ── TUI context ─────────────────────────────────────────────────────────────
+
+interface TUIContext {
+  requestRender(): void;
+}
+
+// ── Manager state ───────────────────────────────────────────────────────────
+
+interface ManagerState {
+  screen: "list" | "detail" | "edit" | "name-input" | "confirm-delete";
+  agents: AgentConfig[];
+  userAgents: AgentConfig[];
+  projectAgents: AgentConfig[];
+  userDir: string;
+  projectDir: string | null;
+
+  // List state
+  listCursor: number;
+  listScroll: number;
+  filterQuery: string;
+  filterMode: boolean;
+
+  // Detail state
+  detailAgent: AgentConfig | null;
+  detailScroll: number;
+
+  // Edit state
+  editAgent: AgentConfig | null;
+  editFieldIndex: number;
+  editInField: boolean;
+  editDirty: boolean;
+  editFieldCursor: number;
+  editPromptMode: boolean;       // true when editing systemPrompt via 'p'
+  editPromptCursor: number;      // cursor position in prompt text
+  editPromptScroll: number;      // scroll offset for prompt editor
+  editDiscardPrompt: boolean;    // true when asking y/n to discard changes
+  editError: string | null;
+
+  // Name input state
+  nameInputBuffer: string;
+  nameInputCursor: number;
+  nameInputScope: "user" | "project";
+  nameInputMode: "new" | "clone";
+  nameInputSource: AgentConfig | null;
+  nameInputError: string | null;
+
+  // Confirm delete state
+  deleteTarget: AgentConfig | null;
+  deleteFromScreen: "list" | "detail";
+
+  // New agent tracking
+  isNew: boolean;
+}
+
+// ── Component return type ───────────────────────────────────────────────────
+
+interface Component {
+  render(width: number): string[];
+  handleInput(data: string): void;
+  invalidate(): void;
+  dispose(): void;
+}
+
+// ── Helper functions ────────────────────────────────────────────────────────
+
+function fuzzyFilter(items: AgentConfig[], query: string): AgentConfig[] {
+  if (!query) return items;
+  const q = query.toLowerCase();
+  return items.filter(
+    (a) =>
+      a.name.toLowerCase().includes(q) ||
+      a.description.toLowerCase().includes(q),
+  );
+}
+
+function wrapText(text: string, width: number): string[] {
+  if (width <= 0) return [];
+  const lines: string[] = [];
+  const paragraphs = text.split("\n");
+  for (const para of paragraphs) {
+    if (para.length === 0) {
+      lines.push("");
+      continue;
+    }
+    const words = para.split(/(\s+)/).filter(Boolean);
+    let current = "";
+    for (const word of words) {
+      const test = current === "" ? word : current + word;
+      if (test.length > width && current.length > 0) {
+        lines.push(current);
+        current = word;
+      } else {
+        current = test;
+      }
+    }
+    if (current) lines.push(current);
+  }
+  return lines;
+}
+
+function padEnd(text: string, width: number): string {
+  if (width <= 0) return "";
+  const vw = visibleWidth(text);
+  if (vw >= width) return text;
+  return text + " ".repeat(width - vw);
+}
+
+function visibleWidth(text: string): number {
+  // Strip ANSI escape sequences for width calculation
+  return text.replace(/\x1b\[[0-9;]*m/g, "").length;
+}
+
+function row(text: string, width: number, theme: Theme): string {
+  return padEnd(text, width);
+}
+
+function renderHeader(text: string, width: number, theme: Theme): string {
+  return theme.fg("accent", padEnd(text, width));
+}
+
+function renderFooter(text: string, width: number, theme: Theme): string {
+  return theme.fg("dim", padEnd(text, width));
+}
+
+function scopeLabel(source: "user" | "project"): string {
+  return source === "user" ? "user" : "proj";
+}
+
+function agentModel(a: AgentConfig): string {
+  return a.model ?? "default";
+}
+
+// ── List screen ─────────────────────────────────────────────────────────────
+
+function renderList(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+  const filtered = fuzzyFilter(state.agents, state.filterQuery);
+
+  // Header
+  lines.push(renderHeader(` Agents [${state.agents.length}] `, width, theme));
+
+  // Search bar
+  if (state.filterMode || state.filterQuery.length > 0) {
+    const cursor = state.filterMode ? CURSOR_MARKER : "";
+    const queryText = state.filterQuery.length > 0 ? state.filterQuery : "type to filter...";
+    const placeholder = state.filterQuery.length === 0;
+    const searchLine = `◎ ${placeholder ? theme.fg("dim", queryText) : queryText}${cursor}`;
+    lines.push(padEnd(searchLine, width));
+  } else {
+    lines.push(padEnd(`◎ ${theme.fg("dim", "type to filter...")}`, width));
+  }
+
+  // Agent rows
+  const start = state.listScroll;
+  const end = Math.min(start + LIST_VIEWPORT, filtered.length);
+
+  for (let i = start; i < end; i++) {
+    const agent = filtered[i];
+    if (!agent) continue;
+    const isCursor = i === state.listCursor;
+    const cursorMark = isCursor ? ">" : " ";
+
+    const name = truncateToWidth(agent.name, 16);
+    const model = truncateToWidth(agentModel(agent), 12);
+    const scope = `[${scopeLabel(agent.source)}]`;
+    const desc = truncateToWidth(agent.description, Math.max(1, width - 1 - 16 - 1 - 12 - 1 - 8 - 1));
+
+    const nameCol = isCursor
+      ? theme.fg("accent", padEnd(name, 16))
+      : padEnd(name, 16);
+    const modelCol = theme.fg("dim", padEnd(model, 12));
+    const scopeCol = theme.fg("dim", padEnd(scope, 8));
+    const descCol = theme.fg("dim", desc);
+
+    const line = `${cursorMark} ${nameCol} ${modelCol} ${scopeCol} ${descCol}`;
+    lines.push(padEnd(line, width));
+  }
+
+  // Fill remaining viewport rows
+  while (lines.length < 2 + LIST_VIEWPORT + 2) {
+    lines.push(padEnd("", width));
+  }
+
+  // Preview bar
+  if (filtered.length > 0 && state.listCursor >= 0 && state.listCursor < filtered.length) {
+    const previewAgent = filtered[state.listCursor];
+    if (!previewAgent) {
+      lines.push(padEnd("", width));
+    } else {
+      const preview = theme.fg(
+        "dim",
+        truncateToWidth(`Preview: ${previewAgent.description}`, width),
+      );
+      lines.push(preview);
+    }
+  }
+
+  // Footer
+  lines.push(renderFooter(" [enter] view  [n] new  [c] clone  [d] delete  [/] search  [esc] close ", width, theme));
+
+  return lines;
+}
+
+function handleListInput(
+  state: ManagerState,
+  data: string,
+  done: () => void,
+  requestRender: () => void,
+): "close" | void {
+  const filtered = fuzzyFilter(state.agents, state.filterQuery);
+
+  if (matchesKey(data, Key.up)) {
+    if (state.listCursor > 0) {
+      state.listCursor--;
+      if (state.listCursor < state.listScroll) {
+        state.listScroll = state.listCursor;
+      }
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.down)) {
+    if (state.listCursor < filtered.length - 1) {
+      state.listCursor++;
+      if (state.listCursor >= state.listScroll + LIST_VIEWPORT) {
+        state.listScroll = state.listCursor - LIST_VIEWPORT + 1;
+      }
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.enter)) {
+    const selected = filtered[state.listCursor];
+    if (selected) {
+      state.screen = "detail";
+      state.detailAgent = selected;
+      state.detailScroll = 0;
+      requestRender();
+    }
+  } else if (matchesKey(data, "n")) {
+    state.screen = "name-input";
+    state.nameInputMode = "new";
+    state.nameInputBuffer = "";
+    state.nameInputCursor = 0;
+    state.nameInputScope = "user";
+    state.nameInputSource = null;
+    state.nameInputError = null;
+    state.isNew = true;
+    requestRender();
+  } else if (matchesKey(data, "c")) {
+    const source = filtered[state.listCursor];
+    if (source) {
+      state.screen = "name-input";
+      state.nameInputMode = "clone";
+      state.nameInputBuffer = `${source.name}-copy`;
+      state.nameInputCursor = state.nameInputBuffer.length;
+      state.nameInputScope = source.source;
+      state.nameInputSource = source;
+      state.nameInputError = null;
+      state.isNew = true;
+      requestRender();
+    }
+  } else if (matchesKey(data, "d")) {
+    const target = filtered[state.listCursor];
+    if (target) {
+      state.screen = "confirm-delete";
+      state.deleteTarget = target;
+      state.deleteFromScreen = "list";
+      requestRender();
+    }
+  } else if (matchesKey(data, "/")) {
+    state.filterMode = true;
+    requestRender();
+  } else if (matchesKey(data, Key.backspace)) {
+    if (state.filterQuery.length > 0) {
+      state.filterQuery = state.filterQuery.slice(0, -1);
+      state.listCursor = 0;
+      state.listScroll = 0;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.escape)) {
+    if (state.filterQuery.length > 0) {
+      state.filterQuery = "";
+      state.filterMode = false;
+      state.listCursor = 0;
+      state.listScroll = 0;
+      requestRender();
+    } else {
+      return "close";
+    }
+  } else {
+    // Single printable char
+    if (state.filterMode || state.filterQuery.length > 0) {
+      if (data.length === 1 && data >= " " && data <= "~") {
+        state.filterQuery += data;
+        state.filterMode = false;
+        state.listCursor = 0;
+        state.listScroll = 0;
+        requestRender();
+      }
+    }
+  }
+}
+
+// ── Detail screen ───────────────────────────────────────────────────────────
+
+function renderDetail(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+  const agent = state.detailAgent;
+  if (!agent) {
+    lines.push(renderHeader(" No agent selected ", width, theme));
+    lines.push(renderFooter(" [esc] back ", width, theme));
+    return lines;
+  }
+
+  // Header
+  lines.push(renderHeader(` Agent: ${agent.name} [${scopeLabel(agent.source)}] `, width, theme));
+
+  // Frontmatter section
+  const fieldLines: string[] = [];
+  fieldLines.push(`name: ${agent.name}`);
+  fieldLines.push(`description: ${agent.description}`);
+  if (agent.tools && agent.tools.length > 0) {
+    fieldLines.push(`tools: ${agent.tools.join(", ")}`);
+  } else {
+    fieldLines.push(`tools: ${theme.fg("dim", "(none)")}`);
+  }
+  fieldLines.push(`model: ${agentModel(agent)}`);
+  fieldLines.push(`thinking: ${agent.thinking ?? theme.fg("dim", "(none)")}`);
+
+  for (const fl of fieldLines) {
+    lines.push(padEnd(fl, width));
+  }
+
+  // Extra fields
+  if (agent.extraFields && Object.keys(agent.extraFields).length > 0) {
+    lines.push(padEnd(theme.fg("dim", "─".repeat(width)), width));
+    for (const [key, value] of Object.entries(agent.extraFields).sort()) {
+      lines.push(padEnd(theme.fg("dim", `${key}: ${value}`), width));
+    }
+  }
+
+  // Body separator
+  lines.push(padEnd(theme.fg("dim", "---"), width));
+
+  // Body (systemPrompt) - scrollable
+  const bodyLines = wrapText(agent.systemPrompt, width);
+  const bodyViewport = Math.max(6, 14 - lines.length);
+  const bodyStart = state.detailScroll;
+  const bodyEnd = Math.min(bodyStart + bodyViewport, bodyLines.length);
+
+  for (let i = bodyStart; i < bodyEnd; i++) {
+    const line = bodyLines[i];
+    if (line != null) lines.push(padEnd(line, width));
+  }
+
+  // Footer
+  lines.push(renderFooter(" [e] edit  [d] delete  [esc] back ", width, theme));
+
+  return lines;
+}
+
+function handleDetailInput(
+  state: ManagerState,
+  data: string,
+  requestRender: () => void,
+): void {
+  if (matchesKey(data, Key.up)) {
+    if (state.detailScroll > 0) {
+      state.detailScroll--;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.down)) {
+    if (state.detailAgent) {
+      const bodyLines = wrapText(state.detailAgent.systemPrompt, 84);
+      const bodyViewport = Math.max(6, 14 - 9);
+      if (state.detailScroll < bodyLines.length - bodyViewport) {
+        state.detailScroll++;
+        requestRender();
+      }
+    }
+    requestRender();
+  } else if (matchesKey(data, "e")) {
+    // Create mutable copy
+    const agent = state.detailAgent;
+    if (agent) {
+      state.screen = "edit";
+      const copy: AgentConfig = { ...agent };
+      if (agent.tools) copy.tools = [...agent.tools];
+      state.editAgent = copy;
+      state.editFieldIndex = 0;
+      state.editInField = false;
+      state.editDirty = false;
+      state.editFieldCursor = 0;
+      state.editPromptMode = false;
+      state.editPromptCursor = 0;
+      state.editPromptScroll = 0;
+      state.editDiscardPrompt = false;
+      state.editError = null;
+      state.isNew = false;
+      requestRender();
+    }
+  } else if (matchesKey(data, "d")) {
+    state.screen = "confirm-delete";
+    state.deleteTarget = state.detailAgent;
+    state.deleteFromScreen = "detail";
+    requestRender();
+  } else if (matchesKey(data, Key.escape)) {
+    state.screen = "list";
+    requestRender();
+  }
+}
+
+// ── Edit screen ─────────────────────────────────────────────────────────────
+
+function renderEdit(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+  const agent = state.editAgent;
+  if (!agent) return lines;
+
+  // Discard prompt
+  if (state.editDiscardPrompt) {
+    lines.push(renderHeader(" Discard changes? ", width, theme));
+    lines.push(padEnd("", width));
+    lines.push(padEnd("Unsaved changes will be lost.", width));
+    lines.push(padEnd("", width));
+    lines.push(renderFooter(" [y] discard  [n / esc] keep editing ", width, theme));
+    return lines;
+  }
+
+  // Header
+  const dirtyMark = state.editDirty ? " *" : "";
+  lines.push(renderHeader(` Edit: ${agent.name}${dirtyMark} `, width, theme));
+
+  // Error line
+  if (state.editError) {
+    lines.push(padEnd(theme.fg("error", `Error: ${state.editError}`), width));
+  }
+
+  // System prompt edit mode
+  if (state.editPromptMode) {
+    lines.push(padEnd(theme.fg("dim", "systemPrompt:"), width));
+    const promptLines = wrapText(agent.systemPrompt, width);
+    const promptViewport = Math.max(6, 14 - lines.length - 2);
+    const promptStart = state.editPromptScroll;
+    const promptEnd = Math.min(promptStart + promptViewport, promptLines.length);
+
+    for (let i = promptStart; i < promptEnd; i++) {
+      const line = promptLines[i];
+      if (line != null) lines.push(padEnd(line, width));
+    }
+
+    // Hint line
+    lines.push(padEnd(theme.fg("dim", " [↑↓] scroll  [ctrl+s] save  [esc] done "), width));
+    return lines;
+  }
+
+  // Field list
+  const fields: { key: EditField; value: string }[] = EDIT_FIELDS.map((key) => {
+    let value: string;
+    switch (key) {
+      case "name":
+        value = agent.name;
+        break;
+      case "description":
+        value = agent.description;
+        break;
+      case "tools":
+        value = agent.tools ? agent.tools.join(", ") : "";
+        break;
+      case "model":
+        value = agent.model ?? "";
+        break;
+      case "thinking":
+        value = agent.thinking ?? "";
+        break;
+    }
+    return { key, value };
+  });
+
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i];
+    if (!field) continue;
+    const { key, value } = field;
+    const isCurrent = i === state.editFieldIndex;
+    const prefix = isCurrent ? "> " : "  ";
+
+    if (isCurrent && state.editInField) {
+      // In-field editing
+      const label = `${key}: `;
+      const labelWidth = visibleWidth(label);
+      const availWidth = width - labelWidth - 2; // prefix takes 2
+
+      if (key === "description") {
+        // Multi-line description editing (3 lines viewport)
+        const descLines = wrapText(value, availWidth);
+        lines.push(padEnd(`${prefix}${label}`, width));
+        for (let j = 0; j < 3 && j < descLines.length; j++) {
+          const descLine = descLines[j];
+          const lineContent = padEnd(descLine ?? "", availWidth);
+          // Place cursor at end of last visible line
+          const displayLine = j === 2 || j === descLines.length - 1
+            ? lineContent + CURSOR_MARKER
+            : lineContent;
+          lines.push(padEnd(`  ${displayLine}`, width));
+        }
+      } else {
+        // Single-line editing
+        const truncated = truncateToWidth(value, availWidth);
+        const inputLine = `${prefix}${label}${truncated}${CURSOR_MARKER}`;
+        lines.push(padEnd(inputLine, width));
+      }
+    } else {
+      // Normal field display
+      const label = `${key}: `;
+      const truncated = truncateToWidth(value, width - visibleWidth(prefix + label));
+      const display = isCurrent
+        ? theme.fg("accent", `${prefix}${label}${truncated}`)
+        : `${prefix}${label}${truncated}`;
+      lines.push(padEnd(display, width));
+    }
+  }
+
+  // Hint
+  lines.push(renderFooter(" [↑↓] fields  [enter] edit  [p] prompt  [ctrl+s] save  [esc] back ", width, theme));
+
+  return lines;
+}
+
+function handleEditInput(
+  state: ManagerState,
+  data: string,
+  requestRender: () => void,
+): void {
+  // Discard prompt handling
+  if (state.editDiscardPrompt) {
+    if (matchesKey(data, "y")) {
+      state.editDiscardPrompt = false;
+      state.editDirty = false;
+      // Re-read from original
+      if (state.detailAgent) {
+        const origCopy: AgentConfig = { ...state.detailAgent };
+        if (state.detailAgent.tools) origCopy.tools = [...state.detailAgent.tools];
+        state.editAgent = origCopy;
+      }
+      state.editFieldIndex = 0;
+      state.editInField = false;
+      state.editPromptMode = false;
+      state.editError = null;
+      requestRender();
+    } else if (matchesKey(data, "n") || matchesKey(data, Key.escape)) {
+      state.editDiscardPrompt = false;
+      requestRender();
+    }
+    return;
+  }
+
+  if (!state.editAgent) return;
+
+  // System prompt edit mode
+  if (state.editPromptMode) {
+    if (matchesKey(data, Key.ctrl("s"))) {
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.escape)) {
+      state.editPromptMode = false;
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.up)) {
+      if (state.editPromptScroll > 0) {
+        state.editPromptScroll--;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.down)) {
+      const promptLines = wrapText(state.editAgent.systemPrompt, 84);
+      const promptViewport = Math.max(6, 14 - 4 - 2);
+      if (state.editPromptScroll < promptLines.length - promptViewport) {
+        state.editPromptScroll++;
+        requestRender();
+      }
+    } else if (data.length === 1 && data >= " " && data <= "~") {
+      // Append char to systemPrompt at cursor
+      const before = state.editAgent.systemPrompt.slice(0, state.editPromptCursor);
+      const after = state.editAgent.systemPrompt.slice(state.editPromptCursor);
+      state.editAgent.systemPrompt = before + data + after;
+      state.editPromptCursor++;
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.backspace)) {
+      if (state.editPromptCursor > 0) {
+        const before = state.editAgent.systemPrompt.slice(0, state.editPromptCursor - 1);
+        const after = state.editAgent.systemPrompt.slice(state.editPromptCursor);
+        state.editAgent.systemPrompt = before + after;
+        state.editPromptCursor--;
+        state.editDirty = true;
+        requestRender();
+      }
+    }
+    return;
+  }
+
+  // In-field edit mode
+  if (state.editInField) {
+    const field = EDIT_FIELDS[state.editFieldIndex];
+    if (!field) return;
+    if (matchesKey(data, Key.enter)) {
+      // Exit field edit, mark dirty
+      state.editInField = false;
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.escape)) {
+      state.editInField = false;
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.ctrl("a"))) {
+      state.editFieldCursor = 0;
+      requestRender();
+    } else if (matchesKey(data, Key.ctrl("e"))) {
+      const val = getFieldValue(state.editAgent, field);
+      state.editFieldCursor = val.length;
+      requestRender();
+    } else if (matchesKey(data, Key.left)) {
+      if (state.editFieldCursor > 0) {
+        state.editFieldCursor--;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.right)) {
+      const val = getFieldValue(state.editAgent, field);
+      if (state.editFieldCursor < val.length) {
+        state.editFieldCursor++;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.backspace)) {
+      if (state.editFieldCursor > 0) {
+        const val = getFieldValue(state.editAgent, field);
+        const newVal = val.slice(0, state.editFieldCursor - 1) + val.slice(state.editFieldCursor);
+        setFieldValue(state.editAgent, field, newVal);
+        state.editFieldCursor--;
+        state.editDirty = true;
+        requestRender();
+      }
+    } else if (data.length === 1 && data >= " " && data <= "~") {
+      const val = getFieldValue(state.editAgent, field);
+      const newVal = val.slice(0, state.editFieldCursor) + data + val.slice(state.editFieldCursor);
+      setFieldValue(state.editAgent, field, newVal);
+      state.editFieldCursor++;
+      state.editDirty = true;
+      requestRender();
+    }
+    return;
+  }
+
+  // Normal edit mode (field cycling)
+  if (matchesKey(data, Key.up)) {
+    if (state.editFieldIndex > 0) {
+      state.editFieldIndex--;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.down)) {
+    if (state.editFieldIndex < EDIT_FIELDS.length - 1) {
+      state.editFieldIndex++;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.enter)) {
+    const field = EDIT_FIELDS[state.editFieldIndex];
+    if (field) {
+      state.editInField = true;
+      state.editFieldCursor = getFieldValue(state.editAgent, field).length;
+      requestRender();
+    }
+  } else if (matchesKey(data, "p")) {
+    state.editPromptMode = true;
+    state.editPromptCursor = state.editAgent.systemPrompt.length;
+    state.editPromptScroll = 0;
+    requestRender();
+  } else if (matchesKey(data, Key.ctrl("s"))) {
+    saveAgent(state, requestRender);
+  } else if (matchesKey(data, Key.escape)) {
+    if (state.editDirty) {
+      state.editDiscardPrompt = true;
+      requestRender();
+    } else {
+      state.screen = "detail";
+      requestRender();
+    }
+  }
+}
+
+function getFieldValue(agent: AgentConfig, field: EditField): string {
+  switch (field) {
+    case "name":
+      return agent.name;
+    case "description":
+      return agent.description;
+    case "tools":
+      return agent.tools ? agent.tools.join(", ") : "";
+    case "model":
+      return agent.model ?? "";
+    case "thinking":
+      return agent.thinking ?? "";
+  }
+}
+
+function setFieldValue(agent: AgentConfig, field: EditField, value: string): void {
+  switch (field) {
+    case "name":
+      agent.name = value;
+      break;
+    case "description":
+      agent.description = value;
+      break;
+    case "tools": {
+      const parsed = value
+        ? value.split(",").map((t) => t.trim()).filter(Boolean)
+        : [];
+      if (parsed.length > 0) {
+        agent.tools = parsed;
+      } else {
+        delete agent.tools;
+      }
+      break;
+    }
+    case "model":
+      if (value) {
+        agent.model = value;
+      } else {
+        delete agent.model;
+      }
+      break;
+    case "thinking":
+      if (value) {
+        agent.thinking = value;
+      } else {
+        delete agent.thinking;
+      }
+      break;
+  }
+}
+
+// ── Save logic ──────────────────────────────────────────────────────────────
+
+function saveAgent(state: ManagerState, requestRender: () => void): void {
+  if (!state.editAgent) return;
+
+  const agent = state.editAgent;
+
+  // Validate name
+  const nameError = validateAgentName(agent.name);
+  if (nameError) {
+    state.editError = nameError;
+    requestRender();
+    return;
+  }
+
+  // Check duplicate name within same scope
+  const duplicate = state.agents.find(
+    (a) => a.source === agent.source && a.name === agent.name && a.filePath !== agent.filePath,
+  );
+  if (duplicate) {
+    state.editError = `Agent "${agent.name}" already exists in ${agent.source} scope`;
+    requestRender();
+    return;
+  }
+
+  // Determine target directory
+  const dir = agent.source === "user" ? state.userDir : state.projectDir;
+  if (!dir) {
+    state.editError = "Target directory not available";
+    requestRender();
+    return;
+  }
+
+  const oldPath = agent.filePath;
+  const newName = agent.name.endsWith(".md") ? agent.name : `${agent.name}.md`;
+  const newPath = path.join(dir, newName);
+
+  try {
+    // Ensure directory exists
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Serialize and write
+    const content = serializeAgent(agent);
+    fs.writeFileSync(newPath, content, "utf-8");
+
+    // Handle rename if name changed
+    if (oldPath && oldPath !== newPath) {
+      try {
+        fs.unlinkSync(oldPath);
+      } catch {
+        // Old file may not exist (e.g., new agent)
+      }
+    }
+
+    // Update filePath
+    agent.filePath = newPath;
+
+    // Refresh agents list
+    const cwd = process.cwd();
+    const discovery = discoverAgentsAll(cwd);
+    state.userAgents = discovery.user;
+    state.projectAgents = discovery.project;
+    state.agents = [...discovery.user, ...discovery.project];
+
+    // Find the saved agent and switch to detail
+    const savedAgent = state.agents.find((a) => a.name === agent.name && a.source === agent.source);
+    if (savedAgent) {
+      state.detailAgent = savedAgent;
+      state.detailScroll = 0;
+      state.screen = "detail";
+    }
+
+    state.editDirty = false;
+    state.editError = null;
+    requestRender();
+  } catch (err) {
+    state.editError = err instanceof Error ? err.message : "Failed to save agent";
+    requestRender();
+  }
+}
+
+// ── Name Input screen ───────────────────────────────────────────────────────
+
+function renderNameInput(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+
+  // Header
+  const title = state.nameInputMode === "new" ? " New Agent " : " Clone Agent ";
+  lines.push(renderHeader(title, width, theme));
+
+  // Label
+  lines.push(padEnd("Name:", width));
+
+  // Input box
+  const boxWidth = Math.min(width - 2, 60);
+  const boxInner = boxWidth - 2;
+  const beforeCursor = state.nameInputBuffer.slice(0, state.nameInputCursor);
+  const afterCursor = state.nameInputBuffer.slice(state.nameInputCursor);
+  const inputContent = `${beforeCursor}${CURSOR_MARKER}${afterCursor}`;
+  const paddedInput = padEnd(inputContent, boxInner);
+  lines.push(padEnd(`│${paddedInput}│`, width));
+
+  // Scope indicator
+  const scopeText = `Scope: [${state.nameInputScope}]  [tab] toggle`;
+  lines.push(padEnd(theme.fg("dim", scopeText), width));
+
+  // Error line
+  if (state.nameInputError) {
+    lines.push(padEnd(theme.fg("error", `  ${state.nameInputError}`), width));
+  } else {
+    lines.push(padEnd("", width));
+  }
+
+  // Footer
+  lines.push(renderFooter(" [enter] continue  [esc] cancel ", width, theme));
+
+  return lines;
+}
+
+function handleNameInput(
+  state: ManagerState,
+  data: string,
+  requestRender: () => void,
+): void {
+  if (matchesKey(data, Key.tab)) {
+    state.nameInputScope = state.nameInputScope === "user" ? "project" : "user";
+    if (state.nameInputScope === "project" && !state.projectDir) {
+      state.nameInputError = "No project agents directory found";
+    } else {
+      state.nameInputError = null;
+    }
+    requestRender();
+  } else if (matchesKey(data, Key.backspace)) {
+    if (state.nameInputCursor > 0) {
+      state.nameInputBuffer =
+        state.nameInputBuffer.slice(0, state.nameInputCursor - 1) +
+        state.nameInputBuffer.slice(state.nameInputCursor);
+      state.nameInputCursor--;
+      state.nameInputError = null;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.left)) {
+    if (state.nameInputCursor > 0) {
+      state.nameInputCursor--;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.right)) {
+    if (state.nameInputCursor < state.nameInputBuffer.length) {
+      state.nameInputCursor++;
+      requestRender();
+    }
+  } else if (matchesKey(data, Key.enter)) {
+    const name = state.nameInputBuffer.trim();
+    const nameError = validateAgentName(name);
+    if (nameError) {
+      state.nameInputError = nameError;
+      requestRender();
+      return;
+    }
+    if (state.nameInputScope === "project" && !state.projectDir) {
+      state.nameInputError = "No project agents directory found";
+      requestRender();
+      return;
+    }
+
+    // Check for duplicate name
+    const duplicate = state.agents.find(
+      (a) => a.name === name && a.source === state.nameInputScope,
+    );
+    if (duplicate) {
+      state.nameInputError = `Agent "${name}" already exists`;
+      requestRender();
+      return;
+    }
+
+    const dir = state.nameInputScope === "user" ? state.userDir : state.projectDir;
+    if (!dir) {
+      state.nameInputError = "Target directory not available";
+      requestRender();
+      return;
+    }
+
+    const filePath = path.join(dir, `${name}.md`);
+
+    let newAgent: AgentConfig;
+    if (state.nameInputMode === "clone" && state.nameInputSource) {
+      const src = state.nameInputSource;
+      newAgent = {
+        ...src,
+        name,
+        source: state.nameInputScope,
+        filePath,
+      };
+      if (src.tools) newAgent.tools = [...src.tools];
+      if (src.extraFields) newAgent.extraFields = { ...src.extraFields };
+    } else {
+      newAgent = {
+        name,
+        description: "",
+        systemPrompt: "",
+        source: state.nameInputScope,
+        filePath,
+      };
+    }
+
+    // Switch to edit screen with new agent
+    state.editAgent = newAgent;
+    state.editFieldIndex = 0;
+    state.editInField = false;
+    state.editDirty = false;
+    state.editFieldCursor = 0;
+    state.editPromptMode = false;
+    state.editPromptCursor = 0;
+    state.editPromptScroll = 0;
+    state.editDiscardPrompt = false;
+    state.editError = null;
+    state.isNew = true;
+    state.screen = "edit";
+    requestRender();
+  } else if (matchesKey(data, Key.escape)) {
+    state.screen = "list";
+    requestRender();
+  } else if (data.length === 1 && data >= " " && data <= "~") {
+    state.nameInputBuffer =
+      state.nameInputBuffer.slice(0, state.nameInputCursor) +
+      data +
+      state.nameInputBuffer.slice(state.nameInputCursor);
+    state.nameInputCursor++;
+    state.nameInputError = null;
+    requestRender();
+  }
+}
+
+// ── Confirm Delete screen ───────────────────────────────────────────────────
+
+function renderConfirmDelete(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+  const target = state.deleteTarget;
+
+  if (!target) {
+    lines.push(renderHeader(" Delete? ", width, theme));
+    lines.push(renderFooter(" [esc] cancel ", width, theme));
+    return lines;
+  }
+
+  // Header
+  lines.push(renderHeader(` Delete "${target.name}"? `, width, theme));
+
+  // File path
+  lines.push(padEnd(`File: ${target.filePath}`, width));
+
+  // Warning
+  lines.push(padEnd(theme.fg("error", "This cannot be undone."), width));
+
+  // Spacer
+  lines.push(padEnd("", width));
+
+  // Footer
+  lines.push(renderFooter(" [y] confirm  [n / esc] cancel ", width, theme));
+
+  return lines;
+}
+
+function handleConfirmDelete(
+  state: ManagerState,
+  data: string,
+  requestRender: () => void,
+): void {
+  if (matchesKey(data, "y") || data === "Y") {
+    if (state.deleteTarget) {
+      try {
+        fs.unlinkSync(state.deleteTarget.filePath);
+      } catch {
+        // File may not exist
+      }
+
+      // Refresh agents list
+      const cwd = process.cwd();
+      const discovery = discoverAgentsAll(cwd);
+      state.userAgents = discovery.user;
+      state.projectAgents = discovery.project;
+      state.agents = [...discovery.user, ...discovery.project];
+
+      state.listCursor = 0;
+      state.listScroll = 0;
+      state.filterQuery = "";
+      state.filterMode = false;
+    }
+    state.screen = "list";
+    requestRender();
+  } else if (matchesKey(data, "n") || data === "N" || matchesKey(data, Key.escape)) {
+    state.screen = state.deleteFromScreen;
+    requestRender();
+  }
+}
+
+// ── Main factory ────────────────────────────────────────────────────────────
+
+export function createAgentManager(
+  userAgents: AgentConfig[],
+  projectAgents: AgentConfig[],
+  userDir: string,
+  projectDir: string | null,
+  tui: TUIContext,
+  theme: Theme,
+  done: () => void,
+): Component {
+  const state: ManagerState = {
+    screen: "list",
+    agents: [...userAgents, ...projectAgents],
+    userAgents,
+    projectAgents,
+    userDir,
+    projectDir,
+
+    listCursor: 0,
+    listScroll: 0,
+    filterQuery: "",
+    filterMode: false,
+
+    detailAgent: null,
+    detailScroll: 0,
+
+    editAgent: null,
+    editFieldIndex: 0,
+    editInField: false,
+    editDirty: false,
+    editFieldCursor: 0,
+    editPromptMode: false,
+    editPromptCursor: 0,
+    editPromptScroll: 0,
+    editDiscardPrompt: false,
+    editError: null,
+
+    nameInputBuffer: "",
+    nameInputCursor: 0,
+    nameInputScope: "user",
+    nameInputMode: "new",
+    nameInputSource: null,
+    nameInputError: null,
+
+    deleteTarget: null,
+    deleteFromScreen: "list",
+
+    isNew: false,
+  };
+
+  let cachedWidth: number | undefined;
+  let cachedLines: string[] | undefined;
+
+  function requestRender(): void {
+    cachedWidth = undefined;
+    cachedLines = undefined;
+    tui.requestRender();
+  }
+
+  function handleInput(data: string): void {
+    const result: "close" | void = (() => {
+      switch (state.screen) {
+        case "list":
+          return handleListInput(state, data, done, requestRender);
+        case "detail":
+          return handleDetailInput(state, data, requestRender);
+        case "edit":
+          return handleEditInput(state, data, requestRender);
+        case "name-input":
+          return handleNameInput(state, data, requestRender);
+        case "confirm-delete":
+          return handleConfirmDelete(state, data, requestRender);
+      }
+    })();
+
+    if (result === "close") {
+      done();
+    }
+  }
+
+  return {
+    render(width: number): string[] {
+      if (cachedLines && cachedWidth === width) {
+        return cachedLines;
+      }
+
+      let lines: string[];
+      switch (state.screen) {
+        case "list":
+          lines = renderList(state, width, theme);
+          break;
+        case "detail":
+          lines = renderDetail(state, width, theme);
+          break;
+        case "edit":
+          lines = renderEdit(state, width, theme);
+          break;
+        case "name-input":
+          lines = renderNameInput(state, width, theme);
+          break;
+        case "confirm-delete":
+          lines = renderConfirmDelete(state, width, theme);
+          break;
+      }
+
+      cachedWidth = width;
+      cachedLines = lines;
+      return lines;
+    },
+
+    handleInput,
+
+    invalidate(): void {
+      cachedWidth = undefined;
+      cachedLines = undefined;
+    },
+
+    dispose(): void {
+      // No resources to clean up
+    },
+  };
+}

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -175,8 +175,7 @@ function wrapWithBorder(lines: string[], width: number, theme: Theme): string[] 
   const bottom = theme.fg("dim", `└${"─".repeat(innerWidth)}┘`);
   const result: string[] = [top];
   for (const line of lines) {
-    const content = truncateToWidth(line, contentWidth);
-    const padded = " " + padEnd(content, contentWidth) + " ";
+    const padded = " " + padEnd(line, contentWidth) + " ";
     result.push(left + padded + right);
   }
   result.push(bottom);
@@ -1201,24 +1200,25 @@ export function createAgentManager(
         return cachedLines;
       }
 
-      // Pass inner width (minus border columns) to screen renderers
+      // Pass content width (minus border + padding) to screen renderers
       const innerWidth = Math.max(1, width - 2);
+      const contentWidth = Math.max(1, innerWidth - 2); // minus 1 space padding each side
       let lines: string[];
       switch (state.screen) {
         case "list":
-          lines = renderList(state, innerWidth, theme);
+          lines = renderList(state, contentWidth, theme);
           break;
         case "detail":
-          lines = renderDetail(state, innerWidth, theme);
+          lines = renderDetail(state, contentWidth, theme);
           break;
         case "edit":
-          lines = renderEdit(state, innerWidth, theme);
+          lines = renderEdit(state, contentWidth, theme);
           break;
         case "name-input":
-          lines = renderNameInput(state, innerWidth, theme);
+          lines = renderNameInput(state, contentWidth, theme);
           break;
         case "confirm-delete":
-          lines = renderConfirmDelete(state, innerWidth, theme);
+          lines = renderConfirmDelete(state, contentWidth, theme);
           break;
       }
 

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -163,6 +163,21 @@ function agentModel(a: AgentConfig): string {
   return a.model ?? "default";
 }
 
+
+// ── Border wrapper ────────────────────────────────────────────────────────────
+
+function wrapWithBorder(lines: string[], width: number, theme: Theme): string[] {
+  const innerWidth = Math.max(1, width - 2);
+  const top = theme.fg("dim", `┌${"─".repeat(innerWidth)}┐`);
+  const bottom = theme.fg("dim", `└${"─".repeat(innerWidth)}┘`);
+  const result: string[] = [top];
+  for (const line of lines) {
+    const inner = padEnd(line, innerWidth);
+    result.push(theme.fg("dim", `│${inner}│`));
+  }
+  result.push(bottom);
+  return result;
+}
 // ── List screen ─────────────────────────────────────────────────────────────
 
 function renderList(state: ManagerState, width: number, theme: Theme): string[] {
@@ -1182,28 +1197,31 @@ export function createAgentManager(
         return cachedLines;
       }
 
+      // Pass inner width (minus border columns) to screen renderers
+      const innerWidth = Math.max(1, width - 2);
       let lines: string[];
       switch (state.screen) {
         case "list":
-          lines = renderList(state, width, theme);
+          lines = renderList(state, innerWidth, theme);
           break;
         case "detail":
-          lines = renderDetail(state, width, theme);
+          lines = renderDetail(state, innerWidth, theme);
           break;
         case "edit":
-          lines = renderEdit(state, width, theme);
+          lines = renderEdit(state, innerWidth, theme);
           break;
         case "name-input":
-          lines = renderNameInput(state, width, theme);
+          lines = renderNameInput(state, innerWidth, theme);
           break;
         case "confirm-delete":
-          lines = renderConfirmDelete(state, width, theme);
+          lines = renderConfirmDelete(state, innerWidth, theme);
           break;
       }
 
+      const bordered = wrapWithBorder(lines, width, theme);
       cachedWidth = width;
-      cachedLines = lines;
-      return lines;
+      cachedLines = bordered;
+      return bordered;
     },
 
     handleInput,

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -18,6 +18,8 @@ import { serializeAgent, validateAgentName } from "./frontmatter-io.js";
 // ── Screen constants ────────────────────────────────────────────────────────
 
 const LIST_VIEWPORT = 8;
+const DETAIL_VIEWPORT_HEIGHT = 14;
+const EDIT_PROMPT_VIEWPORT_HEIGHT = 8;
 const MODEL_SELECTOR_HEIGHT = 10;
 const TOOL_PICKER_HEIGHT = 14;
 const EDIT_FIELDS = ["name", "description", "tools", "model", "thinking"] as const;
@@ -78,6 +80,8 @@ interface ManagerState {
   editPromptScroll: number;      // scroll offset for prompt editor
   editDiscardPrompt: boolean;    // true when asking y/n to discard changes
   editError: string | null;
+  editOriginal: AgentConfig | null;     // captured when entering edit
+  editReturnScreen: "list" | "detail" | "name-input";  // where to return on esc
 
   // Name input state
   nameInputBuffer: string;
@@ -111,6 +115,7 @@ interface ManagerState {
 
   // Render width (stored so input handlers can compute correct scroll bounds)
   lastWidth: number;
+  lastContentWidth: number;
 }
 
 // ── Component return type ───────────────────────────────────────────────────
@@ -215,18 +220,24 @@ function hardTruncate(text: string, maxVisible: number): string {
   let result = "";
   let plainPos = 0;
   let i = 0;
+  let copiedSgr = false;
   while (i < text.length && plainPos < maxVisible) {
     if (text[i] === "\x1b" && text[i + 1] === "[") {
       // Copy the escape sequence
       let j = i;
       while (j < text.length && text[j] !== "m") j++;
       result += text.slice(i, j + 1);
+      copiedSgr = true;
       i = j + 1;
     } else {
       result += text[i];
       plainPos++;
       i++;
     }
+  }
+  // Ensure styling doesn't bleed: append reset if we copied SGR and result doesn't end with one
+  if (copiedSgr && !/\x1b\[0?m$/.test(result)) {
+    result += "\x1b[0m";
   }
   return result;
 }
@@ -504,8 +515,8 @@ function handleDetailInput(
     }
   } else if (matchesKey(data, Key.down)) {
     if (state.detailAgent) {
-      const bodyLines = wrapText(state.detailAgent.systemPrompt, state.lastWidth);
-      const bodyViewport = Math.max(6, 14 - 9);
+      const bodyLines = wrapText(state.detailAgent.systemPrompt, state.lastContentWidth);
+      const bodyViewport = Math.max(6, DETAIL_VIEWPORT_HEIGHT - 9);
       if (state.detailScroll < bodyLines.length - bodyViewport) {
         state.detailScroll++;
         requestRender();
@@ -520,6 +531,9 @@ function handleDetailInput(
       const copy: AgentConfig = { ...agent };
       if (agent.tools) copy.tools = [...agent.tools];
       state.editAgent = copy;
+      state.editOriginal = { ...agent };
+      if (agent.tools) state.editOriginal.tools = [...agent.tools];
+      state.editReturnScreen = "detail";
       state.editFieldIndex = 0;
       state.editInField = false;
       state.editDirty = false;
@@ -812,9 +826,9 @@ function handleEditInput(
       state.editDiscardPrompt = false;
       state.editDirty = false;
       // Re-read from original
-      if (state.detailAgent) {
-        const origCopy: AgentConfig = { ...state.detailAgent };
-        if (state.detailAgent.tools) origCopy.tools = [...state.detailAgent.tools];
+      if (state.editOriginal) {
+        const origCopy: AgentConfig = { ...state.editOriginal };
+        if (state.editOriginal.tools) origCopy.tools = [...state.editOriginal.tools];
         state.editAgent = origCopy;
       }
       state.editFieldIndex = 0;
@@ -961,10 +975,17 @@ function handleEditInput(
   // System prompt edit mode
   if (state.editPromptMode) {
     if (matchesKey(data, Key.ctrl("s"))) {
-      state.editDirty = true;
-      requestRender();
+      saveAgent(state, requestRender);
     } else if (matchesKey(data, Key.escape)) {
       state.editPromptMode = false;
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.enter)) {
+      // Insert newline at cursor
+      const before = state.editAgent.systemPrompt.slice(0, state.editPromptCursor);
+      const after = state.editAgent.systemPrompt.slice(state.editPromptCursor);
+      state.editAgent.systemPrompt = before + "\n" + after;
+      state.editPromptCursor++;
       state.editDirty = true;
       requestRender();
     } else if (matchesKey(data, Key.up)) {
@@ -973,13 +994,13 @@ function handleEditInput(
         requestRender();
       }
     } else if (matchesKey(data, Key.down)) {
-      const promptLines = wrapText(state.editAgent.systemPrompt, state.lastWidth);
-      const promptViewport = Math.max(6, 14 - 4 - 2);
+      const promptLines = wrapText(state.editAgent.systemPrompt, state.lastContentWidth);
+      const promptViewport = Math.max(6, EDIT_PROMPT_VIEWPORT_HEIGHT - 4 - 2);
       if (state.editPromptScroll < promptLines.length - promptViewport) {
         state.editPromptScroll++;
         requestRender();
       }
-    } else if (data.length === 1 && data >= " " && data <= "~") {
+    } else if (data.length === 1 && (data >= " " && data <= "~")) {
       // Append char to systemPrompt at cursor
       const before = state.editAgent.systemPrompt.slice(0, state.editPromptCursor);
       const after = state.editAgent.systemPrompt.slice(state.editPromptCursor);
@@ -1121,7 +1142,7 @@ function handleEditInput(
       state.editDiscardPrompt = true;
       requestRender();
     } else {
-      state.screen = "detail";
+      state.screen = state.editReturnScreen;
       requestRender();
     }
   }
@@ -1390,6 +1411,9 @@ function handleNameInput(
 
     // Switch to edit screen with new agent
     state.editAgent = newAgent;
+    state.editOriginal = { ...newAgent };
+    if (newAgent.tools) state.editOriginal.tools = [...newAgent.tools];
+    state.editReturnScreen = "list";
     state.editFieldIndex = 0;
     state.editInField = false;
     state.editDirty = false;
@@ -1518,6 +1542,8 @@ export function createAgentManager(
     editPromptScroll: 0,
     editDiscardPrompt: false,
     editError: null,
+    editOriginal: null,
+    editReturnScreen: "list",
 
     nameInputBuffer: "",
     nameInputCursor: 0,
@@ -1545,6 +1571,7 @@ export function createAgentManager(
     isNew: false,
 
     lastWidth: 84,
+    lastContentWidth: 80,
   };
 
   let cachedWidth: number | undefined;
@@ -1580,13 +1607,14 @@ export function createAgentManager(
   return {
     render(width: number): string[] {
       state.lastWidth = width;
+      const innerWidth = Math.max(1, width - 2);
+      const contentWidth = Math.max(1, innerWidth - 2); // minus 1 space padding each side
+      state.lastContentWidth = contentWidth;
       if (cachedLines && cachedWidth === width) {
         return cachedLines;
       }
 
       // Pass content width (minus border + padding) to screen renderers
-      const innerWidth = Math.max(1, width - 2);
-      const contentWidth = Math.max(1, innerWidth - 2); // minus 1 space padding each side
       let lines: string[];
       switch (state.screen) {
         case "list":

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -18,6 +18,7 @@ import { serializeAgent, validateAgentName } from "./frontmatter-io.js";
 // ── Screen constants ────────────────────────────────────────────────────────
 
 const LIST_VIEWPORT = 8;
+const MODEL_SELECTOR_HEIGHT = 10;
 const EDIT_FIELDS = ["name", "description", "tools", "model", "thinking"] as const;
 type EditField = (typeof EDIT_FIELDS)[number];
 
@@ -32,6 +33,12 @@ interface Theme {
 
 interface TUIContext {
   requestRender(): void;
+}
+
+interface ModelInfo {
+  id: string;
+  provider: string;
+  fullId: string;
 }
 
 // ── Manager state ───────────────────────────────────────────────────────────
@@ -73,6 +80,13 @@ interface ManagerState {
   nameInputMode: "new" | "clone";
   nameInputSource: AgentConfig | null;
   nameInputError: string | null;
+
+  // Model picker state
+  models: ModelInfo[];
+  modelPickerOpen: boolean;
+  modelSearchQuery: string;
+  modelCursor: number;
+  filteredModels: ModelInfo[];
 
   // Confirm delete state
   deleteTarget: AgentConfig | null;
@@ -161,6 +175,17 @@ function scopeLabel(source: "user" | "project"): string {
 
 function agentModel(a: AgentConfig): string {
   return a.model ?? "default";
+}
+
+function filterModels(models: ModelInfo[], query: string): ModelInfo[] {
+  if (!query) return models;
+  const q = query.toLowerCase();
+  return models.filter(
+    (m) =>
+      m.fullId.toLowerCase().includes(q) ||
+      m.id.toLowerCase().includes(q) ||
+      m.provider.toLowerCase().includes(q),
+  );
 }
 
 
@@ -521,6 +546,11 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
     return lines;
   }
 
+  // Model picker
+  if (state.modelPickerOpen) {
+    return renderModelPicker(state, width, theme);
+  }
+
   // Header
   const dirtyMark = state.editDirty ? " *" : "";
   lines.push(renderHeader(` Edit: ${agent.name}${dirtyMark} `, width, theme));
@@ -623,7 +653,69 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
   }
 
   // Hint
-  lines.push(renderFooter(" [↑↓] fields  [enter] edit  [p] prompt  [ctrl+s] save  [esc] back ", width, theme));
+  lines.push(renderFooter(" [↑↓] fields  [enter/m] edit  [p] prompt  [ctrl+s] save  [esc] back ", width, theme));
+
+  return lines;
+}
+
+function renderModelPicker(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(renderHeader(" Select Model ", width, theme));
+  lines.push(padEnd("", width));
+
+  // Search box
+  const searchLine = `Search: ${state.modelSearchQuery}${CURSOR_MARKER}`;
+  lines.push(padEnd(searchLine, width));
+  lines.push(padEnd("", width));
+
+  // Current model
+  const currentModel = state.editAgent ? agentModel(state.editAgent) : "default";
+  lines.push(
+    padEnd(theme.fg("dim", "Current: ") + theme.fg("warning", currentModel), width),
+  );
+  lines.push(padEnd("", width));
+
+  // Model list
+  const list = state.filteredModels;
+  if (list.length === 0) {
+    lines.push(padEnd(theme.fg("dim", "No matching models"), width));
+  } else {
+    let startIdx = 0;
+    if (list.length > MODEL_SELECTOR_HEIGHT) {
+      startIdx = Math.max(0, state.modelCursor - Math.floor(MODEL_SELECTOR_HEIGHT / 2));
+      startIdx = Math.min(startIdx, list.length - MODEL_SELECTOR_HEIGHT);
+    }
+    const endIdx = Math.min(startIdx + MODEL_SELECTOR_HEIGHT, list.length);
+
+    if (startIdx > 0) {
+      lines.push(padEnd(theme.fg("dim", `↑ ${startIdx} more`), width));
+    }
+
+    for (let i = startIdx; i < endIdx; i++) {
+      const model = list[i];
+      if (!model) continue;
+      const isSelected = i === state.modelCursor;
+      const prefix = isSelected ? theme.fg("accent", "> ") : "  ";
+      const modelText = isSelected ? theme.fg("accent", model.id) : model.id;
+      const provider = theme.fg("dim", ` [${model.provider}]`);
+      lines.push(padEnd(`${prefix}${modelText}${provider}`, width));
+    }
+
+    const remaining = list.length - endIdx;
+    if (remaining > 0) {
+      lines.push(padEnd(theme.fg("dim", `↓ ${remaining} more`), width));
+    }
+  }
+
+  // Pad to fixed height
+  while (lines.length < 18) {
+    lines.push(padEnd("", width));
+  }
+
+  // Footer
+  lines.push(renderFooter(" [enter] select  [esc] cancel  type to search ", width, theme));
 
   return lines;
 }
@@ -657,6 +749,53 @@ function handleEditInput(
   }
 
   if (!state.editAgent) return;
+
+  // Model picker mode
+  if (state.modelPickerOpen) {
+    if (matchesKey(data, Key.escape)) {
+      state.modelPickerOpen = false;
+      state.modelSearchQuery = "";
+      requestRender();
+    } else if (matchesKey(data, Key.enter)) {
+      const selected = state.filteredModels[state.modelCursor];
+      if (selected) {
+        state.editAgent.model = selected.fullId;
+        state.modelPickerOpen = false;
+        state.modelSearchQuery = "";
+        state.editDirty = true;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.up)) {
+      if (state.filteredModels.length > 0) {
+        state.modelCursor =
+          state.modelCursor > 0
+            ? state.modelCursor - 1
+            : state.filteredModels.length - 1;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.down)) {
+      if (state.filteredModels.length > 0) {
+        state.modelCursor =
+          state.modelCursor < state.filteredModels.length - 1
+            ? state.modelCursor + 1
+            : 0;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.backspace)) {
+      if (state.modelSearchQuery.length > 0) {
+        state.modelSearchQuery = state.modelSearchQuery.slice(0, -1);
+        state.filteredModels = filterModels(state.models, state.modelSearchQuery);
+        state.modelCursor = Math.min(state.modelCursor, Math.max(0, state.filteredModels.length - 1));
+        requestRender();
+      }
+    } else if (data.length === 1 && data >= " " && data <= "~") {
+      state.modelSearchQuery += data;
+      state.filteredModels = filterModels(state.models, state.modelSearchQuery);
+      state.modelCursor = Math.min(state.modelCursor, Math.max(0, state.filteredModels.length - 1));
+      requestRender();
+    }
+    return;
+  }
 
   // System prompt edit mode
   if (state.editPromptMode) {
@@ -762,9 +901,19 @@ function handleEditInput(
       state.editFieldIndex++;
       requestRender();
     }
-  } else if (matchesKey(data, Key.enter)) {
+  } else if (matchesKey(data, Key.enter) || matchesKey(data, "m")) {
     const field = EDIT_FIELDS[state.editFieldIndex];
-    if (field) {
+    if (field === "model") {
+      state.modelPickerOpen = true;
+      state.modelSearchQuery = "";
+      state.filteredModels = state.models;
+      const current = agentModel(state.editAgent);
+      const idx = state.models.findIndex(
+        (m) => m.fullId === current || m.id === current,
+      );
+      state.modelCursor = idx >= 0 ? idx : 0;
+      requestRender();
+    } else if (field) {
       state.editInField = true;
       state.editFieldCursor = getFieldValue(state.editAgent, field).length;
       requestRender();
@@ -1149,6 +1298,7 @@ export function createAgentManager(
   tui: TUIContext,
   theme: Theme,
   done: () => void,
+  models: ModelInfo[],
 ): Component {
   const state: ManagerState = {
     screen: "list",
@@ -1183,6 +1333,12 @@ export function createAgentManager(
     nameInputMode: "new",
     nameInputSource: null,
     nameInputError: null,
+
+    models,
+    modelPickerOpen: false,
+    modelSearchQuery: "",
+    modelCursor: 0,
+    filteredModels: models,
 
     deleteTarget: null,
     deleteFromScreen: "list",

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -166,6 +166,32 @@ function agentModel(a: AgentConfig): string {
 
 // ── Border wrapper ────────────────────────────────────────────────────────────
 
+/** Hard-truncate by visible width — no "..." suffix. Strips ANSI, truncates, rebuilds. */
+function hardTruncate(text: string, maxVisible: number): string {
+  if (visibleWidth(text) <= maxVisible) return text;
+  // Strip ANSI codes, truncate, then re-apply any trailing reset codes
+  const plain = text.replace(/\x1b\[[0-9;]*m/g, "");
+  const truncated = plain.slice(0, maxVisible);
+  // Restore any ANSI codes that were in the original up to this point
+  let result = "";
+  let plainPos = 0;
+  let i = 0;
+  while (i < text.length && plainPos < maxVisible) {
+    if (text[i] === "\x1b" && text[i + 1] === "[") {
+      // Copy the escape sequence
+      let j = i;
+      while (j < text.length && text[j] !== "m") j++;
+      result += text.slice(i, j + 1);
+      i = j + 1;
+    } else {
+      result += text[i];
+      plainPos++;
+      i++;
+    }
+  }
+  return result;
+}
+
 function wrapWithBorder(lines: string[], width: number, theme: Theme): string[] {
   const innerWidth = Math.max(1, width - 2);
   const contentWidth = Math.max(1, innerWidth - 2); // minus 1 space padding each side
@@ -175,7 +201,8 @@ function wrapWithBorder(lines: string[], width: number, theme: Theme): string[] 
   const bottom = theme.fg("dim", `└${"─".repeat(innerWidth)}┘`);
   const result: string[] = [top];
   for (const line of lines) {
-    const padded = " " + padEnd(line, contentWidth) + " ";
+    const clamped = hardTruncate(line, contentWidth);
+    const padded = " " + padEnd(clamped, contentWidth) + " ";
     result.push(left + padded + right);
   }
   result.push(bottom);

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -172,8 +172,8 @@ function wrapWithBorder(lines: string[], width: number, theme: Theme): string[] 
   const bottom = theme.fg("dim", `└${"─".repeat(innerWidth)}┘`);
   const result: string[] = [top];
   for (const line of lines) {
-    const inner = padEnd(line, innerWidth);
-    result.push(theme.fg("dim", `│${inner}│`));
+    const padded = " " + padEnd(line, innerWidth - 2) + " ";
+    result.push(theme.fg("dim", `│${padded}│`));
   }
   result.push(bottom);
   return result;

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -216,6 +216,7 @@ function renderList(state: ManagerState, width: number, theme: Theme): string[] 
 
   // Header
   lines.push(renderHeader(` Agents [${state.agents.length}] `, width, theme));
+  lines.push(padEnd("", width));
 
   // Search bar
   if (state.filterMode || state.filterQuery.length > 0) {
@@ -227,6 +228,7 @@ function renderList(state: ManagerState, width: number, theme: Theme): string[] 
   } else {
     lines.push(padEnd(`◎ ${theme.fg("dim", "type to filter...")}`, width));
   }
+  lines.push(padEnd("", width));
 
   // Agent rows or empty state
   const start = state.listScroll;
@@ -261,7 +263,7 @@ function renderList(state: ManagerState, width: number, theme: Theme): string[] 
   }
 
   // Fill remaining viewport rows
-  while (lines.length < 2 + LIST_VIEWPORT + 2) {
+  while (lines.length < 4 + LIST_VIEWPORT + 2) {
     lines.push(padEnd("", width));
   }
 

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -19,6 +19,7 @@ import { serializeAgent, validateAgentName } from "./frontmatter-io.js";
 
 const LIST_VIEWPORT = 8;
 const MODEL_SELECTOR_HEIGHT = 10;
+const TOOL_PICKER_HEIGHT = 14;
 const EDIT_FIELDS = ["name", "description", "tools", "model", "thinking"] as const;
 type EditField = (typeof EDIT_FIELDS)[number];
 
@@ -39,6 +40,11 @@ interface ModelInfo {
   id: string;
   provider: string;
   fullId: string;
+}
+
+interface ToolInfo {
+  name: string;
+  description: string;
 }
 
 // ── Manager state ───────────────────────────────────────────────────────────
@@ -87,6 +93,14 @@ interface ManagerState {
   modelSearchQuery: string;
   modelCursor: number;
   filteredModels: ModelInfo[];
+
+  // Tool picker state
+  tools: ToolInfo[];
+  toolPickerOpen: boolean;
+  toolCursor: number;
+  toolSelected: Set<string>;
+  toolSearch: string;
+  filteredTools: ToolInfo[];
 
   // Confirm delete state
   deleteTarget: AgentConfig | null;
@@ -551,6 +565,11 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
     return renderModelPicker(state, width, theme);
   }
 
+  // Tool picker
+  if (state.toolPickerOpen) {
+    return renderToolPicker(state, width, theme);
+  }
+
   // Header
   const dirtyMark = state.editDirty ? " *" : "";
   lines.push(renderHeader(` Edit: ${agent.name}${dirtyMark} `, width, theme));
@@ -653,7 +672,7 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
   }
 
   // Hint
-  lines.push(renderFooter(" [↑↓] fields  [enter/m] edit  [p] prompt  [ctrl+s] save  [esc] back ", width, theme));
+  lines.push(renderFooter(" [↑↓] fields  [enter] edit  [t] tools  [m] model  [p] prompt  [ctrl+s] save  [esc] back ", width, theme));
 
   return lines;
 }
@@ -716,6 +735,68 @@ function renderModelPicker(state: ManagerState, width: number, theme: Theme): st
 
   // Footer
   lines.push(renderFooter(" [enter] select  [esc] cancel  type to search ", width, theme));
+
+  return lines;
+}
+
+function renderToolPicker(state: ManagerState, width: number, theme: Theme): string[] {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(renderHeader(" Select Tools ", width, theme));
+  lines.push(padEnd("", width));
+
+  // Search box
+  const searchLine = `Search: ${state.toolSearch}`;
+  lines.push(padEnd(searchLine, width));
+  lines.push(padEnd("", width));
+
+  // Help line
+  lines.push(padEnd(theme.fg("dim", "space toggle · enter confirm · esc cancel · ↑↓ navigate"), width));
+  lines.push(padEnd("", width));
+
+  // Tool list
+  const list = state.filteredTools;
+  if (list.length === 0) {
+    lines.push(padEnd(theme.fg("dim", "No matching tools"), width));
+  } else {
+    let startIdx = 0;
+    if (list.length > TOOL_PICKER_HEIGHT) {
+      startIdx = Math.max(0, state.toolCursor - Math.floor(TOOL_PICKER_HEIGHT / 2));
+      startIdx = Math.min(startIdx, list.length - TOOL_PICKER_HEIGHT);
+    }
+    const endIdx = Math.min(startIdx + TOOL_PICKER_HEIGHT, list.length);
+
+    if (startIdx > 0) {
+      lines.push(padEnd(theme.fg("dim", `↑ ${startIdx} more`), width));
+    }
+
+    for (let i = startIdx; i < endIdx; i++) {
+      const tool = list[i];
+      if (!tool) continue;
+      const isCursor = i === state.toolCursor;
+      const checked = state.toolSelected.has(tool.name);
+      const cursor = isCursor ? theme.fg("accent", "> ") : "  ";
+      const box = checked ? theme.fg("accent", "[x] ") : "[ ] ";
+      const nameText = isCursor ? theme.fg("accent", tool.name) : tool.name;
+      const desc = tool.description ? ` ${theme.fg("dim", "— " + tool.description)}` : "";
+      const rowText = cursor + box + nameText + desc;
+      lines.push(padEnd(truncateToWidth(rowText, width), width));
+    }
+
+    const remaining = list.length - endIdx;
+    if (remaining > 0) {
+      lines.push(padEnd(theme.fg("dim", `↓ ${remaining} more`), width));
+    }
+  }
+
+  // Pad to fixed height
+  while (lines.length < 18) {
+    lines.push(padEnd("", width));
+  }
+
+  // Footer
+  lines.push(renderFooter(" [enter] confirm  [esc] cancel  [space] toggle  [type] search ", width, theme));
 
   return lines;
 }
@@ -792,6 +873,86 @@ function handleEditInput(
       state.modelSearchQuery += data;
       state.filteredModels = filterModels(state.models, state.modelSearchQuery);
       state.modelCursor = Math.min(state.modelCursor, Math.max(0, state.filteredModels.length - 1));
+      requestRender();
+    }
+    return;
+  }
+
+  // Tool picker mode
+  if (state.toolPickerOpen) {
+    if (matchesKey(data, Key.escape)) {
+      state.toolPickerOpen = false;
+      state.toolSearch = "";
+      requestRender();
+    } else if (matchesKey(data, Key.enter)) {
+      const names = [...state.toolSelected];
+      if (names.length > 0) {
+        state.editAgent.tools = names;
+      } else {
+        delete state.editAgent.tools;
+      }
+      state.toolPickerOpen = false;
+      state.toolSearch = "";
+      state.editDirty = true;
+      requestRender();
+    } else if (matchesKey(data, Key.up)) {
+      if (state.filteredTools.length > 0) {
+        state.toolCursor = state.toolCursor > 0 ? state.toolCursor - 1 : state.filteredTools.length - 1;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.down)) {
+      if (state.filteredTools.length > 0) {
+        state.toolCursor = state.toolCursor < state.filteredTools.length - 1 ? state.toolCursor + 1 : 0;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.pageUp)) {
+      if (state.filteredTools.length > 0) {
+        state.toolCursor = Math.max(0, state.toolCursor - TOOL_PICKER_HEIGHT);
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.pageDown)) {
+      if (state.filteredTools.length > 0) {
+        state.toolCursor = Math.min(state.filteredTools.length - 1, state.toolCursor + TOOL_PICKER_HEIGHT);
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.home)) {
+      if (state.filteredTools.length > 0) {
+        state.toolCursor = 0;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.end)) {
+      if (state.filteredTools.length > 0) {
+        state.toolCursor = state.filteredTools.length - 1;
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.space) || matchesKey(data, Key.tab)) {
+      // Toggle current tool
+      const tool = state.filteredTools[state.toolCursor];
+      if (tool) {
+        if (state.toolSelected.has(tool.name)) {
+          state.toolSelected.delete(tool.name);
+        } else {
+          state.toolSelected.add(tool.name);
+        }
+        requestRender();
+      }
+    } else if (matchesKey(data, Key.backspace)) {
+      if (state.toolSearch.length > 0) {
+        state.toolSearch = state.toolSearch.slice(0, -1);
+        const q = state.toolSearch.toLowerCase();
+        state.filteredTools = state.tools.filter(
+          (t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q),
+        );
+        state.toolCursor = Math.min(state.toolCursor, Math.max(0, state.filteredTools.length - 1));
+        requestRender();
+      }
+    } else if (data.length === 1 && data >= " " && data <= "~") {
+      state.toolSearch += data;
+      const q = state.toolSearch.toLowerCase();
+      state.filteredTools = state.tools.filter(
+        (t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q),
+      );
+      state.toolCursor = Math.min(state.toolCursor, Math.max(0, state.filteredTools.length - 1));
       requestRender();
     }
     return;
@@ -901,7 +1062,7 @@ function handleEditInput(
       state.editFieldIndex++;
       requestRender();
     }
-  } else if (matchesKey(data, Key.enter) || matchesKey(data, "m")) {
+  } else if (matchesKey(data, Key.enter)) {
     const field = EDIT_FIELDS[state.editFieldIndex];
     if (field === "model") {
       state.modelPickerOpen = true;
@@ -913,9 +1074,39 @@ function handleEditInput(
       );
       state.modelCursor = idx >= 0 ? idx : 0;
       requestRender();
+    } else if (field === "tools") {
+      state.toolPickerOpen = true;
+      state.toolSelected = new Set(state.editAgent.tools ?? []);
+      state.toolSearch = "";
+      state.filteredTools = state.tools;
+      state.toolCursor = 0;
+      requestRender();
     } else if (field) {
       state.editInField = true;
       state.editFieldCursor = getFieldValue(state.editAgent, field).length;
+      requestRender();
+    }
+  } else if (matchesKey(data, "m")) {
+    const field = EDIT_FIELDS[state.editFieldIndex];
+    if (field === "model") {
+      state.modelPickerOpen = true;
+      state.modelSearchQuery = "";
+      state.filteredModels = state.models;
+      const current = agentModel(state.editAgent);
+      const idx = state.models.findIndex(
+        (m) => m.fullId === current || m.id === current,
+      );
+      state.modelCursor = idx >= 0 ? idx : 0;
+      requestRender();
+    }
+  } else if (matchesKey(data, "t")) {
+    const field = EDIT_FIELDS[state.editFieldIndex];
+    if (field === "tools") {
+      state.toolPickerOpen = true;
+      state.toolSelected = new Set(state.editAgent.tools ?? []);
+      state.toolSearch = "";
+      state.filteredTools = state.tools;
+      state.toolCursor = 0;
       requestRender();
     }
   } else if (matchesKey(data, "p")) {
@@ -1299,6 +1490,7 @@ export function createAgentManager(
   theme: Theme,
   done: () => void,
   models: ModelInfo[],
+  tools: ToolInfo[],
 ): Component {
   const state: ManagerState = {
     screen: "list",
@@ -1339,6 +1531,13 @@ export function createAgentManager(
     modelSearchQuery: "",
     modelCursor: 0,
     filteredModels: models,
+
+    tools,
+    toolPickerOpen: false,
+    toolCursor: 0,
+    toolSelected: new Set<string>(),
+    toolSearch: "",
+    filteredTools: tools,
 
     deleteTarget: null,
     deleteFromScreen: "list",

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -80,6 +80,9 @@ interface ManagerState {
 
   // New agent tracking
   isNew: boolean;
+
+  // Render width (stored so input handlers can compute correct scroll bounds)
+  lastWidth: number;
 }
 
 // ── Component return type ───────────────────────────────────────────────────
@@ -415,7 +418,7 @@ function handleDetailInput(
     }
   } else if (matchesKey(data, Key.down)) {
     if (state.detailAgent) {
-      const bodyLines = wrapText(state.detailAgent.systemPrompt, 84);
+      const bodyLines = wrapText(state.detailAgent.systemPrompt, state.lastWidth);
       const bodyViewport = Math.max(6, 14 - 9);
       if (state.detailScroll < bodyLines.length - bodyViewport) {
         state.detailScroll++;
@@ -623,7 +626,7 @@ function handleEditInput(
         requestRender();
       }
     } else if (matchesKey(data, Key.down)) {
-      const promptLines = wrapText(state.editAgent.systemPrompt, 84);
+      const promptLines = wrapText(state.editAgent.systemPrompt, state.lastWidth);
       const promptViewport = Math.max(6, 14 - 4 - 2);
       if (state.editPromptScroll < promptLines.length - promptViewport) {
         state.editPromptScroll++;
@@ -1138,6 +1141,8 @@ export function createAgentManager(
     deleteFromScreen: "list",
 
     isNew: false,
+
+    lastWidth: 84,
   };
 
   let cachedWidth: number | undefined;
@@ -1172,6 +1177,7 @@ export function createAgentManager(
 
   return {
     render(width: number): string[] {
+      state.lastWidth = width;
       if (cachedLines && cachedWidth === width) {
         return cachedLines;
       }

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -168,12 +168,16 @@ function agentModel(a: AgentConfig): string {
 
 function wrapWithBorder(lines: string[], width: number, theme: Theme): string[] {
   const innerWidth = Math.max(1, width - 2);
+  const contentWidth = Math.max(1, innerWidth - 2); // minus 1 space padding each side
+  const left = theme.fg("dim", "│");
+  const right = theme.fg("dim", "│");
   const top = theme.fg("dim", `┌${"─".repeat(innerWidth)}┐`);
   const bottom = theme.fg("dim", `└${"─".repeat(innerWidth)}┘`);
   const result: string[] = [top];
   for (const line of lines) {
-    const padded = " " + padEnd(line, innerWidth - 2) + " ";
-    result.push(theme.fg("dim", `│${padded}│`));
+    const content = truncateToWidth(line, contentWidth);
+    const padded = " " + padEnd(content, contentWidth) + " ";
+    result.push(left + padded + right);
   }
   result.push(bottom);
   return result;

--- a/packages/subagent/src/agent-manager.ts
+++ b/packages/subagent/src/agent-manager.ts
@@ -468,7 +468,7 @@ function renderEdit(state: ManagerState, width: number, theme: Theme): string[] 
   if (state.editDiscardPrompt) {
     lines.push(renderHeader(" Discard changes? ", width, theme));
     lines.push(padEnd("", width));
-    lines.push(padEnd("Unsaved changes will be lost.", width));
+    lines.push(padEnd(theme.fg("dim", "Unsaved changes will be lost."), width));
     lines.push(padEnd("", width));
     lines.push(renderFooter(" [y] discard  [n / esc] keep editing ", width, theme));
     return lines;
@@ -882,7 +882,7 @@ function renderNameInput(state: ManagerState, width: number, theme: Theme): stri
   lines.push(renderHeader(title, width, theme));
 
   // Label
-  lines.push(padEnd("Name:", width));
+  lines.push(padEnd(theme.fg("accent", "Name:"), width));
 
   // Input box
   const boxWidth = Math.min(width - 2, 60);
@@ -1045,7 +1045,7 @@ function renderConfirmDelete(state: ManagerState, width: number, theme: Theme): 
   lines.push(renderHeader(` Delete "${target.name}"? `, width, theme));
 
   // File path
-  lines.push(padEnd(`File: ${target.filePath}`, width));
+  lines.push(padEnd(theme.fg("dim", `File: ${target.filePath}`), width));
 
   // Warning
   lines.push(padEnd(theme.fg("error", "This cannot be undone."), width));

--- a/packages/subagent/src/agents.ts
+++ b/packages/subagent/src/agents.ts
@@ -17,7 +17,7 @@ export interface AgentConfig {
   source: "user" | "project";
   filePath: string;
   // Extra fields preserved from frontmatter but not editable in TUI
-  extraFields?: Record<string, string>;
+  extraFields?: Record<string, unknown>;
 }
 
 function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig[] {
@@ -48,16 +48,24 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 
     if (!frontmatter.name || !frontmatter.description) continue;
 
-    const tools = typeof frontmatter.tools === "string"
-      ? frontmatter.tools.split(",").map((t: string) => t.trim()).filter(Boolean)
-      : undefined;
+    // Handle tools specially — preserve non-string values in extraFields
+    let parsedTools: string[] | undefined;
+    if (typeof frontmatter.tools === "string") {
+      parsedTools = frontmatter.tools.split(",").map((t: string) => t.trim()).filter(Boolean);
+    }
 
-    const knownKeys = new Set(["name", "description", "tools", "model", "thinking"]);
-    const extraFields: Record<string, string> = {};
+    const knownKeys = new Set(["name", "description", "model", "thinking"]);
+    const extraFields: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(frontmatter)) {
       if (!knownKeys.has(key) && value != null && typeof value !== "object") {
         extraFields[key] = String(value);
+      } else if (!knownKeys.has(key) && value != null) {
+        extraFields[key] = value;
       }
+    }
+    // If tools was non-string, store it in extraFields for round-trip preservation
+    if (frontmatter.tools !== undefined && !parsedTools && "tools" in frontmatter) {
+      extraFields.tools = frontmatter.tools;
     }
 
     const config: AgentConfig = {
@@ -69,7 +77,7 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
     };
     if (frontmatter.model) config.model = frontmatter.model as string;
     if (frontmatter.thinking) config.thinking = frontmatter.thinking as string;
-    if (tools && tools.length > 0) config.tools = tools;
+    if (parsedTools && parsedTools.length > 0) config.tools = parsedTools;
     if (Object.keys(extraFields).length > 0) config.extraFields = extraFields;
 
     agents.push(config);
@@ -87,10 +95,13 @@ function isDirectory(p: string): boolean {
 }
 
 function findNearestProjectAgentsDir(cwd: string): string | null {
+  // Walk up looking for a git repo, even if .pi/agents doesn't exist yet
   let currentDir = cwd;
   while (true) {
-    const candidate = path.join(currentDir, ".pi", "agents");
-    if (isDirectory(candidate)) return candidate;
+    const gitPath = path.join(currentDir, ".git");
+    if (fs.existsSync(gitPath)) {
+      return path.join(currentDir, ".pi", "agents");
+    }
 
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir) return null;

--- a/packages/subagent/src/agents.ts
+++ b/packages/subagent/src/agents.ts
@@ -10,12 +10,14 @@ import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 export interface AgentConfig {
   name: string;
   description: string;
+  tools?: string[];
   model?: string;
   thinking?: string;
-  tools?: string[];
   systemPrompt: string;
   source: "user" | "project";
   filePath: string;
+  // Extra fields preserved from frontmatter but not editable in TUI
+  extraFields?: Record<string, string>;
 }
 
 function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig[] {
@@ -50,6 +52,14 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
       ? frontmatter.tools.split(",").map((t: string) => t.trim()).filter(Boolean)
       : undefined;
 
+    const knownKeys = new Set(["name", "description", "tools", "model", "thinking"]);
+    const extraFields: Record<string, string> = {};
+    for (const [key, value] of Object.entries(frontmatter)) {
+      if (!knownKeys.has(key) && value != null && typeof value !== "object") {
+        extraFields[key] = String(value);
+      }
+    }
+
     const config: AgentConfig = {
       name: frontmatter.name as string,
       description: frontmatter.description as string,
@@ -60,6 +70,7 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
     if (frontmatter.model) config.model = frontmatter.model as string;
     if (frontmatter.thinking) config.thinking = frontmatter.thinking as string;
     if (tools && tools.length > 0) config.tools = tools;
+    if (Object.keys(extraFields).length > 0) config.extraFields = extraFields;
 
     agents.push(config);
   }
@@ -88,6 +99,16 @@ function findNearestProjectAgentsDir(cwd: string): string | null {
 }
 
 /**
+ * Result of discovering agents — separated by source with directory paths.
+ */
+export interface AgentsDiscoveryResult {
+  user: AgentConfig[];
+  project: AgentConfig[];
+  userDir: string;        // e.g., ~/.pi/agent/agents
+  projectDir: string | null;  // e.g., .pi/agents or null if not found
+}
+
+/**
  * Discover all available agents from user and/or project directories.
  */
 export function discoverAgents(cwd: string): AgentConfig[] {
@@ -103,6 +124,24 @@ export function discoverAgents(cwd: string): AgentConfig[] {
   for (const agent of projectAgents) agentMap.set(agent.name, agent);
 
   return Array.from(agentMap.values());
+}
+
+/**
+ * Discover agents and return them separated by source with directory paths.
+ */
+export function discoverAgentsAll(cwd: string): AgentsDiscoveryResult {
+  const userDir = path.join(getAgentDir(), "agents");
+  const projectDir = findNearestProjectAgentsDir(cwd);
+
+  const userAgents = loadAgentsFromDir(userDir, "user");
+  const projectAgents = projectDir ? loadAgentsFromDir(projectDir, "project") : [];
+
+  return {
+    user: userAgents,
+    project: projectAgents,
+    userDir,
+    projectDir,
+  };
 }
 
 /**

--- a/packages/subagent/src/agents.ts
+++ b/packages/subagent/src/agents.ts
@@ -57,6 +57,7 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
     const knownKeys = new Set(["name", "description", "model", "thinking"]);
     const extraFields: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(frontmatter)) {
+      if (key === "tools") continue; // tools is handled separately above/below
       if (!knownKeys.has(key) && value != null && typeof value !== "object") {
         extraFields[key] = String(value);
       } else if (!knownKeys.has(key) && value != null) {
@@ -84,14 +85,6 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
   }
 
   return agents;
-}
-
-function isDirectory(p: string): boolean {
-  try {
-    return fs.statSync(p).isDirectory();
-  } catch {
-    return false;
-  }
 }
 
 function findNearestProjectAgentsDir(cwd: string): string | null {

--- a/packages/subagent/src/frontmatter-io.ts
+++ b/packages/subagent/src/frontmatter-io.ts
@@ -1,0 +1,89 @@
+/**
+ * Frontmatter serialization and validation for agent config files.
+ */
+
+import type { AgentConfig } from "./agents.js";
+
+/**
+ * Regex for valid agentspec names: lowercase alphanumeric + hyphens, 3-50 chars.
+ * Alphanumeric start/end. Also allows single-char names.
+ */
+export const AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$/;
+
+const SINGLE_CHAR_NAME_REGEX = /^[a-z0-9]$/;
+
+/**
+ * Validate an agent name against agentspec format rules.
+ * Returns an error message string if invalid, null if valid.
+ */
+export function validateAgentName(name: string): string | null {
+  if (!name || name.length === 0) {
+    return "Name is required";
+  }
+  if (SINGLE_CHAR_NAME_REGEX.test(name)) {
+    return null;
+  }
+  if (AGENT_NAME_REGEX.test(name)) {
+    return null;
+  }
+  return "Name must be 3-50 lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric";
+}
+
+function needsYamlQuoting(value: string): boolean {
+  if (value === "") return true;
+  // Special YAML characters at start
+  if (/^["'#\{\[\|>&!*%?@`-]/.test(value)) return true;
+  // Contains colon (could be mistaken for mapping)
+  if (value.includes(":")) return true;
+  // Contains newline
+  if (value.includes("\n")) return true;
+  // Leading/trailing whitespace
+  if (value !== value.trim()) return true;
+  // YAML booleans/nulls
+  if (/^(true|false|yes|no|on|off|null|True|False|Yes|No|On|Off|NULL|Null)$/i.test(value)) return true;
+  return false;
+}
+
+function quoteYamlValue(value: string): string {
+  if (!needsYamlQuoting(value)) return value;
+  // Escape backslashes and double quotes, wrap in double quotes
+  const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+/**
+ * Serialize an AgentConfig back to a valid .md file with frontmatter.
+ * Produces output that parseFrontmatter can re-parse faithfully.
+ */
+export function serializeAgent(config: AgentConfig): string {
+  const lines: string[] = ["---"];
+
+  // Required fields
+  lines.push(`name: ${quoteYamlValue(config.name)}`);
+  lines.push(`description: ${quoteYamlValue(config.description)}`);
+
+  // Optional known fields
+  if (config.tools && config.tools.length > 0) {
+    lines.push(`tools: ${quoteYamlValue(config.tools.join(", "))}`);
+  }
+  if (config.model) {
+    lines.push(`model: ${quoteYamlValue(config.model)}`);
+  }
+  if (config.thinking) {
+    lines.push(`thinking: ${quoteYamlValue(config.thinking)}`);
+  }
+
+  // Extra fields (sorted alphabetically)
+  if (config.extraFields) {
+    for (const key of Object.keys(config.extraFields).sort()) {
+      lines.push(`${key}: ${quoteYamlValue(config.extraFields[key]!)}`);
+    }
+  }
+
+  lines.push("---");
+  lines.push("");
+  lines.push(config.systemPrompt);
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/packages/subagent/src/frontmatter-io.ts
+++ b/packages/subagent/src/frontmatter-io.ts
@@ -35,6 +35,8 @@ function needsYamlQuoting(value: string): boolean {
   if (/^["'#\{\[\|>&!*%?@`-]/.test(value)) return true;
   // Contains colon (could be mistaken for mapping)
   if (value.includes(":")) return true;
+  // Contains # (inline comment marker) anywhere
+  if (value.includes("#")) return true;
   // Contains newline
   if (value.includes("\n")) return true;
   // Leading/trailing whitespace
@@ -76,7 +78,19 @@ export function serializeAgent(config: AgentConfig): string {
   // Extra fields (sorted alphabetically)
   if (config.extraFields) {
     for (const key of Object.keys(config.extraFields).sort()) {
-      lines.push(`${key}: ${quoteYamlValue(config.extraFields[key]!)}`);
+      const value = config.extraFields[key]!;
+      if (typeof value === "string") {
+        lines.push(`${key}: ${quoteYamlValue(value)}`);
+      } else if (Array.isArray(value)) {
+        // Serialize array as YAML block sequence
+        lines.push(`${key}:`);
+        for (const item of value) {
+          lines.push(`  - ${quoteYamlValue(String(item))}`);
+        }
+      } else {
+        // Fallback: JSON stringify for objects
+        lines.push(`${key}: ${JSON.stringify(value)}`);
+      }
     }
   }
 

--- a/packages/subagent/src/index.ts
+++ b/packages/subagent/src/index.ts
@@ -1,9 +1,10 @@
-import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { Text, TUI } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { executeSubagent, executeParallel } from "./execute.js";
 import { renderSubagentResult } from "./render.js";
 import { discoverAgents, discoverAgentsAll, findAgent } from "./agents.js";
+import { createAgentManager } from "./agent-manager.js";
 import type {
   SubagentDetails,
   SubagentProgress,
@@ -257,6 +258,24 @@ function formatResultsSummary(results: SubagentResult[]): string {
     return `${status} ${r.agent}${summary ? " " + summary : ""}`;
   });
   return lines.join("\n");
+}
+
+// ── Command registration ────────────────────────────────────────────────────
+
+export function registerAgentsCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("agents", {
+    description: "Open the Agents Manager",
+    handler: async (_args: string, ctx: ExtensionCommandContext) => {
+      const { user, project, userDir, projectDir } = discoverAgentsAll(ctx.cwd);
+
+      await ctx.ui.custom<void>(
+        (tui: TUI, theme: Theme, _keybindings, done: () => void) => {
+          return createAgentManager(user, project, userDir, projectDir, tui, theme, done);
+        },
+        { overlay: true, overlayOptions: { anchor: "center", width: 84, maxHeight: "80%" } },
+      );
+    },
+  });
 }
 
 // ── Default export ──────────────────────────────────────────────────────────

--- a/packages/subagent/src/index.ts
+++ b/packages/subagent/src/index.ts
@@ -3,7 +3,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { executeSubagent, executeParallel } from "./execute.js";
 import { renderSubagentResult } from "./render.js";
-import { discoverAgents, findAgent } from "./agents.js";
+import { discoverAgents, discoverAgentsAll, findAgent } from "./agents.js";
 import type {
   SubagentDetails,
   SubagentProgress,

--- a/packages/subagent/src/index.ts
+++ b/packages/subagent/src/index.ts
@@ -268,9 +268,15 @@ export function registerAgentsCommand(pi: ExtensionAPI): void {
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
       const { user, project, userDir, projectDir } = discoverAgentsAll(ctx.cwd);
 
+      const availableModels = ctx.modelRegistry.getAvailable().map((m) => ({
+        id: m.id,
+        provider: m.provider,
+        fullId: `${m.provider}/${m.id}`,
+      }));
+
       await ctx.ui.custom<void>(
         (tui: TUI, theme: Theme, _keybindings, done: () => void) => {
-          return createAgentManager(user, project, userDir, projectDir, tui, theme, done);
+          return createAgentManager(user, project, userDir, projectDir, tui, theme, done, availableModels);
         },
         { overlay: true, overlayOptions: { anchor: "center", width: 84, maxHeight: "80%" } },
       );

--- a/packages/subagent/src/index.ts
+++ b/packages/subagent/src/index.ts
@@ -274,9 +274,14 @@ export function registerAgentsCommand(pi: ExtensionAPI): void {
         fullId: `${m.provider}/${m.id}`,
       }));
 
+      const availableTools = pi.getAllTools().map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+      }));
+
       await ctx.ui.custom<void>(
         (tui: TUI, theme: Theme, _keybindings, done: () => void) => {
-          return createAgentManager(user, project, userDir, projectDir, tui, theme, done, availableModels);
+          return createAgentManager(user, project, userDir, projectDir, tui, theme, done, availableModels, availableTools);
         },
         { overlay: true, overlayOptions: { anchor: "center", width: 84, maxHeight: "80%" } },
       );


### PR DESCRIPTION
## Summary
Add a `/agents` slash command that opens a TUI overlay for full CRUD of agent frontmatter files.

- **5-screen TUI overlay:** List → Detail → Edit, Name Input, Confirm Delete
- **Expanded AgentConfig** with `extraFields` for unknown frontmatter keys (faithful round-trip)
- **Frontmatter I/O:** `serializeAgent` with YAML-safe quoting, `validateAgentName` for agentspec format
- **Full CRUD:** Create, read, update, delete agents from both user (`~/.pi/agent/agents/`) and project (`.pi/agents/`) scopes
- **UX polish:** Empty state, cross-scope collision warnings, scroll indicators, dirty tracking with discard prompt, file write error handling

### Commits
- `bc38ef6` feat: expand AgentConfig with extraFields and add frontmatter I/O
- `d0dce2f` feat: add agent-manager TUI component with CRUD screens
- `6ea9fd9` feat: register /agents command and wire into meta orchestrator
- `825d557` fix: polish agent-manager UX — empty state, errors, theming
- `d0e5716` chore: verification pass for /agents command
- `ab8aca8` fix: store render width in state for correct scroll bounds
- `8e56410` fix: quote YAML values in serializeAgent for safe round-trip
- `2e05325` fix: apply theme.fg() to unthemed text in agent-manager

### Files changed
- `packages/subagent/src/agents.ts` — expanded AgentConfig, added discoverAgentsAll
- `packages/subagent/src/frontmatter-io.ts` — new file (serializer + validator)
- `packages/subagent/src/agent-manager.ts` — new file (5-screen TUI component, ~1200 lines)
- `packages/subagent/src/index.ts` — added registerAgentsCommand
- `meta/src/index.ts` — wired registerAgentsCommand

## Test plan
- [ ] Run `npx tsc --noEmit` in `packages/subagent/` and `meta/` (both pass ✅)
- [ ] Load pi-archimedes extension and run `/agents` command
- [ ] Verify list screen shows agents with search, viewport, preview
- [ ] Verify detail screen shows frontmatter + scrollable body
- [ ] Verify edit screen cycles fields, edits inline, tracks dirty state
- [ ] Verify create agent (n) with name validation and scope toggle
- [ ] Verify clone agent (c) copies all fields
- [ ] Verify delete agent (d) with confirmation
- [ ] Verify save writes file with correct frontmatter
- [ ] Verify empty state shows "No agents found"
- [ ] Verify cross-scope collision warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **`/agents`** slash command that opens a multi-screen TUI overlay for full agent CRUD.
  * Added list/detail/edit workflows with search and filtering, inline editing, system prompt editing, model/tool pickers, and delete confirmation.
  * Improved agent persistence by safely serializing agent frontmatter and preserving non-standard “extra” fields during load/save.
  * Updated project agent discovery to separate **user** vs **project** agents for clearer scope handling.
* **Documentation**
  * Added plan documentation for the `/agents` command and updated the plans overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->