### PR TITLE
feat: replace spawn+socket subagent with fork+IPC

### DIFF
--- a/docs/plans/2025-06-17-fork-ipc-subagent.md
+++ b/docs/plans/2025-06-17-fork-ipc-subagent.md
@@ -1,0 +1,388 @@
+# Fork + IPC Subagent Communication
+
+**Goal:** Replace `spawn()` + Unix domain socket + JSON stdout with `fork()` + SDK-based child + single IPC channel for all parent↔child communication.
+
+**Architecture:** A forked child script imports `createAgentSession` from the pi SDK, subscribes to all `AgentSessionEvent`s, and forwards them to the parent via `process.send()`. The parent sends ask responses and abort signals back via `child.send()`. One bidirectional IPC channel replaces two unidirectional channels (stdout pipe + unix socket).
+
+**Tech Stack:** Node.js `child_process.fork()`, pi SDK `createAgentSession()`, `AgentSession.subscribe()`, built-in IPC (`process.send`/`process.on('message')`)
+
+---
+
+## Message Protocol
+
+All IPC messages use a discriminated union keyed by `type`:
+
+```typescript
+// Parent → Child
+interface ParentToChild {
+  type: "ask_response";
+  requestId: string;
+  cancelled: boolean;
+  results: Array<{ id: string; selectedOptions: string[]; customInput?: string }>;
+} | {
+  type: "abort";
+} | {
+  type: "init_ack";  // parent acknowledges child is ready
+};
+
+// Child → Parent
+interface ChildToParent {
+  type: "event";
+  event: AgentSessionEvent;  // forwarded from session.subscribe()
+} | {
+  type: "ask_request";
+  requestId: string;
+  questions: Array<{ id: string; question: string; description?: string; options: Array<{ label: string }>; multi?: boolean; recommended?: number }>;
+} | {
+  type: "ready";  // child signals it has started the session
+} | {
+  type: "error";
+  message: string;
+};
+```
+
+---
+
+### Task 1: Create the IPC message types and child entry point
+
+**Context:**
+The foundation of the new architecture. Defines the shared message protocol and creates the forked child script that will run the subagent's AgentSession. This script replaces the current pattern of `spawn("pi", ["--mode", "json", "-p", ...])` with a self-contained Node.js process that uses the pi SDK directly.
+
+**Files:**
+- Create: `packages/subagent/src/ipc-types.ts`
+- Create: `packages/subagent/src/child.ts`
+
+**What to implement:**
+
+1. **`ipc-types.ts`** — Shared type definitions for IPC messages:
+   - `ParentToChild` union type (`ask_response` | `abort`)
+   - `ChildToParent` union type (`event` | `ask_request` | `ready` | `error`)
+   - `ChildInitParams` interface (task, model, cwd, agent config, system prompt) — passed via `fork()` second argument or first IPC message
+
+2. **`child.ts`** — The forked child entry point (~150 lines):
+   - Parse `process.argv` or first received message for init params (task, model, agent config, system prompt path, cwd)
+   - Import `createAgentSession` from `@earendil-works/pi-coding-agent`
+   - Create an `AgentSession` with:
+     - `model` resolved from params
+     - `cwd` from params
+     - `excludedToolNames: ["subagent"]` to prevent recursive spawning
+     - `customTools` that includes an IPC-based ask tool (see Task 2)
+     - `sessionManager: SessionManager.inMemory()` (no session file for subagents)
+     - If agent has a custom system prompt, write to temp file and use `--append-system-prompt` equivalent (or pass via session config if SDK supports it)
+   - Call `session.bindExtensions()` with minimal bindings (no UI, no command context)
+   - Subscribe to events: `session.subscribe(event => process.send?.({ type: "event", event }))`
+   - Send `{ type: "ready" }` to parent when session is initialized
+   - Listen for parent messages: `process.on("message", handleParentMessage)`
+     - `ask_response` → resolve the pending ask promise
+     - `abort` → call `session.abort()`
+   - Call `session.prompt(task)` to start the agent loop
+   - On `agent_end` event, exit the process with code 0 (or 1 on error)
+   - Handle `SIGTERM`/`SIGINT` → graceful shutdown (abort session, exit)
+
+**Steps:**
+- [ ] Create `packages/subagent/src/ipc-types.ts` with all IPC message types
+- [ ] Create `packages/subagent/src/child.ts` with the child entry point
+- [ ] Verify child script can be forked and receives/sends messages (manual test with a simple parent script)
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+- [ ] Commit with message: "feat: add IPC child process entry point for subagent"
+
+**Acceptance criteria:**
+- [ ] `child.ts` can be forked and sends a `{ type: "ready" }` message
+- [ ] `child.ts` forwards `AgentSessionEvent`s to parent via `process.send()`
+- [ ] `child.ts` handles `abort` messages from parent
+- [ ] TypeScript check passes with no errors
+
+---
+
+### Task 2: Create the IPC-based ask tool for the child
+
+**Context:**
+The current ask tool (`packages/ask/src/index.ts`) has two modes: with UI (TUI dialog) and headless (Unix socket connect). In the SDK-based child, there's no TUI and no socket — communication is purely IPC. We need a lightweight ask tool that sends questions to the parent via `process.send()` and awaits the response via `process.on('message')`.
+
+This tool is registered as a `customTool` when creating the AgentSession in the child. It replaces the socket-based headless ask flow entirely.
+
+**Files:**
+- Create: `packages/subagent/src/ipc-ask-tool.ts`
+
+**What to implement:**
+
+1. **`ipc-ask-tool.ts`** — A minimal ask tool definition (~80 lines):
+   - Export `createIpcAskTool(): ToolDefinition`
+   - Parameters schema matches the existing ask tool (`AskParamsSchema` from ask package)
+   - `execute()` implementation:
+     - Generate `requestId` via `crypto.randomUUID()`
+     - Send `{ type: "ask_request", requestId, questions: params.questions }` via `process.send()`
+     - `Promise` that resolves when parent sends `{ type: "ask_response", requestId }`
+     - Wire `process.on("message")` listener (one-time, removed after response)
+     - 5-minute timeout → resolve with cancelled
+     - Build `QuestionResult[]` from response, return content matching existing ask tool's session text format
+   - No `renderCall` or `renderResult` needed (child has no UI)
+
+**Key design decisions:**
+- The listener for `ask_response` is registered per-execution (not global), matched by `requestId`
+- If `process.send` is null (IPC channel closed), resolve immediately with cancelled
+- Reuse the `buildAskSessionContent()` and sanitization logic from the existing ask tool (import from `@pi-archimedes/ask` or inline the minimal needed functions)
+
+**Steps:**
+- [ ] Create `packages/subagent/src/ipc-ask-tool.ts`
+- [ ] Implement `createIpcAskTool()` with IPC-based execute
+- [ ] Handle timeout and channel-close edge cases
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+- [ ] Commit with message: "feat: add IPC-based ask tool for subagent child"
+
+**Acceptance criteria:**
+- [ ] Tool sends `ask_request` via `process.send()` and awaits `ask_response`
+- [ ] Timeout after 5 minutes resolves with cancelled
+- [ ] Channel close resolves with cancelled
+- [ ] Returned content matches the format expected by the parent's session text
+
+---
+
+### Task 3: Replace spawnSubagent with fork-based spawning
+
+**Context:**
+The current `spawnSubagent()` in `spawn.ts` does: resolve pi command → create Unix socket server → spawn `pi --mode json` → wire socket for ask round-trip → wire stdout for JSON events. All of this is replaced by: fork child script → listen for IPC messages.
+
+This is the core change that eliminates the socket entirely. The function signature stays the same (`spawnSubagent(options)`) but returns a `ChildProcess` from `fork()` instead of `spawn()`.
+
+**Files:**
+- Modify: `packages/subagent/src/spawn.ts`
+
+**What to implement:**
+
+1. Replace `spawnSubagent()` implementation:
+   - Import `fork` from `node:child_process`
+   - Resolve the child script path: `import.meta.url` → `../subagent/src/child.ts` (use `import { fileURLToPath } from "node:url"` to compute path)
+   - Use `fork(childScriptPath, [], { env, cwd, stdio: ["ignore", "ignore", "ignore", "ipc"] })`
+     - `stdio: ["ignore", "ignore", "ignore", "ipc"]` — no stdout/stderr, only IPC
+     - `env` includes all current env vars (for API keys, etc.)
+     - Remove `PI_SUBAGENT_SOCKET` env var (no longer needed)
+   - Remove all socket server code (`createServer`, `server.listen`, `pendingAsks` Map, socket event handlers)
+   - Remove `resolvePiCommand()` (no longer spawning `pi` CLI)
+   - Remove `writePromptToFile()` / `cleanupTempFiles()` — system prompt is passed via IPC or SDK config instead
+   - Wire `child.on("message", ...)` to handle `ChildToParent` messages:
+     - `{ type: "event" }` → forward to the existing JSON event handler (or refactor streamEvents to listen for IPC messages instead of stdout lines)
+     - `{ type: "ask_request" }` → emit `Events.ASK_REQUEST` on the bus
+     - `{ type: "ready" }` → clear startup timer
+     - `{ type: "error" }` → log error
+   - Keep `ASK_RESPONSE` bus listener → send response via `child.send({ type: "ask_response", ... })` instead of `socket.write()`
+   - Keep abort signal handler → send `child.send({ type: "abort" })` before `child.kill("SIGTERM")`
+   - Keep startup timeout (2 minutes) → clear on first `ready` or `event` message
+
+2. Update return type: `fork()` returns `ChildProcess` (same as `spawn()`), so the return type is compatible. However, `streamEvents()` currently reads from `child.stdout` — this needs to change (see Task 4).
+
+**Steps:**
+- [ ] Replace `spawn()` call with `fork()` in `spawnSubagent()`
+- [ ] Remove Unix socket server code (createServer, listen, pendingAsks, socket handlers)
+- [ ] Remove `resolvePiCommand()`, `writePromptToFile()`, `cleanupTempFiles()`
+- [ ] Add `child.on("message")` handler for ChildToParent messages
+- [ ] Update `ASK_RESPONSE` bus handler to use `child.send()` instead of socket.write()
+- [ ] Update abort handler to send IPC abort message
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+- [ ] Commit with message: "feat: replace spawn+socket with fork+IPC in spawnSubagent"
+
+**Acceptance criteria:**
+- [ ] `spawnSubagent()` uses `fork()` instead of `spawn()`
+- [ ] No Unix socket is created or used
+- [ ] No `PI_SUBAGENT_SOCKET` env var
+- [ ] `child.on("message")` handles all ChildToParent message types
+- [ ] `ASK_RESPONSE` bus events are sent via `child.send()`
+- [ ] TypeScript check passes
+
+---
+
+### Task 4: Replace streamEvents to read from IPC instead of stdout
+
+**Context:**
+`streamEvents()` currently creates a `readline.Interface` on `child.stdout` and parses JSON lines. With `fork()` + IPC, events come through `child.on("message")` as structured objects. The streaming logic (state machine, progress building, cost tracking) stays the same — only the input source changes.
+
+**Files:**
+- Modify: `packages/subagent/src/stream.ts`
+- Modify: `packages/subagent/src/spawn.ts` (pass message handler or refactor)
+
+**What to implement:**
+
+Two approaches — pick one:
+
+**Approach A (recommended): Move event handling into spawn.ts, simplify streamEvents**
+- `spawnSubagent()` returns both the `ChildProcess` and a `Promise<SubagentResult>` (or an event emitter)
+- `streamEvents()` takes a message source (callback or async iterator) instead of `child.stdout`
+- The `child.on("message")` handler in spawn.ts extracts `{ type: "event", event }` messages and feeds them to streamEvents
+
+**Approach B: streamEvents attaches its own message listener**
+- `streamEvents(child)` does `child.on("message", handler)` instead of `createInterface({ input: child.stdout })`
+- Filter messages by `type === "event"` and extract `event` field
+- Rest of the state machine stays identical
+
+**Recommended: Approach B** — minimal changes to the existing state machine.
+
+Changes to `stream.ts`:
+- Replace `createInterface({ input: child.stdout! })` with `child.on("message", (msg) => { ... })`
+- Cast message to `ChildToParent`, check `msg.type === "event"`, extract `msg.event as JsonEvent`
+- Remove JSON.parse (events are already parsed objects)
+- Remove `rl.on("line", ...)` → use direct `child.on("message", ...)`
+- Keep `child.stderr?.on("data", ...)` → remove (no stderr with `stdio: ["ignore", ...]`)
+  - Instead, handle `{ type: "error", message }` from IPC
+- Keep state machine, progress building, heartbeat, startup timer — all identical
+- Update `buildProgress()` and event handlers — they work with `JsonEvent` which matches `AgentSessionEvent`
+
+**Steps:**
+- [ ] Refactor `streamEvents()` to use `child.on("message")` instead of stdout readline
+- [ ] Remove JSON.parse — events are structured objects from IPC
+- [ ] Remove stderr collection — use IPC error messages instead
+- [ ] Keep all state machine logic, progress building, cost tracking
+- [ ] Update types: `JsonEvent` → use `AgentSessionEvent` from SDK types where possible
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+- [ ] Commit with message: "feat: update streamEvents to read from IPC messages"
+
+**Acceptance criteria:**
+- [ ] `streamEvents()` reads events from `child.on("message")` instead of stdout
+- [ ] No JSON.parse needed (events are structured objects)
+- [ ] State machine and progress tracking work unchanged
+- [ ] Startup timer clears on first event
+- [ ] TypeScript check passes
+
+---
+
+### Task 5: Handle system prompts and agent config in the child
+
+**Context:**
+The current approach writes the agent's system prompt to a temp file and passes `--append-system-prompt <path>` to the pi CLI. With the SDK-based child, system prompts need to be handled differently. Options:
+
+1. Pass the system prompt text via the initial IPC message (simple, no temp files)
+2. Use the SDK's system prompt configuration (check if `createAgentSession` supports custom system prompts)
+3. Write to temp file in the child and use SDK's resource loading
+
+**Files:**
+- Modify: `packages/subagent/src/child.ts`
+- Modify: `packages/subagent/src/spawn.ts`
+
+**What to implement:**
+
+1. In `spawn.ts` — pass agent config to child via `fork()` args or first message:
+   - Send `ChildInitParams` with: task, model, agent name, agent system prompt text, agent tools, agent thinking, cwd
+   - No temp files needed — pass prompt text directly
+
+2. In `child.ts` — apply agent config:
+   - After `createAgentSession()`, if agent has a system prompt, use the session's system prompt API
+   - If agent has custom tools, pass `allowedToolNames` to `createAgentSession()`
+   - If agent has custom model, resolve and set model
+   - If agent has thinking level, set via `session.setThinkingLevel()`
+
+**Steps:**
+- [ ] Define `ChildInitParams` interface in `ipc-types.ts`
+- [ ] Update `spawn.ts` to send init params via first IPC message (or fork args)
+- [ ] Update `child.ts` to receive and apply init params
+- [ ] Remove temp file creation/cleanup from spawn.ts
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`
+- [ ] Commit with message: "feat: pass agent config via IPC instead of temp files"
+
+**Acceptance criteria:**
+- [ ] Agent system prompt is passed via IPC (no temp files)
+- [ ] Agent model, tools, thinking are applied in the child
+- [ ] No temp file creation or cleanup needed
+- [ ] TypeScript check passes
+
+---
+
+### Task 6: Update the ask package for IPC compatibility
+
+**Context:**
+The current `packages/ask/src/index.ts` has headless mode that connects to `PI_SUBAGENT_SOCKET`. With the new architecture, the child uses the IPC ask tool (Task 2) and the parent never needs to connect to a socket. The headless socket code in the ask package becomes dead code.
+
+**Files:**
+- Modify: `packages/ask/src/index.ts`
+
+**What to implement:**
+
+1. In `handleAskRequest` (parent-side, listens for `ASK_REQUEST` bus events):
+   - No changes needed — this already works. It receives bus events from the subagent package and shows the TUI dialog.
+
+2. In the ask tool's `execute()` method:
+   - The headless branch (`if (!ctx.hasUI)`) that connects to `PI_SUBAGENT_SOCKET` is no longer needed for the fork-based architecture
+   - **Keep it for backward compatibility** — if someone runs the subagent in spawn mode (during transition), it should still work
+   - Add a comment noting this code path is deprecated in favor of the IPC ask tool
+
+3. No functional changes required — the ask package works as-is. The IPC ask tool (Task 2) is used by the child, and the parent's ask dialog works through the bus as before.
+
+**Steps:**
+- [ ] Add deprecation comment to the headless socket code path in `ask/index.ts`
+- [ ] Verify the parent-side `ASK_REQUEST` / `ASK_RESPONSE` bus flow works with the new IPC messages
+- [ ] Run `npx tsc --noEmit` in `packages/ask/`
+- [ ] Commit with message: "chore: deprecate socket-based headless ask in favor of IPC"
+
+**Acceptance criteria:**
+- [ ] Headless socket code path is marked deprecated
+- [ ] Parent-side ask dialog works with IPC-based ask requests from child
+- [ ] TypeScript check passes
+
+---
+
+### Task 7: Clean up, verify, and integrate
+
+**Context:**
+Final integration task — ensure all pieces work together, clean up dead code, and verify the full flow.
+
+**Files:**
+- Modify: `packages/subagent/src/index.ts`
+- Modify: `packages/subagent/src/execute.ts`
+- Modify: `packages/core/src/bus.ts` (if needed)
+- Modify: `packages/subagent/package.json` (add child.ts to exports if needed)
+
+**What to implement:**
+
+1. **Integration verification:**
+   - Full flow: parent calls `subagent` tool → `executeSubagent()` → `spawnSubagent()` (fork) → child creates AgentSession → child sends events via IPC → parent streams events → parent shows progress → child calls ask tool → parent shows dialog → parent sends response via IPC → child receives response → child continues → child finishes → parent gets result
+
+2. **Dead code cleanup:**
+   - Remove `resolvePiCommand()` if not used elsewhere
+   - Remove socket-related imports from `spawn.ts`
+   - Remove `PI_SUBAGENT_SOCKET` references
+   - Remove temp file cleanup code
+
+3. **Error handling:**
+   - Child crashes → parent detects via `child.on("close", code !== 0)`
+   - IPC channel broken → parent detects via `child.on("error")`
+   - Child startup fails → parent's startup timeout kills process
+
+4. **TypeScript verification:**
+   - Run `npx tsc --noEmit` in all affected packages
+
+**Steps:**
+- [ ] Verify full end-to-end flow works (manual test)
+- [ ] Clean up dead code and unused imports
+- [ ] Verify error handling for child crash, IPC break, startup failure
+- [ ] Run `npx tsc --noEmit` in `packages/subagent/`, `packages/ask/`, `packages/core/`
+- [ ] Commit with message: "feat: integrate fork+IPC subagent, clean up socket code"
+
+**Acceptance criteria:**
+- [ ] Full subagent flow works with fork + IPC
+- [ ] Ask tool round-trip works through IPC
+- [ ] Error handling covers child crash, IPC break, startup failure
+- [ ] No dead code or unused imports
+- [ ] TypeScript checks pass in all affected packages
+- [ ] No regression in existing functionality (parallel subagents, cost tracking, todo updates)
+
+---
+
+## Migration Strategy
+
+**Phase 1 (Tasks 1-3):** Core infrastructure — child script, IPC types, fork-based spawning. Not functional yet (streamEvents still reads stdout).
+
+**Phase 2 (Tasks 4-5):** Wire up event streaming and agent config. Functional but ask tool uses old socket path.
+
+**Phase 3 (Tasks 6-7):** Ask tool migration and cleanup. Full migration complete.
+
+**Rollback:** At any phase, the old `spawn()` + socket code can be restored by reverting the relevant commits. The bus events (`ASK_REQUEST`, `ASK_RESPONSE`, `COST_UPDATE`, etc.) are unchanged, so other packages (footer, todo, ask) are unaffected during transition.
+
+---
+
+## What Does NOT Change
+
+- **Bus events** — `COST_UPDATE`, `TODOS_UPDATE`, `TODOS_CLEAR`, `ASK_REQUEST`, `ASK_RESPONSE` stay the same
+- **Footer cost accumulation** — reads from bus, no changes needed
+- **Todo widget** — reads from bus, no changes needed
+- **Ask dialog UI** — shows on `ASK_REQUEST` bus event, emits `ASK_RESPONSE`, no changes needed
+- **`executeSubagent()` / `executeParallel()`** — call `spawnSubagent()` + `streamEvents()`, signatures unchanged
+- **Agent discovery** — `discoverAgents()`, `findAgent()` unchanged
+- **Agent Manager TUI** — unchanged

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,7 +10,12 @@
 | [Subagent package](plans/2026-06-04-subagent.md) | ✅ COMPLETED (PR #1) | 2026-06-04 |
 | [Create pi-archimedes](plans/2026-06-04-create-pi-archimedes.md) | ✅ COMPLETED | 2026-06-04 |
 
+## In Progress
+
+| Plan | Status | Created |
+| [Fork + IPC subagent communication](plans/2025-06-17-fork-ipc-subagent.md) | 🚧 IN PROGRESS | 2026-06-17 |
+
 ## Quick Stats
 
-- Total Plans: 6
+- Total Plans: 7
 - Completed: 6

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,7 @@
 ## Completed Plans
 
 | Plan | Status | Created |
+| [Fork + IPC subagent communication](plans/2025-06-17-fork-ipc-subagent.md) | ✅ COMPLETED (PR #10) | 2026-06-17 |
 | [Ask tool](plans/2025-06-17-ask-tool.md) | ✅ COMPLETED (PR #9) | 2025-06-17 |
 | [Todo list with auto-clear + subagent visibility](plans/2026-06-15-todo-plan.md) | ✅ COMPLETED (PR #8) | 2026-06-15 |
 | [README overhaul + hephaestus deprecation](plans/2026-06-14-readme-overhaul.md) | ✅ COMPLETED (PRs #7 and #4) | 2026-06-14 |
@@ -12,10 +13,9 @@
 
 ## In Progress
 
-| Plan | Status | Created |
-| [Fork + IPC subagent communication](plans/2025-06-17-fork-ipc-subagent.md) | 🚧 IN PROGRESS | 2026-06-17 |
+_None_
 
 ## Quick Stats
 
 - Total Plans: 7
-- Completed: 6
+- Completed: 7

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -284,7 +284,10 @@ export function registerAsk(pi: ExtensionAPI) {
 		parameters: AskParamsSchema,
 
 		async execute(_toolCallId, params: AskParams, _signal, _onUpdate, ctx) {
-			// Headless mode (subagent) — send question to parent via socket, await response on same socket
+			// DEPRECATED: Socket-based headless mode.
+			// The fork-based subagent child (child.ts) now uses an IPC ask tool (ipc-ask-tool.ts)
+			// that communicates directly via process.send()/process.on('message').
+			// This socket-based path is kept for backward compatibility during transition.
 			if (!ctx.hasUI) {
 				const requestId = randomUUID();
 				const socketPath = process.env.PI_SUBAGENT_SOCKET;

--- a/packages/subagent/package.json
+++ b/packages/subagent/package.json
@@ -14,6 +14,7 @@
     "@pi-archimedes/core": "workspace:*"
   },
   "peerDependencies": {
+    "@earendil-works/pi-ai": ">=0.1.0",
     "@earendil-works/pi-coding-agent": ">=0.1.0",
     "@earendil-works/pi-tui": ">=0.1.0",
     "typebox": ">=1.1.0"

--- a/packages/subagent/package.json
+++ b/packages/subagent/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typebox": "^1.1.38",
-    "typescript": "^6.0.0"
+    "typescript": "^6.0.3"
   },
   "pi": {
     "extensions": [

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -11,6 +11,7 @@
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { getModel, type Model } from "@earendil-works/pi-ai";
 import type { ParentToChild, ChildToParent } from "./ipc-types.js";
+import { createIpcAskTool } from "./ipc-ask-tool.js";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -26,14 +27,6 @@ interface InitParams {
   agentThinking: string | undefined;
   cwd: string | undefined;
 }
-
-// ── Pending ask tracking (for IPC ask tool in Task 2) ───────────────────────
-// The IPC ask tool (created in Task 2) will register pending asks here.
-// Parent messages of type "ask_response" resolve them.
-const pendingAsks = new Map<
-  string,
-  { resolve: (value: unknown) => void; reject: (reason: unknown) => void }
->();
 
 // ── Model resolution ────────────────────────────────────────────────────────
 
@@ -81,22 +74,12 @@ let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | null = 
 
 function handleParentMessage(msg: ParentToChild): void {
   switch (msg.type) {
-    case "ask_response": {
-      const pending = pendingAsks.get(msg.requestId);
-      if (pending) {
-        pendingAsks.delete(msg.requestId);
-        pending.resolve({
-          cancelled: msg.cancelled,
-          results: msg.results,
-        });
-      }
-      break;
-    }
     case "abort": {
       session?.abort();
       break;
     }
     // "init" is handled synchronously before this listener is set up
+    // "ask_response" is handled by the IPC ask tool's own per-execution listener
   }
 }
 
@@ -155,7 +138,7 @@ async function main(): Promise<void> {
   // Build options object — omit undefined values to satisfy exactOptionalPropertyTypes.
   const sessionOptions: Parameters<typeof createAgentSession>[0] = {
     excludeTools: ["subagent"],
-    customTools: [],
+    customTools: [createIpcAskTool()],
     sessionManager: SessionManager.inMemory(),
     ...(model ? { model } : {}),
     ...(thinkingLevel ? { thinkingLevel } : {}),
@@ -163,9 +146,7 @@ async function main(): Promise<void> {
     ...(tools ? { tools } : {}),
   };
 
-  // Create the agent session.
-  // customTools: TODO — wire up IPC ask tool (created in Task 2).
-  // For now, empty array. Will be replaced with: import { createIpcAskTool } from "./ipc-ask-tool.js"
+  // Create the agent session with IPC ask tool for user questions.
   const { session: agentSession } = await createAgentSession(sessionOptions);
 
   session = agentSession;

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -8,8 +8,11 @@
  * Usage: node child.js (forked with stdio: ["pipe", "pipe", "pipe", "ipc"])
  */
 
-import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
-import { getModel, type Model } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import type { Model } from "@earendil-works/pi-ai";
 import type { ParentToChild, ChildToParent, SerializedAgentEvent } from "./ipc-types.ts";
 import { createIpcAskTool } from "./ipc-ask-tool.ts";
 
@@ -31,23 +34,31 @@ interface InitParams {
 // ── Model resolution ────────────────────────────────────────────────────────
 
 /**
- * Parse a model string like "anthropic/claude-opus-4-5" into a Model object.
- * Returns undefined if the string is empty or cannot be parsed.
+ * Resolve a model reference via a ModelRegistry.
+ *
+ * Supports:
+ * - "provider/modelId" (canonical)
+ * - "modelId" (bare — resolved across providers, ambiguous matches rejected)
+ *
+ * The registry must include extension-registered providers (e.g. "tama"),
+ * which is why this is called AFTER createAgentSession has loaded
+ * extensions — not with a bare ModelRegistry.create() that only knows
+ * built-ins + models.json.
  */
-function resolveModel(modelString: string | undefined): Model<any> | undefined {
+function resolveModel(modelString: string | undefined, registry: { find(p: string, m: string): Model<any> | undefined; getAll(): Model<any>[] }): Model<any> | undefined {
   if (!modelString) return undefined;
 
   const slashIndex = modelString.indexOf("/");
-  if (slashIndex <= 0) return undefined;
-
-  const provider = modelString.slice(0, slashIndex);
-  const modelId = modelString.slice(slashIndex + 1);
-
-  try {
-    return getModel(provider as any, modelId as any);
-  } catch {
-    return undefined;
+  if (slashIndex > 0) {
+    const provider = modelString.slice(0, slashIndex);
+    const modelId = modelString.slice(slashIndex + 1);
+    return registry.find(provider, modelId);
   }
+
+  // Bare model id — search all providers, reject ambiguous matches
+  const matches = registry.getAll().filter((m) => m.id === modelString);
+  if (matches.length === 1) return matches[0];
+  return undefined;
 }
 
 // ── Thinking level parsing ──────────────────────────────────────────────────
@@ -125,10 +136,6 @@ async function main(): Promise<void> {
 
   initParams = await initPromise;
 
-  // Resolve model: agent-level model takes priority, then top-level model.
-  const modelString = initParams.agentModel ?? initParams.model;
-  const model = resolveModel(modelString);
-
   // Resolve thinking level from agent config.
   const thinkingLevel = parseThinkingLevel(initParams.agentThinking);
 
@@ -136,20 +143,35 @@ async function main(): Promise<void> {
   const tools = initParams.agentTools;
 
   // Build options object — omit undefined values to satisfy exactOptionalPropertyTypes.
+  // NOTE: we deliberately do NOT pass authStorage/modelRegistry/settingsManager —
+  // createAgentSession builds a DefaultResourceLoader that loads extensions
+  // (including custom providers like "tama") and registers them into the
+  // registry. Passing a bare ModelRegistry.create() would skip extension
+  // loading and break custom-provider model resolution.
   const sessionOptions: Parameters<typeof createAgentSession>[0] = {
     excludeTools: ["subagent"],
     customTools: [createIpcAskTool()],
     sessionManager: SessionManager.inMemory(),
-    ...(model ? { model } : {}),
     ...(thinkingLevel ? { thinkingLevel } : {}),
     ...(initParams.cwd ? { cwd: initParams.cwd } : {}),
     ...(tools ? { tools } : {}),
   };
 
   // Create the agent session with IPC ask tool for user questions.
+  // The session loads extensions (custom providers) and picks the settings
+  // default model when none is passed.
   const { session: agentSession } = await createAgentSession(sessionOptions);
 
   session = agentSession;
+
+  // If a specific model was requested, resolve it through the session's
+  // registry (which now includes extension-registered providers) and switch
+  // to it. This handles "tama/whatevers-hot-n-fresh" and bare ids like "glm".
+  const modelString = initParams.agentModel ?? initParams.model;
+  const resolvedModel = resolveModel(modelString, session.modelRegistry);
+  if (resolvedModel && (session.model?.provider !== resolvedModel.provider || session.model?.id !== resolvedModel.id)) {
+    await session.setModel(resolvedModel);
+  }
 
   // Bind extensions with empty bindings (no UI, no command context).
   await session.bindExtensions({});

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -34,30 +34,100 @@ interface InitParams {
 // ── Model resolution ────────────────────────────────────────────────────────
 
 /**
- * Resolve a model reference via a ModelRegistry.
+ * Known providers' default model ids (subset of pi's defaultModelPerProvider).
+ * Used by buildFallbackModel to pick a template model when the requested
+ * model id isn't in the registry (e.g. newly-released openrouter models).
+ */
+const DEFAULT_MODEL_PER_PROVIDER: Record<string, string | undefined> = {
+  openrouter: "anthropic/claude-sonnet-4-5",
+  anthropic: "claude-sonnet-4-5",
+  openai: "gpt-4o",
+  google: "gemini-2.5-pro",
+  // fall back to first model of provider when undefined
+};
+
+/**
+ * Build a fallback model for a known provider when the exact model id isn't
+ * registered. Mirrors pi's buildFallbackModel(): take the provider's default
+ * model as a template and override id/name with the requested modelId.
+ */
+function buildFallbackModel(provider: string, modelId: string, available: Model<any>[]): Model<any> | undefined {
+  const providerModels = available.filter((m) => m.provider === provider);
+  if (providerModels.length === 0) return undefined;
+  const defaultId = DEFAULT_MODEL_PER_PROVIDER[provider];
+  const baseModel = defaultId
+    ? (providerModels.find((m) => m.id === defaultId) ?? providerModels[0]!)
+    : providerModels[0]!;
+  return { ...baseModel, id: modelId, name: modelId };
+}
+
+interface ModelRegistryLike {
+  find(provider: string, modelId: string): Model<any> | undefined;
+  getAll(): Model<any>[];
+}
+
+/**
+ * Resolve a model reference the same way the pi CLI does (resolveCliModel).
  *
  * Supports:
- * - "provider/modelId" (canonical)
- * - "modelId" (bare — resolved across providers, ambiguous matches rejected)
+ * - "provider/modelId" where provider is a known provider
+ * - "modelId" containing slashes (e.g. openrouter's "z-ai/glm-5.2")
+ * - bare "modelId"
+ * - fuzzy/partial matching on id within a provider
+ * - fallback: build a custom model for a known provider when the id isn't
+ *   registered (handles newly-released models like openrouter/z-ai/glm-5.2)
  *
  * The registry must include extension-registered providers (e.g. "tama"),
  * which is why this is called AFTER createAgentSession has loaded
  * extensions — not with a bare ModelRegistry.create() that only knows
  * built-ins + models.json.
  */
-function resolveModel(modelString: string | undefined, registry: { find(p: string, m: string): Model<any> | undefined; getAll(): Model<any>[] }): Model<any> | undefined {
+function resolveModel(modelString: string | undefined, registry: ModelRegistryLike): Model<any> | undefined {
   if (!modelString) return undefined;
+  const cliModel = modelString.trim();
+  if (!cliModel) return undefined;
 
-  const slashIndex = modelString.indexOf("/");
-  if (slashIndex > 0) {
-    const provider = modelString.slice(0, slashIndex);
-    const modelId = modelString.slice(slashIndex + 1);
-    return registry.find(provider, modelId);
+  const available = registry.getAll();
+  if (available.length === 0) return undefined;
+
+  const lower = cliModel.toLowerCase();
+
+  // Build canonical provider lookup (case-insensitive)
+  const providerMap = new Map<string, string>();
+  for (const m of available) {
+    if (!providerMap.has(m.provider.toLowerCase())) {
+      providerMap.set(m.provider.toLowerCase(), m.provider);
+    }
   }
 
-  // Bare model id — search all providers, reject ambiguous matches
-  const matches = registry.getAll().filter((m) => m.id === modelString);
-  if (matches.length === 1) return matches[0];
+  // If the input is a full canonical "provider/id", match it directly.
+  // This handles models whose ids contain slashes (e.g. openrouter "z-ai/glm-5.2").
+  const canonicalMatch = available.find(
+    (m) => `${m.provider}/${m.id}`.toLowerCase() === lower,
+  );
+  if (canonicalMatch) return canonicalMatch;
+
+  // Try interpreting "provider/modelId" when the prefix is a known provider.
+  const slashIndex = cliModel.indexOf("/");
+  if (slashIndex !== -1) {
+    const maybeProvider = cliModel.substring(0, slashIndex);
+    const canonicalProvider = providerMap.get(maybeProvider.toLowerCase());
+    if (canonicalProvider) {
+      const modelId = cliModel.substring(slashIndex + 1);
+      // Exact match within provider
+      const within = available.filter(
+        (m) => m.provider === canonicalProvider && m.id.toLowerCase() === modelId.toLowerCase(),
+      );
+      if (within.length === 1) return within[0];
+      // Fallback: unknown model id on a known provider → build a custom model
+      return buildFallbackModel(canonicalProvider, modelId, available);
+    }
+  }
+
+  // Bare id (no slash, or slash prefix isn't a known provider) — exact id match
+  const idMatches = available.filter((m) => m.id.toLowerCase() === lower);
+  if (idMatches.length === 1) return idMatches[0];
+
   return undefined;
 }
 

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -10,7 +10,7 @@
 
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { getModel, type Model } from "@earendil-works/pi-ai";
-import type { ParentToChild, ChildToParent } from "./ipc-types.ts";
+import type { ParentToChild, ChildToParent, SerializedAgentEvent } from "./ipc-types.ts";
 import { createIpcAskTool } from "./ipc-ask-tool.ts";
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -157,7 +157,7 @@ async function main(): Promise<void> {
   // Subscribe to agent events and stream them to parent.
   session.subscribe((event) => {
     const serialized = serializeEvent(event);
-    sendToParent({ type: "event", event: serialized });
+    sendToParent({ type: "event", event: serialized as SerializedAgentEvent });
 
     // On agent_end, exit the process.
     if (event.type === "agent_end") {

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -10,8 +10,8 @@
 
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { getModel, type Model } from "@earendil-works/pi-ai";
-import type { ParentToChild, ChildToParent } from "./ipc-types.js";
-import { createIpcAskTool } from "./ipc-ask-tool.js";
+import type { ParentToChild, ChildToParent } from "./ipc-types.ts";
+import { createIpcAskTool } from "./ipc-ask-tool.ts";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -178,7 +178,11 @@ async function main(): Promise<void> {
   sendToParent({ type: "ready" });
 
   // Start the agent loop.
-  await session.prompt(initParams.task);
+  // Prepend the agent's system prompt to the first prompt (no SDK-level systemPrompt option).
+  const fullPrompt = initParams.agentSystemPrompt && initParams.agentSystemPrompt.trim()
+    ? `${initParams.agentSystemPrompt}\n\n---\n\n${initParams.task}`
+    : initParams.task;
+  await session.prompt(fullPrompt);
 }
 
 // ── Graceful shutdown ───────────────────────────────────────────────────────

--- a/packages/subagent/src/child.ts
+++ b/packages/subagent/src/child.ts
@@ -1,0 +1,222 @@
+/**
+ * Forked child entry point for IPC-based subagent architecture.
+ *
+ * This script is forked by the parent process. It receives an "init" message
+ * with task and configuration, creates an AgentSession, runs the agent loop,
+ * and streams events back to the parent over IPC.
+ *
+ * Usage: node child.js (forked with stdio: ["pipe", "pipe", "pipe", "ipc"])
+ */
+
+import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
+import { getModel, type Model } from "@earendil-works/pi-ai";
+import type { ParentToChild, ChildToParent } from "./ipc-types.js";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
+interface InitParams {
+  task: string;
+  model: string | undefined;
+  agentName: string | undefined;
+  agentSystemPrompt: string | undefined;
+  agentTools: string[] | undefined;
+  agentModel: string | undefined;
+  agentThinking: string | undefined;
+  cwd: string | undefined;
+}
+
+// ── Pending ask tracking (for IPC ask tool in Task 2) ───────────────────────
+// The IPC ask tool (created in Task 2) will register pending asks here.
+// Parent messages of type "ask_response" resolve them.
+const pendingAsks = new Map<
+  string,
+  { resolve: (value: unknown) => void; reject: (reason: unknown) => void }
+>();
+
+// ── Model resolution ────────────────────────────────────────────────────────
+
+/**
+ * Parse a model string like "anthropic/claude-opus-4-5" into a Model object.
+ * Returns undefined if the string is empty or cannot be parsed.
+ */
+function resolveModel(modelString: string | undefined): Model<any> | undefined {
+  if (!modelString) return undefined;
+
+  const slashIndex = modelString.indexOf("/");
+  if (slashIndex <= 0) return undefined;
+
+  const provider = modelString.slice(0, slashIndex);
+  const modelId = modelString.slice(slashIndex + 1);
+
+  try {
+    return getModel(provider as any, modelId as any);
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Thinking level parsing ──────────────────────────────────────────────────
+
+function parseThinkingLevel(level: string | undefined): ThinkingLevel | undefined {
+  if (!level) return undefined;
+  const validLevels: readonly ThinkingLevel[] = [
+    "off",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+  ];
+  if (validLevels.includes(level as ThinkingLevel)) {
+    return level as ThinkingLevel;
+  }
+  return undefined;
+}
+
+// ── Parent message handler ──────────────────────────────────────────────────
+
+let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | null = null;
+
+function handleParentMessage(msg: ParentToChild): void {
+  switch (msg.type) {
+    case "ask_response": {
+      const pending = pendingAsks.get(msg.requestId);
+      if (pending) {
+        pendingAsks.delete(msg.requestId);
+        pending.resolve({
+          cancelled: msg.cancelled,
+          results: msg.results,
+        });
+      }
+      break;
+    }
+    case "abort": {
+      session?.abort();
+      break;
+    }
+    // "init" is handled synchronously before this listener is set up
+  }
+}
+
+// ── Event serialization ─────────────────────────────────────────────────────
+
+/**
+ * Strip non-serializable fields (functions, symbols) from events.
+ */
+function serializeEvent(event: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(event));
+}
+
+// ── Send helper ─────────────────────────────────────────────────────────────
+
+function sendToParent(msg: ChildToParent): void {
+  process.send?.(msg);
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Wait for the "init" message from parent.
+  let initParams: InitParams | null = null;
+
+  const initPromise = new Promise<InitParams>((resolve) => {
+    const handler = (msg: ParentToChild) => {
+      if (msg.type === "init") {
+        process.removeListener("message", handler);
+        resolve({
+          task: msg.task,
+          model: msg.model,
+          agentName: msg.agentName,
+          agentSystemPrompt: msg.agentSystemPrompt,
+          agentTools: msg.agentTools,
+          agentModel: msg.agentModel,
+          agentThinking: msg.agentThinking,
+          cwd: msg.cwd,
+        });
+      }
+    };
+    process.on("message", handler);
+  });
+
+  initParams = await initPromise;
+
+  // Resolve model: agent-level model takes priority, then top-level model.
+  const modelString = initParams.agentModel ?? initParams.model;
+  const model = resolveModel(modelString);
+
+  // Resolve thinking level from agent config.
+  const thinkingLevel = parseThinkingLevel(initParams.agentThinking);
+
+  // Build tools allowlist from agent config.
+  const tools = initParams.agentTools;
+
+  // Build options object — omit undefined values to satisfy exactOptionalPropertyTypes.
+  const sessionOptions: Parameters<typeof createAgentSession>[0] = {
+    excludeTools: ["subagent"],
+    customTools: [],
+    sessionManager: SessionManager.inMemory(),
+    ...(model ? { model } : {}),
+    ...(thinkingLevel ? { thinkingLevel } : {}),
+    ...(initParams.cwd ? { cwd: initParams.cwd } : {}),
+    ...(tools ? { tools } : {}),
+  };
+
+  // Create the agent session.
+  // customTools: TODO — wire up IPC ask tool (created in Task 2).
+  // For now, empty array. Will be replaced with: import { createIpcAskTool } from "./ipc-ask-tool.js"
+  const { session: agentSession } = await createAgentSession(sessionOptions);
+
+  session = agentSession;
+
+  // Bind extensions with empty bindings (no UI, no command context).
+  await session.bindExtensions({});
+
+  // Subscribe to agent events and stream them to parent.
+  session.subscribe((event) => {
+    const serialized = serializeEvent(event);
+    sendToParent({ type: "event", event: serialized });
+
+    // On agent_end, exit the process.
+    if (event.type === "agent_end") {
+      const willRetry = (event as { willRetry?: boolean }).willRetry ?? false;
+      if (!willRetry) {
+        // Give events time to flush, then exit.
+        setTimeout(() => {
+          process.exit(0);
+        }, 100);
+      }
+    }
+  });
+
+  // Set up parent message handler for ask_response and abort.
+  process.on("message", handleParentMessage);
+
+  // Send ready signal to parent.
+  sendToParent({ type: "ready" });
+
+  // Start the agent loop.
+  await session.prompt(initParams.task);
+}
+
+// ── Graceful shutdown ───────────────────────────────────────────────────────
+
+function gracefulShutdown(signal: string): void {
+  if (session) {
+    session.abort();
+    session.dispose();
+  }
+  process.exit(signal === "SIGTERM" ? 143 : 130);
+}
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  sendToParent({ type: "error", message });
+  process.exit(1);
+});

--- a/packages/subagent/src/handlers.ts
+++ b/packages/subagent/src/handlers.ts
@@ -67,20 +67,23 @@ export function handleToolEnd(state: StreamState): void {
 }
 
 /**
- * Handle a tool_result_end event — capture tool output for live display.
+ * Handle a tool_execution_end event — capture tool result output for live display.
+ * The result is in event.result (the tool's return value).
  */
 export function handleToolResult(state: StreamState, event: JsonEvent): void {
-  const toolMessage = event.message as Record<string, unknown> | undefined;
-  if (!toolMessage || toolMessage.role !== "toolResult") return;
+  const result = event.result as Record<string, unknown> | undefined;
+  if (!result) return;
 
-  const toolContent = toolMessage.content as Array<Record<string, unknown>> | string | undefined;
-  const toolName = (toolMessage.toolName as string) ?? "tool";
+  const toolName = (event.toolName as string) ?? "tool";
 
-  if (typeof toolContent === "string" && toolContent.trim()) {
-    const lines = toolContent.split("\n").filter((l) => l.trim());
+  // Extract text content from tool result
+  const content = result.content as Array<Record<string, unknown>> | string | undefined;
+
+  if (typeof content === "string" && content.trim()) {
+    const lines = content.split("\n").filter((l) => l.trim());
     state.recentOutput.push(`[${toolName}] ${lines[0]?.slice(0, ARGS_PREVIEW_MAX)}`);
-  } else if (Array.isArray(toolContent)) {
-    for (const part of toolContent) {
+  } else if (Array.isArray(content)) {
+    for (const part of content) {
       if (part.type === "text" && (part.text as string)?.trim()) {
         const text = part.text as string;
         const lines = text.split("\n").filter((l) => l.trim());

--- a/packages/subagent/src/index.ts
+++ b/packages/subagent/src/index.ts
@@ -98,7 +98,7 @@ export function registerSubagent(pi: ExtensionAPI): void {
             agentConfig: t.agent ? findAgent(agents, t.agent) : undefined,
             task: t.task,
             model: t.model,
-            activeModel: ctx.model?.id,
+            activeModel: ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined,
             cwd: t.cwd ?? undefined,
           })),
           signal: signal ?? undefined,
@@ -148,7 +148,7 @@ export function registerSubagent(pi: ExtensionAPI): void {
           agentConfig,
           task: params.task,
           model: params.model,
-          activeModel: ctx.model?.id,
+          activeModel: ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined,
           cwd: params.cwd ?? undefined,
           signal: signal ?? undefined,
           onUpdate: (progress: SubagentProgress) => {

--- a/packages/subagent/src/ipc-ask-tool.ts
+++ b/packages/subagent/src/ipc-ask-tool.ts
@@ -1,0 +1,248 @@
+/**
+ * Minimal "ask" tool for the forked child process.
+ *
+ * Uses IPC (process.send / process.on("message")) to forward questions
+ * to the parent, which displays the UI and sends back the response.
+ */
+
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type, type Static } from "typebox";
+import { randomUUID } from "node:crypto";
+
+// ── Schema (matches the existing ask tool) ───────────────────────────────────
+
+const OptionItemSchema = Type.Object({
+  label: Type.String({ description: "Display label" }),
+});
+
+const QuestionItemSchema = Type.Object({
+  id: Type.String({ description: "Question id" }),
+  question: Type.String({ description: "Question text" }),
+  description: Type.Optional(Type.String({
+    description: "Optional context in Markdown/plain text.",
+  })),
+  options: Type.Array(OptionItemSchema, {
+    description: "Available options. Do not include 'Other'.",
+    minItems: 1,
+  }),
+  multi: Type.Optional(Type.Boolean({ description: "Allow multi-select" })),
+  recommended: Type.Optional(Type.Number({
+    description: "0-indexed recommended option.",
+  })),
+});
+
+const AskParamsSchema = Type.Object({
+  questions: Type.Array(QuestionItemSchema, { description: "Questions to ask", minItems: 1 }),
+});
+
+type AskParams = Static<typeof AskParamsSchema>;
+
+// ── Session content helpers (minimal from packages/ask) ──────────────────────
+
+interface QuestionResult {
+  id: string;
+  question: string;
+  description: string | undefined;
+  options: string[];
+  multi: boolean;
+  selectedOptions: string[];
+  customInput: string | undefined;
+}
+
+function sanitizeForSessionText(value: string): string {
+  return value
+    .replace(/[\r\n\t]/g, " ")
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+function sanitizeMultilineForSessionText(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => sanitizeForSessionText(line))
+    .join("\n")
+    .trim();
+}
+
+function toSessionSafeQuestionResult(result: QuestionResult): QuestionResult {
+  const selectedOptions = result.selectedOptions
+    .map(sanitizeForSessionText)
+    .filter((s) => s.length > 0);
+
+  const rawDescription = result.description;
+  const description = rawDescription == null ? undefined : sanitizeMultilineForSessionText(rawDescription);
+  const rawCustomInput = result.customInput;
+  const customInput = rawCustomInput == null ? undefined : sanitizeForSessionText(rawCustomInput);
+
+  return {
+    id: sanitizeForSessionText(result.id) || "(unknown)",
+    question: sanitizeForSessionText(result.question) || "(empty question)",
+    description: description && description.length > 0 ? description : undefined,
+    options: result.options.map((o) => sanitizeForSessionText(o) || "(empty option)"),
+    multi: result.multi,
+    selectedOptions,
+    customInput: customInput && customInput.length > 0 ? customInput : undefined,
+  };
+}
+
+function formatSelectionForSummary(result: QuestionResult): string {
+  const hasSelected = result.selectedOptions.length > 0;
+  const hasCustom = Boolean(result.customInput);
+
+  if (!hasSelected && !hasCustom) return "(cancelled)";
+  if (hasSelected && hasCustom) {
+    const selected = result.multi ? `[${result.selectedOptions.join(", ")}]` : result.selectedOptions[0] ?? "";
+    return `${selected} + Other: "${result.customInput}"`;
+  }
+  if (hasCustom) return `"${result.customInput}"`;
+  if (result.multi) return `[${result.selectedOptions.join(", ")}]`;
+  return result.selectedOptions[0] ?? "";
+}
+
+function formatQuestionResult(result: QuestionResult): string {
+  return `${result.id}: ${formatSelectionForSummary(result)}`;
+}
+
+function formatQuestionContext(result: QuestionResult, index: number): string {
+  const lines: string[] = [
+    `Question ${index + 1} (${result.id})`,
+    `Prompt: ${result.question}`,
+  ];
+
+  if (result.description) {
+    lines.push("Context:");
+    for (const line of result.description.split("\n")) {
+      lines.push(`  ${line}`);
+    }
+  }
+
+  lines.push("Options:");
+  lines.push(...result.options.map((opt, i) => `  ${i + 1}. ${opt}`));
+  lines.push("Response:");
+
+  const hasSelected = result.selectedOptions.length > 0;
+  const hasCustom = Boolean(result.customInput);
+
+  if (!hasSelected && !hasCustom) {
+    lines.push("  Selected: (cancelled)");
+    return lines.join("\n");
+  }
+
+  if (hasSelected) {
+    const text = result.multi ? `[${result.selectedOptions.join(", ")}]` : result.selectedOptions[0];
+    lines.push(`  Selected: ${text}`);
+  }
+
+  if (hasCustom) {
+    if (!hasSelected) lines.push("  Selected: (Other)");
+    lines.push(`  Custom input: ${result.customInput}`);
+  }
+
+  return lines.join("\n");
+}
+
+function buildAskSessionContent(results: QuestionResult[]): string {
+  const safe = results.map(toSessionSafeQuestionResult);
+  const summary = safe.map(formatQuestionResult).join("\n");
+  const context = safe.map((r, i) => formatQuestionContext(r, i)).join("\n\n");
+  return `User answers:\n${summary}\n\nAnswer context:\n${context}`;
+}
+
+// ── Tool definition ─────────────────────────────────────────────────────────
+
+const ASK_TOOL_DESCRIPTION = `
+Ask the user for clarification when a choice materially affects the outcome.
+
+- Use when multiple valid approaches have different trade-offs.
+- Prefer 2-5 concise options.
+- Use multi=true when multiple answers are valid.
+- Use recommended=<index> (0-indexed) to mark the default option.
+- Use description to provide Markdown/plain context.
+- You can ask multiple related questions in one call using questions[].
+- Do NOT include an 'Other' option; UI adds it automatically.
+`.trim();
+
+export function createIpcAskTool(): ToolDefinition<any, unknown, any> {
+  return {
+    name: "ask",
+    label: "Ask",
+    description: ASK_TOOL_DESCRIPTION,
+    parameters: AskParamsSchema,
+
+    async execute(_toolCallId, params: AskParams, _signal, _onUpdate, _ctx) {
+      const requestId = randomUUID();
+      const questions = params.questions;
+
+      // Send ask_request to parent via IPC.
+      process.send?.({ type: "ask_request", requestId, questions });
+
+      // Await response from parent.
+      const response = await new Promise<{
+        cancelled: boolean;
+        results: Array<{ id: string; selectedOptions: string[]; customInput?: string }>;
+      }>((resolve) => {
+        // If IPC channel is closed, resolve immediately with cancelled.
+        if (!process.send) {
+          resolve({ cancelled: true, results: questions.map((q) => ({ id: q.id, selectedOptions: [] })) });
+          return;
+        }
+
+        let resolved = false;
+        const finish = (r: { cancelled: boolean; results: Array<{ id: string; selectedOptions: string[]; customInput?: string }> }) => {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timer);
+          process.removeListener("message", listener);
+          resolve(r);
+        };
+
+        const listener = (msg: { type?: string; requestId?: string; cancelled?: boolean; results?: unknown[] }) => {
+          if (msg.type === "ask_response" && msg.requestId === requestId) {
+            finish({
+              cancelled: msg.cancelled ?? true,
+              results: msg.results as Array<{ id: string; selectedOptions: string[]; customInput?: string }>,
+            });
+          }
+        };
+        process.on("message", listener);
+
+        // 5-minute timeout.
+        const timer = setTimeout(() => {
+          finish({ cancelled: true, results: questions.map((q) => ({ id: q.id, selectedOptions: [] })) });
+        }, 5 * 60 * 1000);
+        timer.unref();
+      });
+
+      // Build results matching the existing ask tool's format.
+      const results: QuestionResult[] = questions.map((q, i) => {
+        const r = response.results[i];
+        return {
+          id: q.id,
+          question: q.question,
+          description: q.description && q.description.trim().length > 0 ? q.description : undefined,
+          options: q.options.map((o) => o.label),
+          multi: q.multi ?? false,
+          selectedOptions: r?.selectedOptions ?? [],
+          customInput: r?.customInput ?? undefined,
+        };
+      });
+
+      const contentText = buildAskSessionContent(results);
+
+      if (response.cancelled && results.every((r) => r.selectedOptions.length === 0)) {
+        return {
+          content: [{ type: "text", text: "User cancelled the question." }],
+          details: {},
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: contentText }],
+        details: {},
+      };
+    },
+  };
+}

--- a/packages/subagent/src/ipc-ask-tool.ts
+++ b/packages/subagent/src/ipc-ask-tool.ts
@@ -184,12 +184,6 @@ export function createIpcAskTool(): ToolDefinition<any, unknown, any> {
         cancelled: boolean;
         results: Array<{ id: string; selectedOptions: string[]; customInput?: string }>;
       }>((resolve) => {
-        // If IPC channel is closed, resolve immediately with cancelled.
-        if (!process.send) {
-          resolve({ cancelled: true, results: questions.map((q) => ({ id: q.id, selectedOptions: [] })) });
-          return;
-        }
-
         let resolved = false;
         const finish = (r: { cancelled: boolean; results: Array<{ id: string; selectedOptions: string[]; customInput?: string }> }) => {
           if (resolved) return;

--- a/packages/subagent/src/ipc-types.ts
+++ b/packages/subagent/src/ipc-types.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared IPC message types for fork+IPC subagent architecture.
+ *
+ * Parent sends "init" first, then "ask_response" / "abort".
+ * Child sends "ready" after init, then "event" / "ask_request" / "error".
+ */
+
+// ── Parent → Child ──────────────────────────────────────────────────────────
+
+export type ParentToChild =
+  | {
+      type: "ask_response";
+      requestId: string;
+      cancelled: boolean;
+      results: Array<{
+        id: string;
+        selectedOptions: string[];
+        customInput?: string;
+      }>;
+    }
+  | {
+      type: "abort";
+    }
+  | {
+      type: "init";
+      task: string;
+      model?: string;
+      agentName?: string;
+      agentSystemPrompt?: string;
+      agentTools?: string[];
+      agentModel?: string;
+      agentThinking?: string;
+      cwd?: string;
+    };
+
+// ── Child → Parent ──────────────────────────────────────────────────────────
+
+export type ChildToParent =
+  | {
+      type: "event";
+      event: Record<string, unknown>;
+    }
+  | {
+      type: "ask_request";
+      requestId: string;
+      questions: Array<{
+        id: string;
+        question: string;
+        description?: string;
+        options: Array<{ label: string }>;
+        multi?: boolean;
+        recommended?: number;
+      }>;
+    }
+  | {
+      type: "ready";
+    }
+  | {
+      type: "error";
+      message: string;
+    };

--- a/packages/subagent/src/ipc-types.ts
+++ b/packages/subagent/src/ipc-types.ts
@@ -33,12 +33,30 @@ export type ParentToChild =
       cwd?: string;
     };
 
+// ── Serialized agent events ─────────────────────────────────────────────────
+// Matches the event types forwarded by stream.ts. Nested fields use `unknown`
+// because they contain complex objects (AgentMessage, etc.) serialized via
+// JSON.parse(JSON.stringify()). The key point is typing the `type` discriminator
+// and the top-level field names.
+
+export type SerializedAgentEvent =
+  | { type: "agent_start" }
+  | { type: "agent_end"; messages: unknown[]; willRetry?: boolean }
+  | { type: "turn_start" }
+  | { type: "turn_end"; message: unknown; toolResults: unknown[] }
+  | { type: "message_start"; message: unknown }
+  | { type: "message_update"; message: unknown; assistantMessageEvent: unknown }
+  | { type: "message_end"; message: unknown }
+  | { type: "tool_execution_start"; toolCallId: string; toolName: string; args: unknown }
+  | { type: "tool_execution_update"; toolCallId: string; toolName: string; args: unknown; partialResult: unknown }
+  | { type: "tool_execution_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean };
+
 // ── Child → Parent ──────────────────────────────────────────────────────────
 
 export type ChildToParent =
   | {
       type: "event";
-      event: Record<string, unknown>;
+      event: SerializedAgentEvent;
     }
   | {
       type: "ask_request";

--- a/packages/subagent/src/spawn.ts
+++ b/packages/subagent/src/spawn.ts
@@ -8,7 +8,7 @@ import type { AgentConfig } from "./agents.js";
 // Resolve child script path from this file's location
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const childScriptPath = join(__dirname, "child.js");
+const childScriptPath = join(__dirname, "child.ts");
 
 export interface SpawnOptions {
   task: string;
@@ -27,6 +27,7 @@ export function spawnSubagent(options: SpawnOptions): ChildProcess {
   const child = fork(childScriptPath, [], {
     cwd: options.cwd || process.cwd(),
     env: { ...process.env },
+    execArgv: ["--experimental-strip-types"],
     stdio: ["ignore", "ignore", "ignore", "ipc"],
   });
 

--- a/packages/subagent/src/spawn.ts
+++ b/packages/subagent/src/spawn.ts
@@ -1,22 +1,14 @@
-import { spawn, type ChildProcess } from "node:child_process";
-import { execSync } from "node:child_process";
-import { existsSync, writeFileSync, unlinkSync, mkdtempSync, rmdirSync, rmSync } from "node:fs";
-import { createServer, type Socket } from "node:net";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { fork, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { getBus, Events } from "@pi-archimedes/core/bus";
+import type { ParentToChild, ChildToParent } from "./ipc-types.js";
 import type { AgentConfig } from "./agents.js";
 
-// Track all temp dirs for cleanup on process exit (graceful shutdown only).
-// Note: SIGKILL/OOM cannot be caught — the exit handler only fires for
-// normal exits and catchable signals (SIGTERM, SIGINT, SIGHUP, etc.).
-const tempDirs = new Set<string>();
-
-process.on("exit", () => {
-  for (const dir of tempDirs) {
-    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
-  }
-});
+// Resolve child script path from this file's location
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const childScriptPath = join(__dirname, "child.js");
 
 export interface SpawnOptions {
   task: string;
@@ -28,186 +20,86 @@ export interface SpawnOptions {
 }
 
 /**
- * Resolve the `pi` command — finds it on PATH.
- */
-export function resolvePiCommand(): { command: string; args: string[] } {
-  let piPath: string;
-  try {
-    piPath = execSync(process.platform === "win32" ? 'where pi' : 'which pi', {
-      encoding: "utf-8",
-    }).trim();
-  } catch {
-    throw new Error("pi command not found on PATH. Is pi installed?");
-  }
-
-  // On Windows, the CLI might be a .cmd script
-  if (process.platform === "win32" && !piPath.endsWith(".cmd") && !piPath.endsWith(".exe")) {
-    const cmdPath = piPath + ".cmd";
-    if (existsSync(cmdPath)) {
-      return { command: "cmd", args: ["/c", cmdPath] };
-    }
-  }
-  return { command: piPath, args: [] };
-}
-
-/**
- * Write system prompt to a temp file for --append-system-prompt.
- */
-function writePromptToFile(agentName: string, prompt: string): { dir: string; filePath: string } {
-  const safeName = agentName.replace(/[^\w.-]+/g, "_");
-  const tmpDir = mkdtempSync(join(tmpdir(), "pi-subagent-"));
-  tempDirs.add(tmpDir);
-  const filePath = join(tmpDir, `prompt-${safeName}.md`);
-  writeFileSync(filePath, prompt, { encoding: "utf-8" });
-  return { dir: tmpDir, filePath };
-}
-
-/**
- * Clean up temp prompt file and directory.
- */
-function cleanupTempFiles(dir: string | null, filePath: string | null): void {
-  if (filePath) {
-    try { unlinkSync(filePath); } catch { /* ignore */ }
-  }
-  if (dir) {
-    try {
-      rmdirSync(dir);
-      tempDirs.delete(dir);
-    } catch { /* leave in Set so exit handler can retry with rmSync */ }
-  }
-}
-
-/**
- * Spawn a child `pi` process in JSON mode.
+ * Spawn a child process via fork() with IPC channel.
  */
 export function spawnSubagent(options: SpawnOptions): ChildProcess {
-  const { command, args: baseArgs } = resolvePiCommand();
-  const args: string[] = [
-    ...baseArgs,
-    "--mode", "json",
-    "-p",
-    "--no-session",
-  ];
-
-  // Create IPC socket for ask tool responses.
-  // On Unix: filesystem Unix domain socket. On Windows: named pipe (\\.\pipe\).
-  const socketName = `pi-subagent-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const socketPath = process.platform === "win32"
-    ? `\\\\.\\pipe\\${socketName}`
-    : join(tmpdir(), socketName);
-  // Only Unix socket files need pre-unlinking; Windows named pipes auto-clean.
-  if (process.platform !== "win32") {
-    try { unlinkSync(socketPath); } catch { /* doesn't exist yet */ }
-  }
-  let clientSocket: Socket | undefined;
-  const pendingAsks = new Map<string, Socket>();
-  const server = createServer((socket: Socket) => {
-    clientSocket = socket;
-    (child as ChildProcess & { clientSocket: Socket | undefined }).clientSocket = socket;
-    // Parse incoming lines from the child's ask tool (ask_request) and forward to bus
-    let buffer = "";
-    socket.on("data", (data: Buffer) => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        try {
-          const msg = JSON.parse(line);
-          if (msg.type === "ask_request" && msg.requestId) {
-            pendingAsks.set(msg.requestId, socket);
-            getBus().emit(Events.ASK_REQUEST, {
-              source: `subagent:${options.agent?.name ?? "general"}`,
-              requestId: msg.requestId,
-              questions: msg.questions,
-            });
-          }
-        } catch { /* ignore non-JSON */ }
-      }
-    });
-    socket.on("close", () => {
-      clientSocket = undefined;
-      (child as ChildProcess & { clientSocket: Socket | undefined }).clientSocket = undefined;
-      // Clean up any pending asks tied to this socket
-      for (const [id, s] of pendingAsks) {
-        if (s === socket) pendingAsks.delete(id);
-      }
-    });
-  });
-  server.listen(socketPath); // async, non-blocking
-
-  // Write ask responses back to the child over the originating socket
-  const unsubAskResponse = getBus().on(Events.ASK_RESPONSE, (payload: unknown) => {
-    const data = payload as { requestId: string; cancelled: boolean; results: Array<{ id: string; selectedOptions: string[]; customInput?: string }> };
-    const socket = pendingAsks.get(data.requestId);
-    if (socket && socket.writable) {
-      pendingAsks.delete(data.requestId);
-      socket.write(JSON.stringify({
-        type: "ask_response",
-        requestId: data.requestId,
-        cancelled: data.cancelled,
-        results: data.results,
-      }) + "\n");
-    }
-  });
-  server.on("close", () => {
-    if (process.platform !== "win32") {
-      try { unlinkSync(socketPath); } catch { /* ignore */ }
-    }
-  });
-
-  // Resolve model with correct priority:
-  // 1. frontmatter model (agent.model)
-  // 2. explicit tool-call model (options.model)
-  // 3. currently active model (options.activeModel)
-  // 4. no --model flag → pi default
-  const modelToUse = options.agent?.model ?? options.model ?? options.activeModel;
-  if (modelToUse) {
-    args.push("--model", modelToUse);
-  }
-
-  // Apply other agent config options
-  if (options.agent) {
-    const agent = options.agent;
-    if (agent.thinking) {
-      args.push("--thinking", agent.thinking);
-    }
-    if (agent.tools && agent.tools.length > 0) {
-      args.push("--tools", agent.tools.join(","));
-    }
-  }
-
-  // Temp files for system prompt
-  let tmpDir: string | null = null;
-  let tmpPath: string | null = null;
-
-  if (options.agent && options.agent.systemPrompt.trim()) {
-    const tmp = writePromptToFile(options.agent.name, options.agent.systemPrompt);
-    tmpDir = tmp.dir;
-    tmpPath = tmp.filePath;
-    args.push("--append-system-prompt", tmpPath);
-  }
-
-  args.push(options.task);
-
-  const child = spawn(command, args, {
+  // Fork the child script with IPC channel
+  const child = fork(childScriptPath, [], {
     cwd: options.cwd || process.cwd(),
-    stdio: ["ignore", "pipe", "pipe"],
-    env: {
-      ...process.env,
-      PI_SUBAGENT_SOCKET: socketPath,
-    },
+    env: { ...process.env },
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+
+  // Send init message to child with all configuration
+  // Model priority: agent.model > options.model > options.activeModel
+  const model = options.agent?.model ?? options.model ?? options.activeModel;
+  const initBase: Partial<ParentToChild> & { type: "init"; task: string } = {
+    type: "init",
+    task: options.task,
+  };
+  if (model) initBase.model = model;
+  if (options.agent?.name) initBase.agentName = options.agent.name;
+  if (options.agent?.systemPrompt) initBase.agentSystemPrompt = options.agent.systemPrompt;
+  if (options.agent?.tools) initBase.agentTools = options.agent.tools;
+  if (options.agent?.model) initBase.agentModel = options.agent.model;
+  if (options.agent?.thinking) initBase.agentThinking = options.agent.thinking;
+  if (options.cwd) initBase.cwd = options.cwd;
+  child.send(initBase as ParentToChild);
+
+  // Handle messages from child
+  child.on("message", (msg: ChildToParent) => {
+    switch (msg.type) {
+      case "event": {
+        // Forward events to streamEvents via the child's message handler
+        // (streamEvents attaches its own listener)
+        break;
+      }
+      case "ask_request": {
+        // Forward ask requests to the bus for parent's ask dialog
+        getBus().emit(Events.ASK_REQUEST, {
+          source: `subagent:${options.agent?.name ?? "general"}`,
+          requestId: msg.requestId,
+          questions: msg.questions,
+        });
+        break;
+      }
+      case "ready": {
+        // Child is ready — session created
+        break;
+      }
+      case "error": {
+        console.error(`[subagent:child] ${msg.message}`);
+        break;
+      }
+    }
+  });
+
+  // Handle ask responses from bus → send to child via IPC
+  const unsubAskResponse = getBus().on(Events.ASK_RESPONSE, (payload: unknown) => {
+    const data = payload as {
+      requestId: string;
+      cancelled: boolean;
+      results: Array<{ id: string; selectedOptions: string[]; customInput?: string }>;
+    };
+    const responseMsg: ParentToChild = {
+      type: "ask_response",
+      requestId: data.requestId,
+      cancelled: data.cancelled,
+      results: data.results,
+    };
+    child.send(responseMsg);
   });
 
   // Handle abort signal
   let abortHandler: (() => void) | undefined;
   if (options.signal) {
     abortHandler = () => {
+      // Send abort message to child before killing
+      child.send({ type: "abort" });
       if (child.pid && !child.killed) {
         child.kill("SIGTERM");
         const forceKill = setTimeout(() => {
-          if (!child.killed) {
-            child.kill("SIGKILL");
-          }
+          if (!child.killed) child.kill("SIGKILL");
         }, 3000);
         forceKill.unref();
       }
@@ -215,22 +107,17 @@ export function spawnSubagent(options: SpawnOptions): ChildProcess {
     options.signal.addEventListener("abort", abortHandler, { once: true });
   }
 
-  // Clean up temp files and listeners on exit
+  // Clean up on exit
   const exitCleanup = (): void => {
     child.removeListener("exit", exitCleanup);
     child.removeListener("error", exitCleanup);
     if (abortHandler && options.signal) {
       options.signal.removeEventListener("abort", abortHandler);
     }
-    server.close();
     unsubAskResponse();
-    if (clientSocket) clientSocket.destroy();
-    cleanupTempFiles(tmpDir, tmpPath);
   };
   child.on("exit", exitCleanup);
   child.on("error", exitCleanup);
 
-  // Attach client socket reference to child for streamEvents
-  (child as ChildProcess & { clientSocket: Socket | undefined }).clientSocket = clientSocket;
   return child;
 }

--- a/packages/subagent/src/stream.ts
+++ b/packages/subagent/src/stream.ts
@@ -1,5 +1,5 @@
-import { createInterface } from "node:readline";
 import type { ChildProcess } from "node:child_process";
+import type { ChildToParent } from "./ipc-types.js";
 import type { StreamState, SubagentProgress, SubagentResult } from "./types.js";
 import { getBus, Events } from "@pi-archimedes/core/bus";
 import {
@@ -97,25 +97,20 @@ export function streamEvents(
     // Periodic progress updates for live duration display
     const heartbeat = setInterval(emitProgress, 1000);
 
-    // Collect stderr
-    const stderrParts: string[] = [];
-    child.stderr?.on("data", (data: Buffer) => {
-      stderrParts.push(data.toString());
-    });
+    // Listen for IPC messages from child
+    child.on("message", (msg: unknown) => {
+      const childMsg = msg as ChildToParent;
 
-    // Parse JSON lines from stdout
-    const rl = createInterface({
-      input: child.stdout!,
-      crlfDelay: Infinity,
-    });
-
-    rl.on("line", (line: string) => {
-      let event: JsonEvent;
-      try {
-        event = JSON.parse(line);
-      } catch {
-        return; // Skip non-JSON lines
+      // Handle error messages from child
+      if (childMsg.type === "error") {
+        error = childMsg.message;
+        return;
       }
+
+      // Only process "event" messages (AgentSessionEvent forwarded from child)
+      if (childMsg.type !== "event") return;
+
+      const event = childMsg.event as JsonEvent;
 
       // First event received from the child means the model has engaged —
       // from here on, the user controls lifetime via the abort signal.
@@ -141,15 +136,13 @@ export function streamEvents(
         case "tool_execution_end": {
           handleToolEnd(state);
           emitProgress();
+          // Also capture tool result output here (previously in tool_result_end)
+          handleToolResult(state, event);
+          emitProgress();
           break;
         }
         case "turn_start": {
           state.turnCount++;
-          break;
-        }
-        case "tool_result_end": {
-          handleToolResult(state, event);
-          emitProgress();
           break;
         }
         case "message_end": {
@@ -171,9 +164,7 @@ export function streamEvents(
       const durationMs = Date.now() - startTime;
       const exitCode = code ?? 1;
 
-      if (stderrParts.length > 0 && exitCode !== 0) {
-        error = stderrParts.join("").trim();
-      }
+      // Error is set via IPC error messages or remains undefined
 
       const result: SubagentResult = {
         agent: callbacks.agent ?? "subagent",

--- a/packages/subagent/tsconfig.json
+++ b/packages/subagent/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/todo/src/ui/todo-widget.ts
+++ b/packages/todo/src/ui/todo-widget.ts
@@ -63,6 +63,12 @@ export function updateWidget(
 
     const maxRows = Math.max(...columns.map((c) => c.todos.length));
 
+    // When any column has a subagent header, reserve an extra row at the top
+    // for the headers so todo[0] isn't overwritten by the header text.
+    const hasSubHeader = columns.some((c) => c.header.length > 0);
+    const headerRows = hasSubHeader ? 1 : 0;
+    const totalRows = maxRows + headerRows;
+
     return {
       render(width: number) {
         const lines: string[] = [];
@@ -81,29 +87,31 @@ export function updateWidget(
         let colWidth = numCols > 0 ? Math.floor((width - dividerWidth) / numCols) : width;
         colWidth = Math.max(colWidth, minColWidth);
 
-        // Render subagent headers on row 0
-        const hasSubHeader = columns.some((c) => c.header.length > 0);
-
-        for (let row = 0; row < maxRows; row++) {
+        for (let row = 0; row < totalRows; row++) {
           const cellParts: string[] = [];
 
           for (const column of columns) {
             let cellText: string;
 
-            if (row === 0 && hasSubHeader && column.header) {
+            if (row === 0 && headerRows > 0 && column.header) {
+              // Header row for subagent columns
               cellText = ` ${column.header}`;
-            } else if (row < column.todos.length) {
-              const todo = column.todos[row];
-              if (todo) {
-                const icon = getStatusIcon(todo.status, theme);
-                const idStr = theme.fg("accent", `${todo.id}.`);
-                const title = formatTodoTitle(todo, theme);
-                cellText = ` ${icon} ${idStr} ${title}`;
+            } else {
+              // Todo row — offset by the header row count
+              const todoIndex = row - headerRows;
+              if (todoIndex >= 0 && todoIndex < column.todos.length) {
+                const todo = column.todos[todoIndex];
+                if (todo) {
+                  const icon = getStatusIcon(todo.status, theme);
+                  const idStr = theme.fg("accent", `${todo.id}.`);
+                  const title = formatTodoTitle(todo, theme);
+                  cellText = ` ${icon} ${idStr} ${title}`;
+                } else {
+                  cellText = "";
+                }
               } else {
                 cellText = "";
               }
-            } else {
-              cellText = "";
             }
 
             // Truncate and pad to column width

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         specifier: ^1.1.38
         version: 1.1.38
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
 
   packages/todo:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
 
   packages/subagent:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: '>=0.1.0'
+        version: 0.78.0(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: '>=0.1.0'
         version: 0.78.0(ws@8.21.0)(zod@4.4.3)


### PR DESCRIPTION
## Summary

Replaces the `spawn("pi", ["--mode","json"])` + Unix domain socket + JSON stdout architecture with `fork()` + pi SDK + a single bidirectional IPC channel.

A forked child (`child.ts`) imports `createAgentSession` from the pi SDK, subscribes to all `AgentSessionEvent`s, and forwards them to the parent via `process.send()`. The parent sends ask responses and abort signals back via `child.send()`. One IPC channel replaces two unidirectional channels (stdout pipe + unix socket).

### What changed
- **`packages/subagent/src/ipc-types.ts`** (new) — `ParentToChild` / `ChildToParent` discriminated unions + `SerializedAgentEvent`
- **`packages/subagent/src/child.ts`** (new) — forked child entry point. Creates an `AgentSession` via the SDK (loads extensions so custom providers like `tama` register), forwards events, handles abort, exits on `agent_end`
- **`packages/subagent/src/ipc-ask-tool.ts`** (new) — minimal ask tool for the child that sends `ask_request` via `process.send()` and awaits `ask_response` by `requestId`
- **`packages/subagent/src/spawn.ts`** — `spawn()` → `fork()` with `--experimental-strip-types`; removed socket server, `resolvePiCommand`, temp-file prompt handling; wires `child.on("message")` and `child.send()`
- **`packages/subagent/src/stream.ts`** — reads events from `child.on("message")` instead of stdout readline; no `JSON.parse`; errors via IPC `{type:"error"}`
- **`packages/subagent/src/handlers.ts`** — `handleToolResult` reads `event.result` (`tool_execution_end`) instead of the old `tool_result_end`
- **`packages/ask/src/index.ts`** — deprecation comment on the socket-based headless path
- **`packages/todo/src/ui/todo-widget.ts`** — fix: subagent column header was overwriting the first todo

### Model resolution (the hard part)
The child replicates pi CLI's `resolveCliModel` + `buildFallbackModel` logic so it handles:
- custom providers registered via extensions (`tama/whatevers-hot-n-fresh`)
- models whose ids contain slashes (`openrouter/z-ai/glm-5.2`)
- newly-released models not in `models.json` (fallback model built from the provider's default template)
- bare ids and `provider/modelId` forms

The parent passes the full canonical `provider/id` (was just `ctx.model.id`).

## Test plan
- [x] `npx tsc --noEmit` passes in `subagent`, `ask`, `core`, `todo`
- [x] Subagent runs with explicit custom-provider model (`tama/whatevers-hot-n-fresh`)
- [x] Subagent inherits parent's active model (`build` agent, no frontmatter model → `openrouter/z-ai/glm-5.2`)
- [x] Agent frontmatter model takes priority (`general` agent → `tama/...`)
- [x] Ask tool round-trip: child → parent dialog → child (IPC both ways)
- [x] Todo workflow: 3 todos created and worked through one-by-one; all 3 render in widget
- [x] Cost/token tracking shows in footer
- [ ] Parallel subagents
- [ ] Abort signal

## Known issue (pre-existing, not a regression)
`buildFallbackModel` in the pi SDK copies the template model's `cost` field, so cost for newly-released fallback models (e.g. `glm-5.2`) is calculated using the template's pricing (Claude Sonnet). The old `spawn(pi --model ...)` approach had the same behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool result handling in subagent communication.
  * Fixed display of subagent headers in the todo widget.

* **Chores**
  * Refactored subagent communication architecture to use internal process-based messaging.
  * Updated package dependencies and TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->