### PR TITLE
feat: add @pi-archimedes/notify package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           pnpm --filter "@pi-archimedes/core" publish --access public --no-git-checks
           pnpm --filter "@pi-archimedes/ask" publish --access public --no-git-checks
           pnpm --filter "@pi-archimedes/todo" publish --access public --no-git-checks
+          pnpm --filter "@pi-archimedes/notify" publish --access public --no-git-checks
           pnpm --filter "@pi-archimedes/footer" publish --access public --no-git-checks
           pnpm --filter "@pi-archimedes/diff" publish --access public --no-git-checks
           pnpm --filter "@pi-archimedes/image-paste" publish --access public --no-git-checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Rules for AI agents working on this monorepo.
 - `packages/image-paste` — clipboard image paste (standalone)
 - `packages/subagent` — subagent dispatch with live TUI streaming and cost tracking (depends on core)
 - `packages/todo` — todo list tool with auto-clear and subagent visibility (depends on core)
-- `meta` — orchestrator + composed settings (depends on all seven)
+- `packages/notify` — delayed desktop notifications with circuit breaker (depends on core)
+- `meta` — orchestrator + composed settings (depends on all eight)
 
 ## Adding a New Package
 
@@ -91,15 +92,15 @@ Root `package.json` has `pi.extensions` pointing to `meta/src/index.ts`.
 
 - All packages share the same version (bump all together)
 - `git tag v0.x.y && git push origin v0.x.y` triggers the release workflow
-- Publishes in dependency order: core → ask → todo → footer → diff → image-paste → subagent → meta
+- Publishes in dependency order: core → ask → todo → notify → footer → diff → image-paste → subagent → meta
 
 ## Release Steps
 
 When releasing a new version, apply these steps after bumping versions but before tagging:
 
-1. **Bump all 8 package versions** — `packages/core`, `packages/ask`, `packages/footer`, `packages/diff`, `packages/image-paste`, `packages/subagent`, `packages/todo`, `meta` all share the same version. The root `package.json` is private and has no version to bump.
+1. **Bump all 9 package versions** — `packages/core`, `packages/ask`, `packages/footer`, `packages/diff`, `packages/image-paste`, `packages/notify`, `packages/subagent`, `packages/todo`, `meta` all share the same version. The root `package.json` is private and has no version to bump.
 
-2. **Type-check all packages** — run `npx tsc --noEmit` in each of the 7 package directories (6 components + todo). Don't release if any check fails.
+2. **Type-check all packages** — run `npx tsc --noEmit` in each of the 8 package directories (7 components + notify). Don't release if any check fails.
 
 3. **Ensure CI is green** — check the latest CI run on `feature/monorepo-split` (or `main`). Don't release on a red build.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ Most question tools only work when the main agent calls them. Ask works everywhe
 
 ![ask from a subagent](docs/images/ask-subagent.png)
 
+### 🔔 Notify ([`@pi-archimedes/notify`](packages/notify/README.md))
+
+Desktop notifications when you've stepped away — with a circuit breaker that cancels if you interact.
+
+- Delayed notification on task complete or unanswered questions
+- Terminal-aware dispatch: Ghostty, WezTerm, iTerm2, Kitty, Windows Terminal
+- tmux passthrough for all OSC sequences
+- Configurable delay and per-trigger toggles
+
 ## Quick Start
 
 ```bash
@@ -128,6 +137,7 @@ That's it. Reload Pi and you're set.
 - `pi install @pi-archimedes/subagent`
 - `pi install @pi-archimedes/todo`
 - `pi install @pi-archimedes/ask`
+- `pi install @pi-archimedes/notify`
 
 ## Settings
 
@@ -171,6 +181,15 @@ No settings yet. Tool/cost events flow through `@pi-archimedes/core/bus` for the
 
 No settings yet.
 
+### [`@pi-archimedes/notify`](packages/notify/README.md)
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable desktop notifications |
+| `notifyOnAgentEnd` | bool | `true` | Notify when agent finishes a task |
+| `notifyOnQuestion` | bool | `true` | Notify when a question needs your answer |
+| `delayMs` | number | `60000` | Seconds to wait before sending notification |
+
 ## Architecture
 
 ### Monorepo layout
@@ -184,8 +203,9 @@ pi-archimedes/
 │   ├── diff/         # @pi-archimedes/diff — Shiki-powered diff rendering
 │   ├── image-paste/  # @pi-archimedes/image-paste — clipboard images
 │   ├── subagent/     # @pi-archimedes/subagent — sub-agent dispatch
-│   └── todo/         # @pi-archimedes/todo — todo list with auto-clear
-└── meta/             # pi-archimedes — meta-package bundling all seven
+│   ├── todo/         # @pi-archimedes/todo — todo list with auto-clear
+│   └── notify/       # @pi-archimedes/notify — delayed desktop notifications
+└── meta/             # pi-archimedes — meta-package bundling all eight
 ```
 
 Each package is a focused TypeScript ESM module with its own `src/index.ts` entry point.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ No settings yet.
 | `enabled` | bool | `true` | Enable desktop notifications |
 | `notifyOnAgentEnd` | bool | `true` | Notify when agent finishes a task |
 | `notifyOnQuestion` | bool | `true` | Notify when a question needs your answer |
-| `delayMs` | number | `60` | Seconds to wait before sending notification (stored as ms) |
+| `delayMs` | number | `30` | Seconds to wait before sending notification (stored as ms) |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ No settings yet.
 | `enabled` | bool | `true` | Enable desktop notifications |
 | `notifyOnAgentEnd` | bool | `true` | Notify when agent finishes a task |
 | `notifyOnQuestion` | bool | `true` | Notify when a question needs your answer |
-| `delayMs` | number | `60000` | Seconds to wait before sending notification |
+| `delayMs` | number | `60` | Seconds to wait before sending notification (stored as ms) |
 
 ## Architecture
 

--- a/docs/plans/2026-06-28-notify.md
+++ b/docs/plans/2026-06-28-notify.md
@@ -1,0 +1,261 @@
+# Notify Package Plan
+
+**Goal:** Add `@pi-archimedes/notify` — a delayed notification package with circuit breaker timeout, triggered on `agent_end` and `ASK_REQUEST`, cancelled on user interaction.
+
+**Architecture:** New standalone package depending on `@pi-archimedes/core` (for bus events). OSC escape sequences for terminal notifications (Ghostty, WezTerm, iTerm2, Kitty, Windows Terminal) with tmux passthrough. Settings integrated into `/archimedes` command via meta's composed settings.
+
+**Tech Stack:** TypeScript, Pi ExtensionAPI, OSC 777/99/9, PowerShell toast (Windows), node:child_process (Windows only).
+
+---
+
+### Task 1: Create packages/notify with OSC logic and circuit breaker
+
+**Context:** The core of the feature — a single-file package that schedules notifications after a configurable delay, cancelling if the user interacts. This is independent of meta and can be type-checked on its own.
+
+**Files:**
+- Create: `packages/notify/package.json`
+- Create: `packages/notify/src/index.ts`
+
+**What to implement:**
+
+`packages/notify/package.json`:
+- `"name": "@pi-archimedes/notify"`
+- `"version": "1.3.4"` (matching current monorepo version)
+- `"type": "module"`
+- `"keywords": ["pi-package"]`
+- `"files": ["src"]`
+- `"main": "./src/index.ts"`
+- `"dependencies": { "@pi-archimedes/core": "workspace:*" }`
+- `"peerDependencies": { "@earendil-works/pi-coding-agent": ">=0.1.0" }`
+- `"devDependencies": { "typescript": "^6.0.0" }`
+- `"pi": { "extensions": ["./src/index.ts"] }`
+
+`packages/notify/src/index.ts` — export `registerNotify(pi: ExtensionAPI)` and `getNotifySettingsItems(config: NotifyConfig): SettingItem[]`:
+
+**Config types:**
+```ts
+interface NotifyConfig {
+  enabled: boolean;
+  notifyOnAgentEnd: boolean;
+  notifyOnQuestion: boolean;
+  delayMs: number;
+}
+
+const DEFAULT_NOTIFY_CONFIG: NotifyConfig = {
+  enabled: true,
+  notifyOnAgentEnd: true,
+  notifyOnQuestion: true,
+  delayMs: 60_000,
+};
+
+const NAMESPACE = "archimedes.notify";
+```
+
+Use `loadConfig(NAMESPACE, DEFAULT_NOTIFY_CONFIG)` and `saveConfig(NAMESPACE, config)` from `@pi-archimedes/core/settings-io` for persistence.
+
+**Notification dispatch functions** (adapted from pi-notify, MIT licensed):
+- `wrapForTmux(sequence: string): string` — wrap in `\x1bPtmux;...\x1b\` when `process.env.TMUX` is set, escaping inner `\x1b` to `\x1b\x1b`
+- `notifyOSC777(title, body)` — `\x1b]777;notify;{title};{body}\x07`
+- `notifyOSC9(message)` — `\x1b]9;{message}\x07`
+- `notifyOSC99(title, body)` — two sequences: `\x1b]99;i=1:d=0;{title}\x1b\` then `\x1b]99;i=1:p=body;{body}\x1b\`
+- `notifyWindows(title, body)` — spawn `powershell.exe -NoProfile -Command <windowsToastScript(title, body)>` using `execFile` from `node:child_process`
+- `windowsToastScript(title, body): string` — PowerShell script using `Windows.UI.Notifications.ToastNotificationManager` with `ToastText01` template
+- `notify(title, body): void` — detect terminal via env vars (`WT_SESSION` → Windows, `KITTY_WINDOW_ID` → OSC99, `TERM_PROGRAM=iTerm.app` or `ITERM_SESSION_ID` → OSC9, fallback → OSC777)
+
+**Circuit breaker state:**
+```ts
+let notifyTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingTrigger: "agent_end" | "ask_request" | null = null;
+```
+
+**`scheduleNotify(trigger: "agent_end" | "ask_request")`:**
+1. Call `cancelPending()` first (reset any existing timer)
+2. Load config fresh from `loadConfig(NAMESPACE, DEFAULT_NOTIFY_CONFIG)`
+3. If `!config.enabled` → return
+4. If `trigger === "agent_end" && !config.notifyOnAgentEnd` → return
+5. If `trigger === "ask_request" && !config.notifyOnQuestion` → return
+6. Set `pendingTrigger = trigger`
+7. Set `notifyTimer = setTimeout(() => { fireNotification(pendingTrigger); notifyTimer = null; pendingTrigger = null; }, config.delayMs)`
+8. Call `notifyTimer.unref()` if available (so it doesn't block process exit)
+
+**`cancelPending():`**
+1. If `notifyTimer` → `clearTimeout(notifyTimer)`, set to `null`
+2. Set `pendingTrigger = null`
+
+**`fireNotification(trigger):`**
+1. Pick message: `agent_end` → `("Pi", "Task complete — waiting for input")`, `ask_request` → `("Pi", "A question needs your answer")`
+2. Call `notify(title, body)`
+
+**`registerNotify(pi: ExtensionAPI):`**
+- `pi.on("agent_end", () => scheduleNotify("agent_end"))`
+- `pi.on("input", () => cancelPending())`
+- `pi.on("agent_start", () => cancelPending())`
+- `pi.on("session_shutdown", () => { cancelPending(); unsubAskRequest(); })`
+- `const unsubAskRequest = getBus().on(Events.ASK_REQUEST, () => scheduleNotify("ask_request"))`
+- All handlers registered at top level (NOT inside session_start)
+
+**`getNotifySettingsItems(config: NotifyConfig): SettingItem[]`:**
+Return 4 SettingItems:
+1. `{ id: "enabled", label: "Notifications", description: "Enable desktop notifications", currentValue: config.enabled ? "On" : "Off", values: ["On", "Off"] }`
+2. `{ id: "notifyOnAgentEnd", label: "Notify on task complete", description: "Notify when agent finishes a task", currentValue: config.notifyOnAgentEnd ? "On" : "Off", values: ["On", "Off"] }`
+3. `{ id: "notifyOnQuestion", label: "Notify on question", description: "Notify when a question needs your answer", currentValue: config.notifyOnQuestion ? "On" : "Off", values: ["On", "Off"] }`
+4. `{ id: "delayMs", label: "Delay before notify", description: "Seconds to wait before sending notification", currentValue: String(config.delayMs / 1000) + "s" }` — this one gets a number submenu attached in meta's settings.ts
+
+Also export: `loadNotifyConfig()`, `saveNotifyConfig()`, `DEFAULT_NOTIFY_CONFIG`, `type NotifyConfig`
+
+**Steps:**
+- [ ] Create `packages/notify/package.json`
+- [ ] Create `packages/notify/src/index.ts` with all functions above
+- [ ] Run `npx tsc --noEmit` in `packages/notify/`
+  - Did it succeed? If not, fix type errors and re-run
+- [ ] Commit with message: "feat: add @pi-archimedes/notify package with circuit breaker notifications"
+
+**Acceptance criteria:**
+- [ ] `npx tsc --noEmit` passes in `packages/notify/`
+- [ ] All OSC sequences match pi-notify's format (777, 9, 99, Windows toast)
+- [ ] tmux passthrough wraps all OSC sequences correctly
+- [ ] Circuit breaker cancels on input/agent_start
+- [ ] Config is read fresh on each trigger (settings changes take effect immediately)
+
+---
+
+### Task 2: Wire notify into meta — config, settings menu, registration
+
+**Context:** Integrate the notify package into the archimedes monorepo — register it in meta's entry point, add its settings to the `/archimedes` menu, and add its config to the composed config loader.
+
+**Files:**
+- Modify: `meta/package.json` — add dependency
+- Modify: `meta/src/index.ts` — import and register
+- Modify: `meta/src/config.ts` — re-export notify config
+- Modify: `meta/src/settings.ts` — add notify items + submenu + save handler
+
+**What to implement:**
+
+`meta/package.json`:
+- Add `"@pi-archimedes/notify": "workspace:*"` to dependencies
+
+`meta/src/index.ts`:
+```ts
+import { registerNotify } from "@pi-archimedes/notify";
+// ... in default export, after registerAsk(pi):
+registerNotify(pi);
+```
+
+`meta/src/config.ts`:
+- Import `loadNotifyConfig, saveNotifyConfig, DEFAULT_NOTIFY_CONFIG, type NotifyConfig` from `@pi-archimedes/notify`
+- Re-export them
+- Add `notify: NotifyConfig` to `loadAllConfig()` return type
+- Add `notify: loadNotifyConfig()` to the returned object
+
+`meta/src/settings.ts`:
+- Import `getNotifySettingsItems` from `@pi-archimedes/notify`
+- Import `saveNotifyConfig` from `./config.js`
+- Add `notifyConfig: NotifyConfig = { ...allConfig.notify }` to the config copies
+- Call `getNotifySettingsItems(notifyConfig)` and add to items list
+- Add a number submenu for `delayMs` using `createNumberSubmenu({ label: "Enter delay in seconds (ESC to cancel):", cancelHint: "ESC: cancel", confirmHint: "min 1", min: 1 })`
+- In the `addSubmenus` call, add `addSubmenus(notifyItems)`
+- In the settings callback, handle cases:
+  - `case "enabled": notifyConfig.enabled = newValue === "On"; break;`
+  - `case "notifyOnAgentEnd": notifyConfig.notifyOnAgentEnd = newValue === "On"; break;`
+  - `case "notifyOnQuestion": notifyConfig.notifyOnQuestion = newValue === "On"; break;`
+  - `case "delayMs": { const v = parseInt(newValue, 10); if (Number.isFinite(v) && v >= 1) notifyConfig.delayMs = v * 1000; break; }`
+- In the `save` case, add `saveNotifyConfig(notifyConfig)`
+
+**Steps:**
+- [ ] Add notify dependency to `meta/package.json`
+- [ ] Import and call `registerNotify(pi)` in `meta/src/index.ts`
+- [ ] Re-export notify config in `meta/src/config.ts` and add to `loadAllConfig()`
+- [ ] Add notify settings items, submenu, and save handler in `meta/src/settings.ts`
+- [ ] Run `npx tsc --noEmit` in `meta/`
+  - Did it succeed? If not, fix type errors and re-run
+- [ ] Commit with message: "feat: wire notify package into meta settings and registration"
+
+**Acceptance criteria:**
+- [ ] `npx tsc --noEmit` passes in `meta/`
+- [ ] `registerNotify` is called in meta's default export
+- [ ] Notify settings appear in `/archimedes` menu (4 items)
+- [ ] Saving settings persists notify config to `~/.pi/agent/settings.json` under `archimedes.notify`
+
+---
+
+### Task 3: Update monorepo docs and release workflow
+
+**Context:** Keep AGENTS.md, README.md, and the release workflow in sync with the new package (per the "Adding a New Package" section of AGENTS.md).
+
+**Files:**
+- Modify: `AGENTS.md` — add to monorepo structure, bump counts, add to publish order
+- Modify: `README.md` — add feature section, monorepo tree, install line, settings table entry
+- Modify: `.github/workflows/release.yml` — add publish step for notify (after core, before meta)
+
+**What to implement:**
+
+`AGENTS.md`:
+- Add `packages/notify` to Monorepo Structure list (after `packages/todo`, before `meta`)
+- Bump "all 8 package versions" → "all 9 package versions"
+- Bump "7 package directories (6 components + todo)" → "8 package directories (7 components + notify)"
+- Add `@pi-archimedes/notify` to publish order line: `core → ask → todo → notify → footer → diff → image-paste → subagent → meta`
+- Add notify to the "Adding a New Package" checklist example count
+
+`README.md`:
+- Add a feature bullet for notifications (e.g. "Delayed desktop notifications with circuit breaker — notify only when you've actually stepped away")
+- Add `packages/notify` to the monorepo layout tree
+- Add `pi install @pi-archimedes/notify` under "install selectively"
+- Add a settings table entry if the README has one
+
+`.github/workflows/release.yml`:
+- Add `pnpm --filter "@pi-archimedes/notify" publish --access public --no-git-checks` after core's publish and before meta's publish
+
+**Steps:**
+- [ ] Update `AGENTS.md` with notify package references
+- [ ] Update `README.md` with notify feature, tree, install line
+- [ ] Update `.github/workflows/release.yml` with notify publish step
+- [ ] Commit with message: "chore: update docs and release workflow for notify package"
+
+**Acceptance criteria:**
+- [ ] AGENTS.md lists notify in monorepo structure and publish order
+- [ ] README.md mentions notify feature and install command
+- [ ] Release workflow publishes notify after core and before meta
+
+---
+
+### Task 4: Run pnpm install and type-check all packages
+
+**Context:** Final verification — install the new workspace dependency and type-check every package to ensure nothing is broken.
+
+**Files:**
+- (No file changes — verification only)
+
+**Steps:**
+- [ ] Run `pnpm install` at monorepo root
+  - Did it succeed? If not, fix workspace resolution errors
+- [ ] Run `npx tsc --noEmit` in each package directory:
+  - `packages/core`
+  - `packages/ask`
+  - `packages/footer`
+  - `packages/diff`
+  - `packages/image-paste`
+  - `packages/subagent`
+  - `packages/todo`
+  - `packages/notify`
+  - `meta`
+  - Did each succeed? If any fails, fix and re-run that package
+- [ ] Commit with message: "chore: pnpm install and verify type-check for all packages"
+
+**Acceptance criteria:**
+- [ ] `pnpm install` succeeds without errors
+- [ ] `npx tsc --noEmit` passes in all 9 directories (8 packages + meta)
+
+---
+
+### Task 5: Push branch and create PR
+
+**Context:** Push the completed work for review.
+
+**Steps:**
+- [ ] Run `git push -u origin feature/notify-package`
+- [ ] Create PR to `main` with title "feat: add @pi-archimedes/notify package"
+- [ ] PR description should include: feature summary, settings screenshot (if possible), compatibility matrix
+
+**Acceptance criteria:**
+- [ ] Branch pushed to origin
+- [ ] PR created and linked

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,7 @@
 ## Completed Plans
 
 | Plan | Status | Created |
+| [Notify package](plans/2026-06-28-notify.md) | ✅ COMPLETED (PR #11) | 2026-06-28 |
 | [Fork + IPC subagent communication](plans/2025-06-17-fork-ipc-subagent.md) | ✅ COMPLETED (PR #10) | 2026-06-17 |
 | [Ask tool](plans/2025-06-17-ask-tool.md) | ✅ COMPLETED (PR #9) | 2025-06-17 |
 | [Todo list with auto-clear + subagent visibility](plans/2026-06-15-todo-plan.md) | ✅ COMPLETED (PR #8) | 2026-06-15 |
@@ -17,5 +18,5 @@ _None_
 
 ## Quick Stats
 
-- Total Plans: 7
-- Completed: 7
+- Total Plans: 8
+- Completed: 8

--- a/meta/package.json
+++ b/meta/package.json
@@ -17,7 +17,8 @@
     "@pi-archimedes/ask": "workspace:*",
     "@pi-archimedes/image-paste": "workspace:*",
     "@pi-archimedes/subagent": "workspace:*",
-    "@pi-archimedes/todo": "workspace:*"
+    "@pi-archimedes/todo": "workspace:*",
+    "@pi-archimedes/notify": "workspace:*"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.1.0",

--- a/meta/package.json
+++ b/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-archimedes",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/meta/src/config.ts
+++ b/meta/src/config.ts
@@ -52,16 +52,33 @@ export function saveDiffConfig(config: DiffConfig): void {
   saveConfig(NAMESPACE, config);
 }
 
+// ── Re-export notify config ────────────────────────────────────────────
+
+import {
+  loadNotifyConfig,
+  saveNotifyConfig,
+  DEFAULT_NOTIFY_CONFIG,
+  type NotifyConfig,
+} from "@pi-archimedes/notify";
+export {
+  loadNotifyConfig,
+  saveNotifyConfig,
+  DEFAULT_NOTIFY_CONFIG,
+  type NotifyConfig,
+} from "@pi-archimedes/notify";
+
 // ── Composed config loader ─────────────────────────────────────────────
 
 export function loadAllConfig(): {
   core: CoreConfig;
   footer: FooterConfig;
   diff: DiffConfig;
+  notify: NotifyConfig;
 } {
   return {
     core: loadCoreConfig(),
     footer: loadFooterConfig(),
     diff: loadDiffConfig(),
+    notify: loadNotifyConfig(),
   };
 }

--- a/meta/src/index.ts
+++ b/meta/src/index.ts
@@ -7,6 +7,7 @@ import { registerImagePaste, initImagePasteSession, shutdownImagePaste } from "@
 import { registerSubagent, registerAgentsCommand } from "@pi-archimedes/subagent";
 import { registerTodo } from "@pi-archimedes/todo";
 import { registerAsk } from "@pi-archimedes/ask";
+import { registerNotify } from "@pi-archimedes/notify";
 import { loadDiffConfig } from "./config.js";
 import { openSettings } from "./settings.js";
 
@@ -26,6 +27,9 @@ export default function (pi: ExtensionAPI): void {
 
   // Register ask tool
   registerAsk(pi);
+
+  // Register notify
+  registerNotify(pi);
 
   // Register /agents command
   registerAgentsCommand(pi);

--- a/meta/src/settings.ts
+++ b/meta/src/settings.ts
@@ -6,15 +6,18 @@ import { SettingsList, type SettingItem, TUI } from "@earendil-works/pi-tui";
 import { getCoreSettingsItems } from "@pi-archimedes/core";
 import { getFooterSettingsItems } from "@pi-archimedes/footer/config";
 import { getDiffSettingsItems } from "@pi-archimedes/diff";
+import { getNotifySettingsItems } from "@pi-archimedes/notify";
 import {
   loadAllConfig,
   saveCoreConfig,
   saveFooterConfig,
   saveDiffConfig,
+  saveNotifyConfig,
   ANIMATION_STYLES,
   type CoreConfig,
   type FooterConfig,
   type DiffConfig,
+  type NotifyConfig,
 } from "./config.js";
 
 // ── Factory: text submenu ───────────────────────────────────────────────
@@ -97,11 +100,13 @@ export function openSettings(pi: ExtensionAPI, ctx: ExtensionContext): void {
   const coreConfig: CoreConfig = { ...allConfig.core };
   const footerConfig: FooterConfig = { ...allConfig.footer };
   const diffConfig: DiffConfig = { ...allConfig.diff };
+  const notifyConfig: NotifyConfig = { ...allConfig.notify };
 
   // Build composed items from sub-packages
   const coreItems = getCoreSettingsItems(coreConfig);
   const footerItems = getFooterSettingsItems();
   const diffItems = getDiffSettingsItems();
+  const notifyItems = getNotifySettingsItems(notifyConfig);
 
   // Add submenus for text/number fields
   const addSubmenus = (items: SettingItem[]) => {
@@ -145,6 +150,13 @@ export function openSettings(pi: ExtensionAPI, ctx: ExtensionContext): void {
           confirmHint: "min 80",
           min: 80,
         });
+      } else if (item.id === "delayMs") {
+        item.submenu = createNumberSubmenu({
+          label: "Enter delay in seconds (ESC to cancel):",
+          cancelHint: "ESC: cancel",
+          confirmHint: "min 1",
+          min: 1,
+        });
       }
     }
   };
@@ -152,11 +164,13 @@ export function openSettings(pi: ExtensionAPI, ctx: ExtensionContext): void {
   addSubmenus(coreItems);
   addSubmenus(diffItems);
   addSubmenus(footerItems);
+  addSubmenus(notifyItems);
 
   const items: SettingItem[] = [
     ...coreItems,
     ...footerItems,
     ...diffItems,
+    ...notifyItems,
     {
       id: "save",
       label: "Save",
@@ -196,11 +210,22 @@ export function openSettings(pi: ExtensionAPI, ctx: ExtensionContext): void {
           break;
         }
 
+        // ── Notify settings ──
+        case "enabled": notifyConfig.enabled = newValue === "On"; break;
+        case "notifyOnAgentEnd": notifyConfig.notifyOnAgentEnd = newValue === "On"; break;
+        case "notifyOnQuestion": notifyConfig.notifyOnQuestion = newValue === "On"; break;
+        case "delayMs": {
+          const v = parseInt(newValue, 10);
+          if (Number.isFinite(v) && v >= 1) notifyConfig.delayMs = v * 1000;
+          break;
+        }
+
         // ── Save ──
         case "save": {
           saveCoreConfig(coreConfig);
           saveFooterConfig(footerConfig);
           saveDiffConfig(diffConfig);
+          saveNotifyConfig(notifyConfig);
           done(undefined);
           return;
         }

--- a/packages/ask/package.json
+++ b/packages/ask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/ask",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/packages/ask/package.json
+++ b/packages/ask/package.json
@@ -11,8 +11,7 @@
   ],
   "main": "./src/index.ts",
   "dependencies": {
-    "@pi-archimedes/core": "workspace:*",
-    "@pi-archimedes/notify": "workspace:*"
+    "@pi-archimedes/core": "workspace:*"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.1.0",

--- a/packages/ask/package.json
+++ b/packages/ask/package.json
@@ -11,7 +11,8 @@
   ],
   "main": "./src/index.ts",
   "dependencies": {
-    "@pi-archimedes/core": "workspace:*"
+    "@pi-archimedes/core": "workspace:*",
+    "@pi-archimedes/notify": "workspace:*"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.1.0",

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "typebox";
 import { getBus, Events } from "@pi-archimedes/core/bus";
+import { scheduleNotify } from "@pi-archimedes/notify";
 import { connect } from "node:net";
 import { randomUUID } from "node:crypto";
 import { OTHER_OPTION, type AskQuestion, type AskSelection } from "./selection";
@@ -229,6 +230,9 @@ export function registerAsk(pi: ExtensionAPI) {
 	}) {
 		if (!currentCtx?.ui) return;
 
+		// Schedule notification — user may be away when a subagent asks
+		scheduleNotify("ask_request");
+
 		const questions = data.questions;
 		let cancelled = true;
 		let selections: AskSelection[] = [];
@@ -376,6 +380,9 @@ export function registerAsk(pi: ExtensionAPI) {
 					details: { results, customInput: undefined, description: undefined } satisfies AskToolDetails,
 				};
 			}
+
+			// Schedule notification — user may be away
+			scheduleNotify("ask_request");
 
 			if (params.questions.length === 0) {
 				return {

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -1,7 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "typebox";
 import { getBus, Events } from "@pi-archimedes/core/bus";
-import { scheduleNotify } from "@pi-archimedes/notify";
 import { connect } from "node:net";
 import { randomUUID } from "node:crypto";
 import { OTHER_OPTION, type AskQuestion, type AskSelection } from "./selection";
@@ -230,8 +229,8 @@ export function registerAsk(pi: ExtensionAPI) {
 	}) {
 		if (!currentCtx?.ui) return;
 
-		// Schedule notification — user may be away when a subagent asks
-		scheduleNotify("ask_request");
+		// Emit bus event so notify (if installed) can schedule a desktop notification
+		getBus().emit(Events.ASK_REQUEST, { source: "subagent", requestId: data.requestId, questions: data.questions });
 
 		const questions = data.questions;
 		let cancelled = true;
@@ -381,8 +380,8 @@ export function registerAsk(pi: ExtensionAPI) {
 				};
 			}
 
-			// Schedule notification — user may be away
-			scheduleNotify("ask_request");
+			// Emit bus event so notify (if installed) can schedule a desktop notification
+			getBus().emit(Events.ASK_REQUEST, { source: "main", requestId: randomUUID(), questions: params.questions });
 
 			if (params.questions.length === 0) {
 				return {

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -380,15 +380,15 @@ export function registerAsk(pi: ExtensionAPI) {
 				};
 			}
 
-			// Emit bus event so notify (if installed) can schedule a desktop notification
-			getBus().emit(Events.ASK_REQUEST, { source: "main", requestId: randomUUID(), questions: params.questions });
-
 			if (params.questions.length === 0) {
 				return {
 					content: [{ type: "text", text: "Error: questions must not be empty" }],
 					details: {},
 				};
 			}
+
+			// Emit bus event so notify (if installed) can schedule a desktop notification
+			getBus().emit(Events.ASK_REQUEST, { source: "main", requestId: randomUUID(), questions: params.questions });
 
 			if (params.questions.length === 1) {
 				const q = params.questions[0]!;

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -201,6 +201,9 @@ export function registerAsk(pi: ExtensionAPI) {
 			questions: AskQuestion[];
 		};
 
+		// Skip main agent — it shows its own UI in the tool handler
+		if (data.source === "main") return;
+
 		if (!data.questions || data.questions.length === 0) return;
 
 		// Defer to next tick so TUI can process current state
@@ -228,9 +231,6 @@ export function registerAsk(pi: ExtensionAPI) {
 		questions: AskQuestion[];
 	}) {
 		if (!currentCtx?.ui) return;
-
-		// Emit bus event so notify (if installed) can schedule a desktop notification
-		getBus().emit(Events.ASK_REQUEST, { source: "subagent", requestId: data.requestId, questions: data.questions });
 
 		const questions = data.questions;
 		let cancelled = true;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/core",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/diff",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/footer",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/packages/image-paste/package.json
+++ b/packages/image-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/image-paste",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -1,0 +1,66 @@
+# @pi-archimedes/notify
+
+Delayed desktop notifications with circuit breaker for the [Pi coding agent](https://github.com/earendil-works/pi).
+
+## Features
+
+- **Delayed notification** — fires only after a configurable period of inactivity (default 30s), so you're not spammed when actively working
+- **Circuit breaker** — any keystroke immediately cancels a pending notification via raw terminal input listening
+- **Terminal-aware dispatch** — auto-detects your terminal and uses the optimal protocol:
+  - Kitty → OSC 99 (two-sequence title + body)
+  - iTerm2 → OSC 9
+  - Windows Terminal → PowerShell toast (ToastText02)
+  - Ghostty, WezTerm, others → OSC 777 fallback
+- **tmux passthrough** — all sequences wrapped via DCS for correct rendering inside tmux
+- **Per-trigger toggles** — independently enable/disable notifications for task completion and unanswered questions
+- **Bus-driven** — listens for `agent_end` and `ASK_REQUEST` bus events, so it works with any package that emits them
+
+## Screenshots
+
+### Kitty notification
+
+Notification from Kitty terminal showing title and body via OSC 99:
+
+![notify kitty](../../docs/images/notify-kitty.png)
+
+## Installation
+
+```bash
+pi install @pi-archimedes/notify
+```
+
+Or install the full [pi-archimedes](../..) meta package for the integrated experience:
+
+```bash
+pi install pi-archimedes
+```
+
+## Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable desktop notifications |
+| `notifyOnAgentEnd` | bool | `true` | Notify when agent finishes a task |
+| `notifyOnQuestion` | bool | `true` | Notify when a question needs your answer |
+| `delayMs` | number | `30` | Seconds to wait before sending notification (stored as ms) |
+
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.notify` namespace.
+
+## How it works
+
+When the agent finishes a task (`agent_end`) or a question is asked (`ASK_REQUEST`), a timer starts. If you don't interact for the configured delay, a desktop notification fires. Any keystroke — even just pressing a key without submitting — cancels the timer immediately.
+
+## Terminal compatibility
+
+| Terminal | Protocol | Title + Body |
+|----------|----------|--------------|
+| Kitty | OSC 99 | ✅ |
+| iTerm2 | OSC 9 | Body only |
+| Windows Terminal | PowerShell toast | ✅ |
+| Ghostty | OSC 777 | ✅ |
+| WezTerm | OSC 777 | ✅ |
+| tmux (any above) | DCS passthrough | ✅ |
+
+## Integration
+
+When installed via `pi-archimedes` (the meta package), the notify package is automatically registered and its settings appear in the `/archimedes` settings panel. Standalone installs work independently — any package emitting `agent_end` or `ASK_REQUEST` bus events will trigger notifications.

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -2,10 +2,17 @@
   "name": "@pi-archimedes/notify",
   "version": "1.3.4",
   "type": "module",
-  "keywords": ["pi-package"],
-  "description": "Delayed desktop notifications with circuit breaker — notify only when you've stepped away",
-  "files": ["src"],
+  "keywords": [
+    "pi-package"
+  ],
+  "description": "Delayed desktop notifications with circuit breaker for pi-archimedes",
+  "files": [
+    "src"
+  ],
   "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "dependencies": {
     "@pi-archimedes/core": "workspace:*"
   },
@@ -17,6 +24,8 @@
     "typescript": "^6.0.0"
   },
   "pi": {
-    "extensions": ["./src/index.ts"]
+    "extensions": [
+      "./src/index.ts"
+    ]
   }
 }

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pi-archimedes/notify",
+  "version": "1.3.4",
+  "type": "module",
+  "keywords": ["pi-package"],
+  "description": "Delayed desktop notifications with circuit breaker — notify only when you've stepped away",
+  "files": ["src"],
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@pi-archimedes/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.1.0",
+    "@earendil-works/pi-tui": ">=0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.0"
+  },
+  "pi": {
+    "extensions": ["./src/index.ts"]
+  }
+}

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -165,9 +165,7 @@ export function scheduleNotify(trigger: "agent_end" | "ask_request"): void {
   }, config.delayMs);
 
   // Don't block process exit
-  if (notifyTimer && typeof (notifyTimer as any).unref === "function") {
-    (notifyTimer as any).unref();
-  }
+  notifyTimer.unref();
 }
 
 /** Fire the actual notification based on the pending trigger. */

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -1,7 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { SettingItem } from "@earendil-works/pi-tui";
 import { loadConfig, saveConfig } from "@pi-archimedes/core/settings-io";
-import { getBus, Events } from "@pi-archimedes/core/bus";
 import { execFile } from "node:child_process";
 
 // ── Config ──────────────────────────────────────────────────────────────────
@@ -186,14 +185,7 @@ export function registerNotify(pi: ExtensionAPI): void {
   pi.on("before_agent_start", () => cancelPending());
   pi.on("agent_start", () => cancelPending());
 
-  const unsubAskRequest = getBus().on(Events.ASK_REQUEST, () =>
-    scheduleNotify("ask_request"),
-  );
-
-  pi.on("session_shutdown", () => {
-    cancelPending();
-    unsubAskRequest();
-  });
+  pi.on("session_shutdown", () => cancelPending());
 }
 
 // ── Settings UI ─────────────────────────────────────────────────────────────

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -17,7 +17,7 @@ export const DEFAULT_NOTIFY_CONFIG: NotifyConfig = {
   enabled: true,
   notifyOnAgentEnd: true,
   notifyOnQuestion: true,
-  delayMs: 60_000,
+  delayMs: 30_000,
 };
 
 const NAMESPACE = "archimedes.notify";

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -201,7 +201,6 @@ export function registerNotify(pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", () => {
     cancelPending();
-    unsubAskRequest();
     unsubTerminalInput?.();
   });
 }

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -1,0 +1,231 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { SettingItem } from "@earendil-works/pi-tui";
+import { loadConfig, saveConfig } from "@pi-archimedes/core/settings-io";
+import { getBus, Events } from "@pi-archimedes/core/bus";
+import { execFile } from "node:child_process";
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+export interface NotifyConfig {
+  enabled: boolean;
+  notifyOnAgentEnd: boolean;
+  notifyOnQuestion: boolean;
+  delayMs: number;
+}
+
+export const DEFAULT_NOTIFY_CONFIG: NotifyConfig = {
+  enabled: true,
+  notifyOnAgentEnd: true,
+  notifyOnQuestion: true,
+  delayMs: 60_000,
+};
+
+const NAMESPACE = "archimedes.notify";
+
+export function loadNotifyConfig(): NotifyConfig {
+  return loadConfig(NAMESPACE, DEFAULT_NOTIFY_CONFIG);
+}
+
+export function saveNotifyConfig(config: NotifyConfig): void {
+  saveConfig(NAMESPACE, config);
+}
+
+// ── Terminal detection helpers ──────────────────────────────────────────────
+
+/** Wrap an OSC sequence for tmux passthrough. */
+export function wrapForTmux(sequence: string): string {
+  if (!process.env.TMUX) {
+    return sequence;
+  }
+  // Escape inner ESC characters so tmux doesn't interpret them
+  const escaped = sequence.replace(/\x1b/g, "\x1b\x1b");
+  return `\x1bPtmux;${escaped}\x1b\\`;
+}
+
+// ── OSC notification dispatchers ────────────────────────────────────────────
+
+/** OSC 777 — generic notify (used as fallback) */
+export function notifyOSC777(title: string, body: string): void {
+  const seq = `\x1b]777;notify;${title};${body}\x07`;
+  process.stderr.write(wrapForTmux(seq));
+}
+
+/** OSC 9 — Konsole / generic terminal */
+export function notifyOSC9(message: string): void {
+  const seq = `\x1b]9;${message}\x07`;
+  process.stderr.write(wrapForTmux(seq));
+}
+
+/** OSC 99 — Kitty terminal */
+export function notifyOSC99(title: string, body: string): void {
+  const seq1 = `\x1b]99;i=1:d=0;${title}\x1b\\`;
+  const seq2 = `\x1b]99;i=1:p=${body}\x1b\\`;
+  process.stderr.write(wrapForTmux(seq1));
+  process.stderr.write(wrapForTmux(seq2));
+}
+
+/** Windows Terminal — PowerShell toast notification */
+export function notifyWindows(title: string, body: string): void {
+  const script = windowsToastScript(title, body);
+  execFile(
+    "powershell.exe",
+    ["-NoProfile", "-Command", script],
+    { shell: false },
+    () => {
+      /* ignore */
+    },
+  );
+}
+
+/** Generate a self-contained PowerShell script for toast notifications */
+export function windowsToastScript(title: string, body: string): string {
+  // Escape single quotes for PowerShell string interpolation
+  const escapedTitle = title.replace(/'/g, "''");
+
+  return [
+    "Add-Type -AssemblyName System.Runtime.WindowsRuntime",
+    "Add-Type -AssemblyName System.Runtime.InteropServices.WindowsRuntime",
+    '$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText01)',
+    '$text = $xml.GetElementsByTagName("text")[0]',
+    "$text.InnerText = '" + escapedTitle + "'",
+    '$toast = New-Object Windows.UI.Notifications.ToastNotification $xml',
+    "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Pi').Show($toast)",
+  ].join(";");
+}
+
+// ── Main notify dispatcher ──────────────────────────────────────────────────
+
+/** Dispatch a notification to the appropriate terminal handler. */
+export function notify(title: string, body: string): void {
+  // 1. Windows Terminal
+  if (process.env.WT_SESSION) {
+    notifyWindows(title, body);
+    return;
+  }
+
+  // 2. Kitty
+  if (process.env.KITTY_WINDOW_ID) {
+    notifyOSC99(title, body);
+    return;
+  }
+
+  // 3. iTerm2
+  if (process.env.TERM_PROGRAM === "iTerm.app" || process.env.ITERM_SESSION_ID) {
+    notifyOSC9(body);
+    return;
+  }
+
+  // 4. Fallback — OSC 777
+  notifyOSC777(title, body);
+}
+
+// ── Circuit breaker state ───────────────────────────────────────────────────
+
+let notifyTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingTrigger: "agent_end" | "ask_request" | null = null;
+
+// ── Circuit breaker logic ───────────────────────────────────────────────────
+
+/** Cancel any pending notification timer. */
+export function cancelPending(): void {
+  if (notifyTimer) {
+    clearTimeout(notifyTimer);
+    notifyTimer = null;
+  }
+  pendingTrigger = null;
+}
+
+/** Schedule a delayed notification (circuit breaker). */
+export function scheduleNotify(trigger: "agent_end" | "ask_request"): void {
+  // Cancel any existing timer first
+  cancelPending();
+
+  // Load config fresh on each trigger
+  const config = loadNotifyConfig();
+
+  if (!config.enabled) {
+    return;
+  }
+
+  if (trigger === "agent_end" && !config.notifyOnAgentEnd) {
+    return;
+  }
+
+  if (trigger === "ask_request" && !config.notifyOnQuestion) {
+    return;
+  }
+
+  pendingTrigger = trigger;
+  notifyTimer = setTimeout(() => {
+    fireNotification(pendingTrigger);
+    notifyTimer = null;
+    pendingTrigger = null;
+  }, config.delayMs);
+
+  // Don't block process exit
+  if (notifyTimer && typeof (notifyTimer as any).unref === "function") {
+    (notifyTimer as any).unref();
+  }
+}
+
+/** Fire the actual notification based on the pending trigger. */
+function fireNotification(trigger: "agent_end" | "ask_request" | null): void {
+  if (trigger === "agent_end") {
+    notify("Pi", "Task complete — waiting for input");
+  } else {
+    notify("Pi", "A question needs your answer");
+  }
+}
+
+// ── Registration ────────────────────────────────────────────────────────────
+
+/** Register the notify extension with the Pi agent. */
+export function registerNotify(pi: ExtensionAPI): void {
+  pi.on("agent_end", () => scheduleNotify("agent_end"));
+  pi.on("input", () => cancelPending());
+  pi.on("agent_start", () => cancelPending());
+
+  const unsubAskRequest = getBus().on(Events.ASK_REQUEST, () =>
+    scheduleNotify("ask_request"),
+  );
+
+  pi.on("session_shutdown", () => {
+    cancelPending();
+    unsubAskRequest();
+  });
+}
+
+// ── Settings UI ─────────────────────────────────────────────────────────────
+
+/** Build settings UI items for the notify package. */
+export function getNotifySettingsItems(config: NotifyConfig): SettingItem[] {
+  return [
+    {
+      id: "enabled",
+      label: "Notifications",
+      description: "Enable desktop notifications",
+      currentValue: config.enabled ? "On" : "Off",
+      values: ["On", "Off"],
+    },
+    {
+      id: "notifyOnAgentEnd",
+      label: "Notify on task complete",
+      description: "Notify when agent finishes a task",
+      currentValue: config.notifyOnAgentEnd ? "On" : "Off",
+      values: ["On", "Off"],
+    },
+    {
+      id: "notifyOnQuestion",
+      label: "Notify on question",
+      description: "Notify when a question needs your answer",
+      currentValue: config.notifyOnQuestion ? "On" : "Off",
+      values: ["On", "Off"],
+    },
+    {
+      id: "delayMs",
+      label: "Delay before notify",
+      description: "Seconds to wait before sending notification",
+      currentValue: String(config.delayMs / 1000) + "s",
+    },
+  ];
+}

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SettingItem } from "@earendil-works/pi-tui";
 import { loadConfig, saveConfig } from "@pi-archimedes/core/settings-io";
+import { getBus, Events } from "@pi-archimedes/core/bus";
 import { execFile } from "node:child_process";
 
 // ── Config ──────────────────────────────────────────────────────────────────
@@ -185,6 +186,11 @@ export function registerNotify(pi: ExtensionAPI): void {
   pi.on("before_agent_start", () => cancelPending());
   pi.on("agent_start", () => cancelPending());
 
+  // Listen for ask requests from the bus (ask package emits this)
+  const unsubAskRequest = getBus().on(Events.ASK_REQUEST, () =>
+    scheduleNotify("ask_request"),
+  );
+
   // Listen for raw terminal keystrokes — cancel on any key press
   let unsubTerminalInput: (() => void) | null = null;
   pi.on("session_start", (_event, ctx: ExtensionContext) => {
@@ -195,6 +201,7 @@ export function registerNotify(pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", () => {
     cancelPending();
+    unsubAskRequest();
     unsubTerminalInput?.();
   });
 }

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -183,6 +183,7 @@ function fireNotification(trigger: "agent_end" | "ask_request" | null): void {
 export function registerNotify(pi: ExtensionAPI): void {
   pi.on("agent_end", () => scheduleNotify("agent_end"));
   pi.on("input", () => cancelPending());
+  pi.on("before_agent_start", () => cancelPending());
   pi.on("agent_start", () => cancelPending());
 
   const unsubAskRequest = getBus().on(Events.ASK_REQUEST, () =>

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -81,13 +81,15 @@ export function notifyWindows(title: string, body: string): void {
 export function windowsToastScript(title: string, body: string): string {
   // Escape single quotes for PowerShell string interpolation
   const escapedTitle = title.replace(/'/g, "''");
+  const escapedBody = body.replace(/'/g, "''");
 
   return [
     "Add-Type -AssemblyName System.Runtime.WindowsRuntime",
     "Add-Type -AssemblyName System.Runtime.InteropServices.WindowsRuntime",
-    '$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText01)',
-    '$text = $xml.GetElementsByTagName("text")[0]',
-    "$text.InnerText = '" + escapedTitle + "'",
+    '$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)',
+    '$textNodes = $xml.GetElementsByTagName("text")',
+    "$textNodes.Item(0).InnerText = '" + escapedTitle + "'",
+    "$textNodes.Item(1).InnerText = '" + escapedBody + "'",
     '$toast = New-Object Windows.UI.Notifications.ToastNotification $xml',
     "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Pi').Show($toast)",
   ].join(";");

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SettingItem } from "@earendil-works/pi-tui";
 import { loadConfig, saveConfig } from "@pi-archimedes/core/settings-io";
 import { execFile } from "node:child_process";
@@ -185,7 +185,18 @@ export function registerNotify(pi: ExtensionAPI): void {
   pi.on("before_agent_start", () => cancelPending());
   pi.on("agent_start", () => cancelPending());
 
-  pi.on("session_shutdown", () => cancelPending());
+  // Listen for raw terminal keystrokes — cancel on any key press
+  let unsubTerminalInput: (() => void) | null = null;
+  pi.on("session_start", (_event, ctx: ExtensionContext) => {
+    unsubTerminalInput = ctx.ui.onTerminalInput((_data) => {
+      cancelPending();
+    });
+  });
+
+  pi.on("session_shutdown", () => {
+    cancelPending();
+    unsubTerminalInput?.();
+  });
 }
 
 // ── Settings UI ─────────────────────────────────────────────────────────────

--- a/packages/notify/tsconfig.json
+++ b/packages/notify/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/subagent/package.json
+++ b/packages/subagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/subagent",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-archimedes/todo",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,22 @@ importers:
         specifier: ^6.0.0
         version: 6.0.3
 
+  packages/notify:
+    dependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: '>=0.1.0'
+        version: 0.78.0(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: '>=0.1.0'
+        version: 0.78.0
+      '@pi-archimedes/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+
   packages/subagent:
     dependencies:
       '@earendil-works/pi-ai':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@pi-archimedes/image-paste':
         specifier: workspace:*
         version: link:../packages/image-paste
+      '@pi-archimedes/notify':
+        specifier: workspace:*
+        version: link:../packages/notify
       '@pi-archimedes/subagent':
         specifier: workspace:*
         version: link:../packages/subagent


### PR DESCRIPTION
## Summary

Add `@pi-archimedes/notify` — a delayed desktop notification package with circuit breaker timeout. Notifications fire on `agent_end` (task complete) and `ASK_REQUEST` (question needs answer), but are cancelled if the user interacts (keystroke or new agent start).

### Features
- **Terminal-aware dispatch**: Ghostty/WezTerm (OSC 777), iTerm2 (OSC 9), Kitty (OSC 99), Windows Terminal (PowerShell toast)
- **tmux passthrough**: All OSC sequences wrapped via DCS for tmux compatibility
- **Circuit breaker**: Configurable delay (default 60s) — notification only fires if you've actually stepped away
- **Per-trigger toggles**: Enable/disable notifications independently for task-complete and questions
- **Settings integration**: 4 settings items in `/archimedes` panel with delay number submenu

### Commits
- `8e0d2ba` feat: add @pi-archimedes/notify package with circuit breaker notifications
- `0382e9f` feat: wire notify package into meta settings and registration
- `3b701f5` chore: update docs and release workflow for notify package
- `ea84fd3` fix(notify): use ToastText02 template to show body in Windows toast
- `a4edd93` chore: bump all package versions to 1.3.4
- `cad42f9` fix: correct README delayMs default unit from ms to seconds
- `8210f53` refactor(notify): simplify unref call — remove unnecessary guard

### Compatibility

| Terminal | Protocol | Status |
|----------|----------|--------|
| Ghostty / WezTerm | OSC 777 | ✅ |
| iTerm2 | OSC 9 | ✅ |
| Kitty | OSC 99 | ✅ |
| Windows Terminal | PowerShell toast | ✅ |
| tmux (any of above) | DCS passthrough | ✅ |

### Test plan
- [ ] Install via `pi install pi-archimedes` (or symlink) and verify `/archimedes` shows 4 notify settings
- [ ] Set delay to a low value (e.g. 5s) and step away — verify notification fires
- [ ] Type a key before delay expires — verify notification is cancelled
- [ ] Test on each supported terminal (OSC 777, 9, 99, Windows)
- [ ] Test inside tmux — verify passthrough works
- [ ] Toggle individual triggers off — verify only enabled triggers fire


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Notify component for desktop/terminal notifications with optional delayed delivery and trigger controls.
  * Added Notify settings (enabled, notify on agent end, notify on question, and delay) to the app settings UI.
* **Bug Fixes**
  * Improved request handling so notifications and UI behavior are better aligned between main and subagent flows.
* **Documentation**
  * Updated README, plans, and monorepo layout docs to include the new Notify package and settings.
* **Chores**
  * Bumped versions and updated release/publish order to include the Notify package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->