### PR TITLE
test: add vitest test suite (169 tests across core, diff, footer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Type-check all packages
         run: pnpm -r exec -- tsc --noEmit
+
+      - name: Test
+        run: pnpm test

--- a/docs/plans/2026-07-05-add-tests.md
+++ b/docs/plans/2026-07-05-add-tests.md
@@ -1,0 +1,266 @@
+# Add Tests Plan
+
+**Goal:** Add Vitest unit tests for pure-logic functions across the monorepo (~50-70 test cases).
+**Architecture:** Root Vitest workspace config pointing to all 8 packages. Tests live inline as `src/foo.test.ts` next to source files. No build step — Vitest handles TypeScript directly.
+**Tech Stack:** Vitest (workspace mode), Node environment, no mocking framework needed (pure logic only).
+
+---
+
+### Task 1: Vitest Infrastructure
+
+**Context:**
+Set up the testing infrastructure — Vitest workspace config, per-package configs, and root test script. This is pure configuration with no test code yet. After this task, `pnpm test` should run (finding 0 tests) without error.
+
+**Files:**
+- Modify: `package.json` (root) — add vitest devDependency and test script
+- Create: `vitest.workspace.ts` (root)
+- Create: `packages/core/vitest.config.ts`
+- Create: `packages/diff/vitest.config.ts`
+- Create: `packages/footer/vitest.config.ts`
+- Create: `packages/subagent/vitest.config.ts`
+- Create: `packages/todo/vitest.config.ts`
+- Create: `packages/notify/vitest.config.ts`
+- Create: `packages/ask/vitest.config.ts`
+- Create: `packages/image-paste/vitest.config.ts`
+
+**What to implement:**
+
+1. **Root `package.json`** — add to `scripts` and `devDependencies`:
+   ```json
+   "scripts": {
+     "preinstall": "...",
+     "test": "vitest run"
+   },
+   "devDependencies": {
+     "vitest": "^3.0.0"
+   }
+   ```
+   Do NOT modify any other fields.
+
+2. **Root `vitest.workspace.ts`**:
+   ```ts
+   import { defineWorkspace } from "vitest/config";
+   export default defineWorkspace([
+     "packages/core",
+     "packages/diff",
+     "packages/footer",
+     "packages/subagent",
+     "packages/todo",
+     "packages/notify",
+     "packages/ask",
+     "packages/image-paste",
+   ]);
+
+   // Note: meta is excluded — it is the orchestrator (depends on all packages) and
+   // has no pure-logic functions to test in isolation.
+   ```
+
+3. **Each `packages/*/vitest.config.ts`** — identical content for all 8 packages:
+   ```ts
+   import { defineConfig } from "vitest/config";
+   export default defineConfig({
+     test: {
+       environment: "node",
+       include: ["src/**/*.test.ts"],
+       exclude: ["**/node_modules/**"],
+     },
+   });
+   ```
+
+**Steps:**
+- [ ] Add vitest to root package.json devDependencies and test script
+- [ ] Run `pnpm install`
+- [ ] Create `vitest.workspace.ts` at root
+- [ ] Create `vitest.config.ts` in each of the 8 package directories
+- [ ] Run `pnpm test` — should complete with 0 tests found (no error)
+- [ ] Run `pnpm -r exec -- tsc --noEmit` — ensure type-check still passes
+- [ ] Commit with message: "chore: add vitest test infrastructure"
+
+**Acceptance criteria:**
+- [ ] `pnpm test` runs without error (0 tests is fine)
+- [ ] `pnpm -r exec -- tsc --noEmit` still passes
+- [ ] All config files are valid TypeScript
+
+---
+
+### Task 2: Core Package Tests (color, text, bus)
+
+**Context:**
+Test the pure-logic functions in `@pi-archimedes/core`. These are the most reusable utilities — color conversion, ANSI stripping, key formatting, and the pub/sub bus. All are testable without mocking external dependencies (bus uses globalThis which we reset between tests).
+
+**Files:**
+- Create: `packages/core/src/color.test.ts`
+- Create: `packages/core/src/text.test.ts`
+- Create: `packages/core/src/bus.test.ts`
+
+**What to implement:**
+
+1. **`packages/core/src/color.test.ts`** — test all exported functions from `color.ts`:
+   - `hexToRgb`: valid 6-char hex, 3-char shorthand, with/without `#`, invalid input throws
+   - `rgbToHex`: round-trip with hexToRgb, clamps to 0-255
+   - `rgbToHsl`: grayscale (r=g=b), pure red/green/blue, white, black
+   - `hslToRgb`: round-trip with rgbToHsl, s=0 produces grayscale, h wraps at 360
+   - `ansi256ToRgb`: codes 0-15 (xterm palette), 16-231 (6x6x6 cube), 232-255 (grayscale), out-of-range throws
+   - `parseAnsiFgToRgb`: truecolor sequence (`\x1b[38;2;R;G;Bm`), 256 palette (`\x1b[38;5;Nm`), null/empty input
+   - `deriveDimColor`: number input (ansi256), string input (hex), saturationFactor default 0.5, lightness clamping
+   - `rgbToTruecolorFg`: produces correct `\x1b[38;2;R;G;Bm` format
+   - `gray`: produces truecolor gray with correct level, clamps 0-255
+   - `rgb`: produces truecolor with correct values
+   - `extractRgb`: extracts from themed string, returns [100,100,100] default
+   - `lerp`: t=0 returns a, t=1 returns b, t=0.5 returns midpoint
+
+2. **`packages/core/src/text.test.ts`** — test pure functions from `text.ts`:
+   - `stripAnsi`: CSI sequences, OSC sequences, DCS/SOS/APC/PM, character set escapes, nested escapes, empty string, no-escape string
+   - `isParentBorder`: border char `─` returns true, border with SGR returns true, non-border returns false, empty returns false
+   - `formatKey`: `ctrl+a` → `Ctrl+A`, `alt+shift+f` → `Alt+Shift+F`, `cmd` → `Cmd`, `meta` → `Cmd`, single char uppercase, multi-word capitalize, undefined returns "that key"
+   - Skip `clampLine` and `clampLines` — these depend on `@earendil-works/pi-tui` which is a peer dep not available in tests
+
+3. **`packages/core/src/bus.test.ts`** — test pub/sub + queue from `bus.ts`:
+   - **CRITICAL:** Each test must reset `globalThis[Symbol.for("archimedes:bus")]` and `globalThis[Symbol.for("archimedes:busQueue")]` in `afterEach` to avoid test pollution
+   - `emit` → `on` delivery: subscriber receives payload
+   - Multiple subscribers: all receive the event
+   - Unsubscribe: removed subscriber does not receive subsequent events
+   - Error isolation: one listener throwing does not prevent others from receiving
+   - Late subscriber queue: events emitted before `on()` are delivered when subscriber registers
+   - `initBus`: flushes queued events
+   - `Events` constant: verify all event names are defined
+
+**Steps:**
+- [ ] Write `color.test.ts` with all test cases listed above
+- [ ] Run `pnpm test -- packages/core/src/color.test.ts` — verify all pass
+- [ ] Write `text.test.ts` with all test cases listed above
+- [ ] Run `pnpm test -- packages/core/src/text.test.ts` — verify all pass
+- [ ] Write `bus.test.ts` with all test cases listed above (include globalThis cleanup)
+- [ ] Run `pnpm test -- packages/core/src/bus.test.ts` — verify all pass
+- [ ] Run `pnpm -r exec -- tsc --noEmit` — ensure type-check still passes
+- [ ] Commit with message: "test: add core package tests (color, text, bus)"
+
+**Acceptance criteria:**
+- [ ] All 3 test files pass with `pnpm test`
+- [ ] No test pollution (bus tests clean up globalThis)
+- [ ] `tsc --noEmit` still passes across all packages
+
+---
+
+### Task 3: Diff Package Tests (ansi width, manip, word-diff)
+
+**Context:**
+Test the ANSI manipulation and width calculation utilities in `@pi-archimedes/diff`. These are critical for correct diff rendering — width miscalculations cause TUI overflow bugs.
+
+**Files:**
+- Create: `packages/diff/src/ansi/width.test.ts`
+- Create: `packages/diff/src/ansi/manip.test.ts`
+- Create: `packages/diff/src/word-diff.test.ts`
+
+**What to implement:**
+
+1. **`packages/diff/src/ansi/width.test.ts`** — test `width.ts`:
+   - `graphemeWidth`: ASCII letter = 1, CJK (e.g. `中`) = 2, emoji (e.g. `✅`) = 2, zero-width (combining marks) = 0, tab = 2
+   - `tokenize`: plain text produces single tokens, SGR sequence produces ansi+text pairs, bare ESC without `m` terminator handled gracefully, mixed ANSI + text
+   - `visibleWidth`: plain ASCII length matches, wide chars counted correctly, ANSI escapes don't add width, empty string = 0
+
+2. **`packages/diff/src/ansi/manip.test.ts`** — test `manip.ts`:
+   - `strip`: removes SGR sequences, empty string stays empty
+   - `tabs`: replaces `\t` with 2 spaces
+   - `fit`: truncates to width (ASCII), truncates to width (wide chars — never splits grapheme), pads short strings, width 0 returns empty, wide grapheme wider than budget is dropped
+   - `ansiState`: extracts last fg code, extracts last bg code, `\x1b[0m` resets both, truecolor fg/bg
+   - `isLowContrastShikiFg`: "30" = true, "90" = true, "38;5;0" = true, "38;5;8" = true, "38;2;0;0;0" = true, "38;2;255;255;255" = false, non-fg params = false
+   - `normalizeShikiContrast`: replaces low-contrast codes, leaves high-contrast alone
+   - `lnum`: formats number right-padded, null produces spaces
+   - `shortPath`: relative to cwd returns relative, outside cwd with home returns ~, empty returns empty
+   - `summarize`: +N -M format, zero changes returns "no changes"
+
+3. **`packages/diff/src/word-diff.test.ts`** — test `word-diff.ts`:
+   - `wordDiffAnalysis`: identical strings → similarity 1, empty ranges; completely different → similarity 0, full ranges; partial overlap → correct similarity and ranges
+   - `injectBg`: no ranges returns baseBg + line, single range highlights correctly, overlapping ranges merged, `\x1b[0m` triggers bg re-injection
+   - `plainWordDiff`: removed text gets del bg, added text gets add bg, unchanged passed through
+
+**Steps:**
+- [ ] Write `width.test.ts` with all test cases
+- [ ] Run `pnpm test -- packages/diff/src/ansi/width.test.ts` — verify all pass
+- [ ] Write `manip.test.ts` with all test cases
+- [ ] Run `pnpm test -- packages/diff/src/ansi/manip.test.ts` — verify all pass
+- [ ] Write `word-diff.test.ts` with all test cases
+- [ ] Run `pnpm test -- packages/diff/src/word-diff.test.ts` — verify all pass
+- [ ] Run `pnpm -r exec -- tsc --noEmit` — ensure type-check still passes
+- [ ] Commit with message: "test: add diff package tests (ansi, word-diff)"
+
+**Acceptance criteria:**
+- [ ] All 3 test files pass with `pnpm test`
+- [ ] Width tests cover CJK, emoji, and zero-width graphemes
+- [ ] `tsc --noEmit` still passes across all packages
+
+---
+
+### Task 4: Footer + Subagent Tests (format, cost-accumulator)
+
+**Context:**
+Test the formatting utilities in footer and the cost accumulator. These depend on core/bus (for CostAccumulator) and have interface dependencies (ColorFn for format functions) that need trivial mocks.
+
+**Files:**
+- Create: `packages/footer/src/utils/format.test.ts`
+- Create: `packages/footer/src/cost-accumulator.test.ts`
+
+**What to implement:**
+
+1. **`packages/footer/src/utils/format.test.ts`** — test `format.ts`:
+   - Mock `ColorFn` as `(token, text) => text` (passthrough — we test structure, not coloring)
+   - `formatTokenCount`: 0 → "0", 500 → "500", 1024 → "1.0k", 10240 → "10k", 1048576 → "1.0M", 10485760 → "10M"
+   - `formatContextBar`: 0% produces empty bar, 50% produces half-filled, 100% produces full bar, small availableSpace (≤2) returns empty
+   - `formatGitStatusIndicators`: zero counts returns empty, staged > 0 shows indicator, multiple counts shows all
+   - `formatThinkingIndicator`: "off" returns empty, other levels return indicator
+
+2. **`packages/footer/src/cost-accumulator.test.ts`** — test `cost-accumulator.ts`:
+   - **CRITICAL:** Reset `globalThis[Symbol.for("archimedes:bus")]` and `globalThis[Symbol.for("archimedes:busQueue")]` in `afterEach`
+   - Create accumulator → subscribe → emit cost events → verify accumulated values
+   - `reset()` zeroes all counters
+   - `dispose()` unsubscribes (subsequent events not accumulated)
+   - Multiple cost updates accumulate correctly
+   - Missing fields in payload default to 0
+
+**Steps:**
+- [ ] Write `format.test.ts` with mock ColorFn and all test cases
+- [ ] Run `pnpm test -- packages/footer/src/utils/format.test.ts` — verify all pass
+- [ ] Write `cost-accumulator.test.ts` with bus cleanup and all test cases
+- [ ] Run `pnpm test -- packages/footer/src/cost-accumulator.test.ts` — verify all pass
+- [ ] Run `pnpm -r exec -- tsc --noEmit` — ensure type-check still passes
+- [ ] Commit with message: "test: add footer and subagent tests (format, cost-accumulator)"
+
+**Acceptance criteria:**
+- [ ] Both test files pass with `pnpm test`
+- [ ] CostAccumulator tests properly clean up bus globalThis state
+- [ ] `tsc --noEmit` still passes across all packages
+
+---
+
+### Task 5: CI Integration
+
+**Context:**
+Add the test step to the existing CI workflow so tests run on every push and PR. This ensures regressions are caught before merge.
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**What to implement:**
+
+Add a test step after the type-check step in `ci.yml`:
+
+```yaml
+      - name: Test
+        run: pnpm test
+```
+
+Insert this step after the "Type-check all packages" step. The test step uses `pnpm test` which runs `vitest run` (non-watch, exits with code 0 on success, non-zero on failure).
+
+Do NOT modify any other parts of the workflow.
+
+**Steps:**
+- [ ] Add the test step to `.github/workflows/ci.yml` after the typecheck step
+- [ ] Run `pnpm test` locally to verify full test suite passes
+- [ ] Run `pnpm -r exec -- tsc --noEmit` to verify type-check still passes
+- [ ] Commit with message: "ci: add test step to CI workflow"
+
+**Acceptance criteria:**
+- [ ] `pnpm test` passes locally (all tests across all packages)
+- [ ] CI workflow file is valid YAML
+- [ ] Test step is positioned after typecheck in the workflow

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,7 +18,9 @@
 ## In Progress
 
 | Plan | Status | Created |
+| [Add Tests](plans/2026-07-05-add-tests.md) | 🚧 IN PROGRESS | 2026-07-05 |
+
 ## Quick Stats
 
-- Total Plans: 11
+- Total Plans: 12
 - Completed: 11

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,7 @@
 ## Completed Plans
 
 | Plan | Status | Created |
+| [Add Tests](plans/2026-07-05-add-tests.md) | ✅ COMPLETED (PR #17) | 2026-07-05 |
 | [Stacked, flicker-free parallel subagent rendering](plans/2026-07-04-stacked-parallel-subagents.md) | ✅ COMPLETED (PR #16) | 2026-07-04 |
 | [Fix Core Bus Bug and Standardize Ask Package](plans/2026-07-03-fix-core-and-ask.md) | ✅ COMPLETED | 2026-07-03 |
 | Diff wide-character width overflow fix (PR #14) | ✅ COMPLETED (PR #14) | 2026-07-03 |
@@ -18,9 +19,7 @@
 ## In Progress
 
 | Plan | Status | Created |
-| [Add Tests](plans/2026-07-05-add-tests.md) | 🚧 IN PROGRESS | 2026-07-05 |
-
 ## Quick Stats
 
 - Total Plans: 12
-- Completed: 11
+- Completed: 12

--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
   "type": "module",
   "packageManager": "pnpm@10.0.0",
   "scripts": {
-    "preinstall": "node -e \"if (!/pnpm/.test(process.env.npm_execpath || '')) { console.error('\\n  This project uses pnpm. Please use: pnpm install\\n'); process.exit(1); }\""
+    "preinstall": "node -e \"if (!/pnpm/.test(process.env.npm_execpath || '')) { console.error('\\n  This project uses pnpm. Please use: pnpm install\\n'); process.exit(1); }\"",
+    "test": "vitest run"
   },
   "pi": {
     "extensions": [
       "meta/src/index.ts"
     ]
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/ask/vitest.config.ts
+++ b/packages/ask/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/core/src/bus.test.ts
+++ b/packages/core/src/bus.test.ts
@@ -89,27 +89,55 @@ describe("late subscriber queue", () => {
 // ── initBus ─────────────────────────────────────────────────────────────────
 
 describe("initBus", () => {
-  it("flushes queued events", () => {
-    // Emit before bus exists — queues event
+  it("flushes queued events to subscribers that registered before init", () => {
+    // Emit before any subscriber exists — queues the event
     const bus = getBus();
-    bus.emit("init:event", "queued-before-init");
+    bus.emit("init:test", "queued-value");
 
-    // Create a new subscriber after init
-    // First, reset to simulate fresh start
-    delete (globalThis as Record<symbol, unknown>)[BUS_KEY];
-    delete (globalThis as Record<symbol, unknown>)[QUEUE_KEY];
-
-    // Emit before init — this queues
-    const preBus = getBus();
-    preBus.emit("init:event2", "queued");
-
-    // Now subscribe and init
+    // Subscribe — on() drains queue and delivers
     const received: unknown[] = [];
-    const freshBus = getBus();
-    freshBus.on("init:event2", (p) => received.push(p));
+    bus.on("init:test", (p) => received.push(p));
+    expect(received).toEqual(["queued-value"]);
+  });
 
-    // The event should be delivered when subscribing (queue drain on on())
+  it("initBus re-emits queued events through the bus", () => {
+    // Emit with no subscriber — queues
+    const bus = getBus();
+    bus.emit("init:test2", "queued");
+
+    // initBus re-emits through the bus
+    initBus();
+
+    // Since no subscriber for test2, re-emit goes back to queue.
+    // Now subscribe — on() drains the re-queued event
+    const received: unknown[] = [];
+    bus.on("init:test2", (p) => received.push(p));
     expect(received).toEqual(["queued"]);
+  });
+
+  it("initBus snapshots and clears queue before iterating", () => {
+    // Emit with no subscriber — queues
+    const bus = getBus();
+    bus.emit("snapshot:test", "a");
+    bus.emit("snapshot:test", "b");
+
+    // Subscribe — on() drains queue and delivers (but queue array persists)
+    const received: unknown[] = [];
+    bus.on("snapshot:test", (p) => received.push(p));
+    expect(received).toEqual(["a", "b"]);
+
+    // Queue array still has items (on() delivers but doesn't remove)
+    const queueBefore = (globalThis as Record<symbol, unknown>)[QUEUE_KEY] as Array<unknown>;
+    expect(queueBefore.length).toBe(2);
+
+    // initBus snapshots, clears queue, and re-emits
+    initBus();
+    // Re-emits go to existing subscriber (not re-queued)
+    expect(received).toEqual(["a", "b", "a", "b"]);
+
+    // Queue is now empty (initBus cleared it)
+    const queueAfter = (globalThis as Record<symbol, unknown>)[QUEUE_KEY] as Array<unknown>;
+    expect(queueAfter.length).toBe(0);
   });
 });
 

--- a/packages/core/src/bus.test.ts
+++ b/packages/core/src/bus.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getBus, initBus, Events } from "./bus.js";
+
+// ── globalThis cleanup ──────────────────────────────────────────────────────
+
+const BUS_KEY = Symbol.for("archimedes:bus");
+const QUEUE_KEY = Symbol.for("archimedes:busQueue");
+
+afterEach(() => {
+  // Reset globalThis bus and queue to avoid test pollution
+  delete (globalThis as Record<symbol, unknown>)[BUS_KEY];
+  delete (globalThis as Record<symbol, unknown>)[QUEUE_KEY];
+});
+
+// ── emit → on delivery ─────────────────────────────────────────────────────
+
+describe("emit → on delivery", () => {
+  it("subscriber receives payload", () => {
+    const bus = getBus();
+    const received: unknown[] = [];
+    bus.on("test:event", (payload) => received.push(payload));
+    bus.emit("test:event", { hello: "world" });
+    expect(received).toEqual([{ hello: "world" }]);
+  });
+});
+
+// ── multiple subscribers ────────────────────────────────────────────────────
+
+describe("multiple subscribers", () => {
+  it("all receive the event", () => {
+    const bus = getBus();
+    const a: unknown[] = [];
+    const b: unknown[] = [];
+    bus.on("multi", (p) => a.push(p));
+    bus.on("multi", (p) => b.push(p));
+    bus.emit("multi", "shared");
+    expect(a).toEqual(["shared"]);
+    expect(b).toEqual(["shared"]);
+  });
+});
+
+// ── unsubscribe ─────────────────────────────────────────────────────────────
+
+describe("unsubscribe", () => {
+  it("removed subscriber does not receive subsequent events", () => {
+    const bus = getBus();
+    const received: unknown[] = [];
+    const unsub = bus.on("unsub:test", (p) => received.push(p));
+    bus.emit("unsub:test", "first");
+    unsub();
+    bus.emit("unsub:test", "second");
+    expect(received).toEqual(["first"]);
+  });
+});
+
+// ── error isolation ─────────────────────────────────────────────────────────
+
+describe("error isolation", () => {
+  it("one listener throwing does not prevent others from receiving", () => {
+    const bus = getBus();
+    const received: unknown[] = [];
+    bus.on("err:test", () => {
+      throw new Error("boom");
+    });
+    bus.on("err:test", (p) => received.push(p));
+    bus.emit("err:test", "payload");
+    expect(received).toEqual(["payload"]);
+  });
+});
+
+// ── late subscriber queue ───────────────────────────────────────────────────
+
+describe("late subscriber queue", () => {
+  it("events emitted before on() are delivered when subscriber registers", () => {
+    // Create a fresh bus
+    const bus = getBus();
+
+    // Emit before anyone subscribes — this queues the event
+    bus.emit("queued:event", "queued-payload");
+
+    // Now subscribe — queued events should be delivered
+    const received: unknown[] = [];
+    bus.on("queued:event", (p) => received.push(p));
+
+    expect(received).toEqual(["queued-payload"]);
+  });
+});
+
+// ── initBus ─────────────────────────────────────────────────────────────────
+
+describe("initBus", () => {
+  it("flushes queued events", () => {
+    // Emit before bus exists — queues event
+    const bus = getBus();
+    bus.emit("init:event", "queued-before-init");
+
+    // Create a new subscriber after init
+    // First, reset to simulate fresh start
+    delete (globalThis as Record<symbol, unknown>)[BUS_KEY];
+    delete (globalThis as Record<symbol, unknown>)[QUEUE_KEY];
+
+    // Emit before init — this queues
+    const preBus = getBus();
+    preBus.emit("init:event2", "queued");
+
+    // Now subscribe and init
+    const received: unknown[] = [];
+    const freshBus = getBus();
+    freshBus.on("init:event2", (p) => received.push(p));
+
+    // The event should be delivered when subscribing (queue drain on on())
+    expect(received).toEqual(["queued"]);
+  });
+});
+
+// ── Events constant ─────────────────────────────────────────────────────────
+
+describe("Events constant", () => {
+  it("all event names are defined", () => {
+    expect(Events.COST_UPDATE).toBe("archimedes:cost_update");
+    expect(Events.TODOS_UPDATE).toBe("archimedes:todos_update");
+    expect(Events.TODOS_CLEAR).toBe("archimedes:todos_clear");
+    expect(Events.ASK_REQUEST).toBe("archimedes:ask_request");
+    expect(Events.ASK_RESPONSE).toBe("archimedes:ask_response");
+  });
+});

--- a/packages/core/src/color.test.ts
+++ b/packages/core/src/color.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from "vitest";
+import {
+  hexToRgb,
+  rgbToHex,
+  rgbToHsl,
+  hslToRgb,
+  ansi256ToRgb,
+  parseAnsiFgToRgb,
+  deriveDimColor,
+  rgbToTruecolorFg,
+  gray,
+  rgb,
+  extractRgb,
+  lerp,
+} from "./color.js";
+
+// ── hexToRgb ────────────────────────────────────────────────────────────────
+
+describe("hexToRgb", () => {
+  it("parses valid 6-char hex", () => {
+    expect(hexToRgb("#ff00aa")).toEqual({ r: 255, g: 0, b: 170 });
+  });
+
+  it("parses 3-char shorthand", () => {
+    expect(hexToRgb("#f0a")).toEqual({ r: 255, g: 0, b: 170 });
+  });
+
+  it("parses without hash prefix", () => {
+    expect(hexToRgb("ff00aa")).toEqual({ r: 255, g: 0, b: 170 });
+  });
+
+  it("parses with hash prefix", () => {
+    expect(hexToRgb("#ff00aa")).toEqual({ r: 255, g: 0, b: 170 });
+  });
+
+  it("handles mixed case", () => {
+    expect(hexToRgb("#Ff00Aa")).toEqual({ r: 255, g: 0, b: 170 });
+  });
+
+  it("throws on invalid input", () => {
+    expect(() => hexToRgb("#gggggg")).toThrow("Invalid hex color");
+    expect(() => hexToRgb("#ff")).toThrow("Invalid hex color");
+    expect(() => hexToRgb("#ffffffg")).toThrow("Invalid hex color");
+    expect(() => hexToRgb("")).toThrow("Invalid hex color");
+  });
+});
+
+// ── rgbToHex ────────────────────────────────────────────────────────────────
+
+describe("rgbToHex", () => {
+  it("round-trips with hexToRgb", () => {
+    const hex = "#ff00aa";
+    expect(rgbToHex(hexToRgb(hex))).toBe(hex.toLowerCase());
+  });
+
+  it("round-trips shorthand hex", () => {
+    const hex = "#f0a";
+    // Shorthand expands to 6-char, so round-trip is 6-char form
+    expect(rgbToHex(hexToRgb(hex))).toBe("#ff00aa");
+  });
+
+  it("clamps values to 0-255", () => {
+    expect(rgbToHex({ r: -10, g: 0, b: 0 })).toBe("#000000");
+    expect(rgbToHex({ r: 255, g: 300, b: 0 })).toBe("#ffff00");
+    expect(rgbToHex({ r: 255, g: 255, b: 255 })).toBe("#ffffff");
+  });
+
+  it("pads single-digit hex values", () => {
+    expect(rgbToHex({ r: 0, g: 0, b: 10 })).toBe("#00000a");
+  });
+});
+
+// ── rgbToHsl ────────────────────────────────────────────────────────────────
+
+describe("rgbToHsl", () => {
+  it("grayscale r=g=b returns s=0", () => {
+    const hsl = rgbToHsl({ r: 128, g: 128, b: 128 });
+    expect(hsl.s).toBe(0);
+    expect(hsl.h).toBe(0);
+    expect(hsl.l).toBeCloseTo(128 / 255);
+  });
+
+  it("pure red", () => {
+    const hsl = rgbToHsl({ r: 255, g: 0, b: 0 });
+    expect(hsl.h).toBe(0);
+    expect(hsl.s).toBe(1);
+    expect(hsl.l).toBe(0.5);
+  });
+
+  it("pure green", () => {
+    const hsl = rgbToHsl({ r: 0, g: 255, b: 0 });
+    expect(hsl.h).toBe(120);
+    expect(hsl.s).toBe(1);
+    expect(hsl.l).toBe(0.5);
+  });
+
+  it("pure blue", () => {
+    const hsl = rgbToHsl({ r: 0, g: 0, b: 255 });
+    expect(hsl.h).toBe(240);
+    expect(hsl.s).toBe(1);
+    expect(hsl.l).toBe(0.5);
+  });
+
+  it("white returns h=0, s=0, l=1", () => {
+    const hsl = rgbToHsl({ r: 255, g: 255, b: 255 });
+    expect(hsl.h).toBe(0);
+    expect(hsl.s).toBe(0);
+    expect(hsl.l).toBe(1);
+  });
+
+  it("black returns h=0, s=0, l=0", () => {
+    const hsl = rgbToHsl({ r: 0, g: 0, b: 0 });
+    expect(hsl.h).toBe(0);
+    expect(hsl.s).toBe(0);
+    expect(hsl.l).toBe(0);
+  });
+});
+
+// ── hslToRgb ────────────────────────────────────────────────────────────────
+
+describe("hslToRgb", () => {
+  it("round-trips with rgbToHsl for pure red", () => {
+    const hsl = rgbToHsl({ r: 255, g: 0, b: 0 });
+    expect(hslToRgb(hsl)).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it("round-trips with rgbToHsl for pure green", () => {
+    const hsl = rgbToHsl({ r: 0, g: 255, b: 0 });
+    expect(hslToRgb(hsl)).toEqual({ r: 0, g: 255, b: 0 });
+  });
+
+  it("round-trips with rgbToHsl for pure blue", () => {
+    const hsl = rgbToHsl({ r: 0, g: 0, b: 255 });
+    expect(hslToRgb(hsl)).toEqual({ r: 0, g: 0, b: 255 });
+  });
+
+  it("s=0 produces grayscale", () => {
+    const result = hslToRgb({ h: 0, s: 0, l: 0.5 });
+    expect(result.r).toBe(result.g);
+    expect(result.g).toBe(result.b);
+  });
+
+  it("h wraps at 360", () => {
+    const a = hslToRgb({ h: 0, s: 1, l: 0.5 });
+    const b = hslToRgb({ h: 360, s: 1, l: 0.5 });
+    expect(a).toEqual(b);
+  });
+
+  it("negative h wraps correctly", () => {
+    const a = hslToRgb({ h: 0, s: 1, l: 0.5 });
+    const b = hslToRgb({ h: -360, s: 1, l: 0.5 });
+    expect(a).toEqual(b);
+  });
+});
+
+// ── ansi256ToRgb ────────────────────────────────────────────────────────────
+
+describe("ansi256ToRgb", () => {
+  it("code 0 returns black", () => {
+    expect(ansi256ToRgb(0)).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  it("code 9 returns red", () => {
+    expect(ansi256ToRgb(9)).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it("code 15 returns white", () => {
+    expect(ansi256ToRgb(15)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("code 16 returns cube start (0,0,0)", () => {
+    expect(ansi256ToRgb(16)).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  it("code 196 returns cube red (255,0,0)", () => {
+    expect(ansi256ToRgb(196)).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it("code 231 returns cube end (255,255,255)", () => {
+    expect(ansi256ToRgb(231)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("code 232 returns grayscale start (8,8,8)", () => {
+    expect(ansi256ToRgb(232)).toEqual({ r: 8, g: 8, b: 8 });
+  });
+
+  it("code 255 returns grayscale end (238,238,238)", () => {
+    expect(ansi256ToRgb(255)).toEqual({ r: 238, g: 238, b: 238 });
+  });
+
+  it("out-of-range throws", () => {
+    expect(() => ansi256ToRgb(-1)).toThrow("out of range");
+    expect(() => ansi256ToRgb(256)).toThrow("out of range");
+  });
+});
+
+// ── parseAnsiFgToRgb ────────────────────────────────────────────────────────
+
+describe("parseAnsiFgToRgb", () => {
+  it("parses truecolor sequence", () => {
+    const result = parseAnsiFgToRgb("\x1b[38;2;255;128;64m");
+    expect(result).toEqual({ r: 255, g: 128, b: 64 });
+  });
+
+  it("parses 256 palette sequence", () => {
+    const result = parseAnsiFgToRgb("\x1b[38;5;196m");
+    expect(result).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseAnsiFgToRgb("")).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(parseAnsiFgToRgb(null as unknown as string)).toBeNull();
+  });
+
+  it("returns null for non-matching string", () => {
+    expect(parseAnsiFgToRgb("hello")).toBeNull();
+  });
+});
+
+// ── deriveDimColor ──────────────────────────────────────────────────────────
+
+describe("deriveDimColor", () => {
+  it("number input with anchorLightness", () => {
+    const result = deriveDimColor(100, 0.5);
+    expect(typeof result).toBe("string");
+    expect(result.startsWith("#")).toBe(true);
+  });
+
+  it("string hex input with custom saturationFactor", () => {
+    const result = deriveDimColor("#ff0000", 0.3, 0.7);
+    expect(typeof result).toBe("string");
+    expect(result.startsWith("#")).toBe(true);
+  });
+
+  it("default saturationFactor is 0.5", () => {
+    const withDefault = deriveDimColor("#ff0000", 0.5);
+    const explicit = deriveDimColor("#ff0000", 0.5, 0.5);
+    expect(withDefault).toBe(explicit);
+  });
+
+  it("lightness clamping — anchorLightness limits l", () => {
+    // Pure red has l=0.5, anchorLightness=0.2 should clamp to 0.2
+    const result = deriveDimColor("#ff0000", 0.2);
+    const hsl = rgbToHsl(hexToRgb(result));
+    expect(hsl.l).toBeLessThanOrEqual(0.2);
+  });
+});
+
+// ── rgbToTruecolorFg ────────────────────────────────────────────────────────
+
+describe("rgbToTruecolorFg", () => {
+  it("produces correct format", () => {
+    expect(rgbToTruecolorFg({ r: 255, g: 128, b: 64 })).toBe(
+      "\x1b[38;2;255;128;64m"
+    );
+  });
+
+  it("clamps values to 0-255", () => {
+    expect(rgbToTruecolorFg({ r: -1, g: 0, b: 300 })).toBe(
+      "\x1b[38;2;0;0;255m"
+    );
+  });
+});
+
+// ── gray ────────────────────────────────────────────────────────────────────
+
+describe("gray", () => {
+  it("produces truecolor gray with correct level", () => {
+    expect(gray(128, "hello")).toBe("\x1b[38;2;128;128;128mhello\x1b[0m");
+  });
+
+  it("clamps level to 0-255", () => {
+    expect(gray(-10, "x")).toBe("\x1b[38;2;0;0;0mx\x1b[0m");
+    expect(gray(300, "x")).toBe("\x1b[38;2;255;255;255mx\x1b[0m");
+  });
+});
+
+// ── rgb ─────────────────────────────────────────────────────────────────────
+
+describe("rgb", () => {
+  it("produces truecolor with correct values", () => {
+    expect(rgb(255, 128, 64, "text")).toBe(
+      "\x1b[38;2;255;128;64mtext\x1b[0m"
+    );
+  });
+
+  it("floors float values", () => {
+    expect(rgb(255.9, 128.1, 64.5, "x")).toBe(
+      "\x1b[38;2;255;128;64mx\x1b[0m"
+    );
+  });
+});
+
+// ── extractRgb ──────────────────────────────────────────────────────────────
+
+describe("extractRgb", () => {
+  it("extracts from themed string", () => {
+    expect(extractRgb("\x1b[38;2;200;100;50mhello")).toEqual([200, 100, 50]);
+  });
+
+  it("returns default for non-themed string", () => {
+    expect(extractRgb("plain text")).toEqual([100, 100, 100]);
+  });
+
+  it("returns default for empty string", () => {
+    expect(extractRgb("")).toEqual([100, 100, 100]);
+  });
+});
+
+// ── lerp ────────────────────────────────────────────────────────────────────
+
+describe("lerp", () => {
+  it("t=0 returns a", () => {
+    expect(lerp(10, 20, 0)).toBe(10);
+  });
+
+  it("t=1 returns b", () => {
+    expect(lerp(10, 20, 1)).toBe(20);
+  });
+
+  it("t=0.5 returns midpoint", () => {
+    expect(lerp(10, 20, 0.5)).toBe(15);
+  });
+
+  it("works with negative values", () => {
+    expect(lerp(-10, 10, 0.5)).toBe(0);
+  });
+});

--- a/packages/core/src/text.test.ts
+++ b/packages/core/src/text.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { stripAnsi, isParentBorder, formatKey } from "./text.js";
+
+// ── stripAnsi ───────────────────────────────────────────────────────────────
+
+describe("stripAnsi", () => {
+  it("strips CSI sequences", () => {
+    expect(stripAnsi("\x1b[31mhello\x1b[0m")).toBe("hello");
+  });
+
+  it("strips multiple CSI sequences", () => {
+    expect(stripAnsi("\x1b[1;32mred\x1b[0m \x1b[33myellow\x1b[0m")).toBe(
+      "red yellow"
+    );
+  });
+
+  it("strips OSC sequences", () => {
+    expect(stripAnsi("before\x1b]0;title\x07after")).toBe("beforeafter");
+  });
+
+  it("strips OSC with ST (ESC \\)", () => {
+    expect(stripAnsi("before\x1b]0;title\x1b\\after")).toBe("beforeafter");
+  });
+
+  it("strips DCS sequences", () => {
+    expect(stripAnsi("before\x1bPdata\x07after")).toBe("beforeafter");
+  });
+
+  it("strips SOS sequences", () => {
+    expect(stripAnsi("before\x1b^data\x07after")).toBe("beforeafter");
+  });
+
+  it("strips APC sequences", () => {
+    expect(stripAnsi("before\x1b_data\x07after")).toBe("beforeafter");
+  });
+
+  it("strips PM sequences", () => {
+    expect(stripAnsi("before\x1b\\data\x07after")).toBe("beforeafter");
+  });
+
+  it("strips character set escapes (ESC ( / ESC ))", () => {
+    // The regex strips ESC( and ESC) but not the following charset designator
+    expect(stripAnsi("before\x1b(Bafter")).toBe("beforeBafter");
+    expect(stripAnsi("before\x1b)Bafter")).toBe("beforeBafter");
+  });
+
+  it("handles nested escapes", () => {
+    expect(stripAnsi("\x1b[1m\x1b[31mhello\x1b[0m\x1b[0m")).toBe("hello");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+
+  it("returns input unchanged for no-escape string", () => {
+    expect(stripAnsi("plain text")).toBe("plain text");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(stripAnsi("  \x1b[31mhello\x1b[0m  ")).toBe("hello");
+  });
+});
+
+// ── isParentBorder ──────────────────────────────────────────────────────────
+
+describe("isParentBorder", () => {
+  it("returns true for border char", () => {
+    expect(isParentBorder("─")).toBe(true);
+  });
+
+  it("returns true for border with SGR", () => {
+    expect(isParentBorder("\x1b[90m─\x1b[0m")).toBe(true);
+  });
+
+  it("returns false for non-border", () => {
+    expect(isParentBorder("hello")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isParentBorder("")).toBe(false);
+  });
+});
+
+// ── formatKey ───────────────────────────────────────────────────────────────
+
+describe("formatKey", () => {
+  it("formats ctrl+a", () => {
+    expect(formatKey("ctrl+a")).toBe("Ctrl+A");
+  });
+
+  it("formats alt+shift+f", () => {
+    expect(formatKey("alt+shift+f")).toBe("Alt+Shift+F");
+  });
+
+  it("formats cmd as Cmd", () => {
+    expect(formatKey("cmd")).toBe("Cmd");
+  });
+
+  it("formats meta as Cmd", () => {
+    expect(formatKey("meta")).toBe("Cmd");
+  });
+
+  it("uppercases single char", () => {
+    expect(formatKey("a")).toBe("A");
+    expect(formatKey("z")).toBe("Z");
+  });
+
+  it("capitalizes multi-word", () => {
+    expect(formatKey("escape")).toBe("Escape");
+    expect(formatKey("enter")).toBe("Enter");
+  });
+
+  it("returns that key for undefined", () => {
+    expect(formatKey(undefined)).toBe("that key");
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/diff/src/ansi/manip.test.ts
+++ b/packages/diff/src/ansi/manip.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { strip, tabs, fit, ansiState, isLowContrastShikiFg, normalizeShikiContrast, lnum, shortPath, summarize } from "./manip.js";
+import * as C from "./codes.js";
+
+// ── strip ───────────────────────────────────────────────────────────────────
+
+describe("strip", () => {
+  it("removes SGR sequences", () => {
+    expect(strip("\x1b[31mred\x1b[0m")).toBe("red");
+    expect(strip("\x1b[1m\x1b[31mhi\x1b[0m")).toBe("hi");
+  });
+
+  it("empty string stays empty", () => {
+    expect(strip("")).toBe("");
+  });
+});
+
+// ── tabs ────────────────────────────────────────────────────────────────────
+
+describe("tabs", () => {
+  it("replaces \\t with 2 spaces", () => {
+    expect(tabs("a\tb")).toBe("a  b");
+    expect(tabs("\t")).toBe("  ");
+    expect(tabs("no\ttabs\there")).toBe("no  tabs  here");
+  });
+});
+
+// ── fit ─────────────────────────────────────────────────────────────────────
+
+describe("fit", () => {
+  it("truncates to width (ASCII)", () => {
+    const result = fit("hello world", 8);
+    expect(result).toContain("hello");
+    // Should end with truncation indicator
+    expect(result).toContain("›");
+  });
+
+  it("truncates to width (wide chars — never splits grapheme)", () => {
+    // "中日" is 4 columns. fit to 3 should drop "日" (2 cols) since it
+    // would overflow, keeping only "中" (2 cols)
+    const result = fit("中日", 3);
+    expect(result).toContain("中");
+    // "日" should not appear since it's 2 cols and would overflow budget of 2 (3-1)
+    expect(result).not.toContain("日");
+  });
+
+  it("pads short strings", () => {
+    const result = fit("hi", 5);
+    expect(result).toBe("hi   ");
+  });
+
+  it("width 0 returns empty", () => {
+    expect(fit("hello", 0)).toBe("");
+  });
+
+  it("wide grapheme wider than budget is dropped", () => {
+    // Budget of 1 — wide char "中" (2 cols) can't fit, should be dropped
+    const result = fit("中", 1);
+    expect(result).not.toContain("中");
+  });
+});
+
+// ── ansiState ───────────────────────────────────────────────────────────────
+
+describe("ansiState", () => {
+  it("extracts last fg code (truecolor)", () => {
+    const state = ansiState("\x1b[38;2;255;0;0mhello");
+    expect(state).toContain("\x1b[38;2;255;0;0m");
+  });
+
+  it("extracts last bg code (truecolor)", () => {
+    const state = ansiState("\x1b[48;2;0;255;0mhello");
+    expect(state).toContain("\x1b[48;2;0;255;0m");
+  });
+
+  it("returns bg + fg (background first!)", () => {
+    const state = ansiState("\x1b[38;2;255;0;0m\x1b[48;2;0;0;255mtext");
+    // bg should come before fg in the return value
+    const bgIdx = state.indexOf("\x1b[48;2;0;0;255m");
+    const fgIdx = state.indexOf("\x1b[38;2;255;0;0m");
+    expect(bgIdx).toBeLessThan(fgIdx);
+  });
+
+  it("\\x1b[0m resets both", () => {
+    const state = ansiState("\x1b[38;2;255;0;0m\x1b[0m");
+    expect(state).toBe("");
+  });
+
+  it("truecolor fg/bg", () => {
+    const state = ansiState("\x1b[38;2;255;0;0m\x1b[48;2;0;0;255mtext");
+    expect(state).toContain("\x1b[38;2;255;0;0m");
+    expect(state).toContain("\x1b[48;2;0;0;255m");
+  });
+
+  it("\\x1b[39m resets only fg", () => {
+    const state = ansiState("\x1b[38;2;255;0;0m\x1b[48;2;0;0;255m\x1b[39mtext");
+    expect(state).toContain("\x1b[48;2;0;0;255m");
+    expect(state).not.toContain("\x1b[38;2;255;0;0m");
+  });
+
+  it("plain ANSI codes (31, 42) are not tracked — Shiki uses truecolor", () => {
+    // ansiState only tracks 38;..., 48;..., 39, 0 — plain codes like 31/42 pass through
+    const state = ansiState("\x1b[31m\x1b[42mhello");
+    expect(state).toBe("");
+  });
+});
+
+// ── isLowContrastShikiFg ────────────────────────────────────────────────────
+
+describe("isLowContrastShikiFg", () => {
+  it('"30" = true (dark black)', () => {
+    expect(isLowContrastShikiFg("30")).toBe(true);
+  });
+
+  it('"90" = true (dark gray)', () => {
+    expect(isLowContrastShikiFg("90")).toBe(true);
+  });
+
+  it('"38;5;0" = true (256 palette black)', () => {
+    expect(isLowContrastShikiFg("38;5;0")).toBe(true);
+  });
+
+  it('"38;5;8" = true (256 palette dark gray)', () => {
+    expect(isLowContrastShikiFg("38;5;8")).toBe(true);
+  });
+
+  it('"38;2;0;0;0" = true (truecolor black)', () => {
+    expect(isLowContrastShikiFg("38;2;0;0;0")).toBe(true);
+  });
+
+  it('"38;2;255;255;255" = false (truecolor white)', () => {
+    expect(isLowContrastShikiFg("38;2;255;255;255")).toBe(false);
+  });
+
+  it('"0" = false (reset, not a fg code)', () => {
+    expect(isLowContrastShikiFg("0")).toBe(false);
+  });
+
+  it('"38;5;5" = false (256 palette not-dark)', () => {
+    expect(isLowContrastShikiFg("38;5;5")).toBe(false);
+  });
+
+  it('"48;2;0;0;0" = false (background not foreground)', () => {
+    expect(isLowContrastShikiFg("48;2;0;0;0")).toBe(false);
+  });
+});
+
+// ── normalizeShikiContrast ──────────────────────────────────────────────────
+
+describe("normalizeShikiContrast", () => {
+  it("replaces low-contrast codes", () => {
+    // \x1b[30m is dark black — should be replaced
+    const result = normalizeShikiContrast("\x1b[30mtext\x1b[0m");
+    expect(result).toContain(C.FG_SAFE_MUTED);
+    expect(result).not.toContain("\x1b[30m");
+  });
+
+  it("leaves high-contrast alone", () => {
+    // \x1b[37m is white — should pass through
+    const result = normalizeShikiContrast("\x1b[37mtext\x1b[0m");
+    expect(result).toContain("\x1b[37m");
+  });
+});
+
+// ── lnum ────────────────────────────────────────────────────────────────────
+
+describe("lnum", () => {
+  it("formats number right-padded", () => {
+    const result = lnum(42, 5);
+    expect(result).toContain("42");
+    // Should have spaces before the number
+    const stripped = result.replace(C.RST, "").replace(C.FG_LNUM, "");
+    expect(stripped).toBe("   42");
+  });
+
+  it("null produces spaces", () => {
+    const result = lnum(null, 5);
+    expect(result).toBe("     ");
+  });
+});
+
+// ── shortPath ───────────────────────────────────────────────────────────────
+
+describe("shortPath", () => {
+  it("relative to cwd returns relative", () => {
+    const result = shortPath("/home/user/project", "/home/user", "/home/user/project/src/file.ts");
+    expect(result).toBe("src/file.ts");
+  });
+
+  it("outside cwd with home returns ~", () => {
+    const result = shortPath("/home/user/project", "/home/user", "/home/user/other/file.ts");
+    expect(result).toBe("~/other/file.ts");
+  });
+
+  it("empty returns empty", () => {
+    expect(shortPath("/cwd", "/home", "")).toBe("");
+  });
+});
+
+// ── summarize ───────────────────────────────────────────────────────────────
+
+describe("summarize", () => {
+  it("+N -M format", () => {
+    const result = summarize(3, 2);
+    expect(result).toContain("+3");
+    expect(result).toContain("-2");
+  });
+
+  it("zero changes returns 'no changes'", () => {
+    const result = summarize(0, 0);
+    expect(result).toContain("no changes");
+  });
+});

--- a/packages/diff/src/ansi/width.test.ts
+++ b/packages/diff/src/ansi/width.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { graphemeWidth, tokenize, visibleWidth } from "./width.js";
+
+// ── graphemeWidth ───────────────────────────────────────────────────────────
+
+describe("graphemeWidth", () => {
+  it("ASCII letter = 1", () => {
+    expect(graphemeWidth("a")).toBe(1);
+    expect(graphemeWidth("Z")).toBe(1);
+  });
+
+  it("CJK character = 2", () => {
+    expect(graphemeWidth("中")).toBe(2);
+    expect(graphemeWidth("日")).toBe(2);
+    expect(graphemeWidth("韩")).toBe(2);
+  });
+
+  it("emoji = 2", () => {
+    expect(graphemeWidth("✅")).toBe(2);
+    expect(graphemeWidth("🔥")).toBe(2);
+    expect(graphemeWidth("😀")).toBe(2);
+  });
+
+  it("zero-width combining marks = 0", () => {
+    // Combining acute accent (U+0301) — zero width on its own
+    expect(graphemeWidth("\u0301")).toBe(0);
+    // Combining tilde (U+0303)
+    expect(graphemeWidth("\u0303")).toBe(0);
+  });
+
+  it("tab = 2", () => {
+    expect(graphemeWidth("\t")).toBe(2);
+  });
+});
+
+// ── tokenize ────────────────────────────────────────────────────────────────
+
+describe("tokenize", () => {
+  it("plain text produces single tokens", () => {
+    const tokens = tokenize("ab");
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).toEqual({ ansi: "", text: "a", width: 1 });
+    expect(tokens[1]).toEqual({ ansi: "", text: "b", width: 1 });
+  });
+
+  it("SGR sequence produces ansi+text pairs", () => {
+    // \x1b[31m is red fg, followed by "a"
+    const tokens = tokenize("\x1b[31ma");
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toEqual({ ansi: "\x1b[31m", text: "a", width: 1 });
+  });
+
+  it("bare ESC without m terminator handled gracefully", () => {
+    // ESC (0x1b) with no 'm' after it — should not hang
+    const tokens = tokenize("\x1ba");
+    // The bare ESC produces a zero-width token, then "a" is a normal token
+    expect(tokens.length).toBeGreaterThanOrEqual(2);
+    // Last token should be the "a"
+    expect(tokens[tokens.length - 1]!.text).toBe("a");
+  });
+
+  it("mixed ANSI + text", () => {
+    const tokens = tokenize("\x1b[31mred\x1b[0mplain");
+    // "red" under \x1b[31m, then "plain" after reset
+    const redToken = tokens.find((t) => t.text === "r");
+    expect(redToken?.ansi).toBe("\x1b[31m");
+
+    const plainToken = tokens.find((t) => t.text === "p");
+    expect(plainToken?.ansi).toBe("\x1b[0m");
+  });
+});
+
+// ── visibleWidth ────────────────────────────────────────────────────────────
+
+describe("visibleWidth", () => {
+  it("plain ASCII length matches", () => {
+    expect(visibleWidth("hello")).toBe(5);
+    expect(visibleWidth("abc")).toBe(3);
+  });
+
+  it("wide chars counted correctly", () => {
+    expect(visibleWidth("中")).toBe(2);
+    expect(visibleWidth("中日")).toBe(4);
+    expect(visibleWidth("a中b")).toBe(4); // 1 + 2 + 1
+  });
+
+  it("ANSI escapes don't add width", () => {
+    expect(visibleWidth("\x1b[31mhello\x1b[0m")).toBe(5);
+    expect(visibleWidth("\x1b[1m\x1b[31mhi\x1b[0m")).toBe(2);
+  });
+
+  it("empty string = 0", () => {
+    expect(visibleWidth("")).toBe(0);
+  });
+});

--- a/packages/diff/src/word-diff.test.ts
+++ b/packages/diff/src/word-diff.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { wordDiffAnalysis, injectBg, plainWordDiff } from "./word-diff.js";
+import * as Ansi from "./ansi/index.js";
+import type { DiffBg } from "./ansi/index.js";
+
+// ── wordDiffAnalysis ────────────────────────────────────────────────────────
+
+describe("wordDiffAnalysis", () => {
+  it("identical strings → similarity 1, empty ranges", () => {
+    const result = wordDiffAnalysis("hello world", "hello world");
+    expect(result.similarity).toBe(1);
+    expect(result.oldRanges).toEqual([]);
+    expect(result.newRanges).toEqual([]);
+  });
+
+  it("completely different → similarity 0, full ranges", () => {
+    const result = wordDiffAnalysis("abc", "xyz");
+    expect(result.similarity).toBe(0);
+    expect(result.oldRanges).toEqual([[0, 3]]);
+    expect(result.newRanges).toEqual([[0, 3]]);
+  });
+
+  it("partial overlap → correct similarity and ranges", () => {
+    const result = wordDiffAnalysis("hello world", "hello earth");
+    expect(result.similarity).toBeGreaterThan(0);
+    expect(result.similarity).toBeLessThan(1);
+    // "world" changed to "earth" — both 5 chars, same position in new string
+    expect(result.oldRanges.length).toBeGreaterThan(0);
+    expect(result.newRanges.length).toBeGreaterThan(0);
+  });
+
+  it("one empty string", () => {
+    const result = wordDiffAnalysis("hello", "");
+    expect(result.similarity).toBe(0);
+    expect(result.oldRanges).toEqual([[0, 5]]);
+    expect(result.newRanges).toEqual([]);
+  });
+
+  it("both empty → similarity 1", () => {
+    const result = wordDiffAnalysis("", "");
+    expect(result.similarity).toBe(1);
+    expect(result.oldRanges).toEqual([]);
+    expect(result.newRanges).toEqual([]);
+  });
+});
+
+// ── injectBg ────────────────────────────────────────────────────────────────
+
+describe("injectBg", () => {
+  const baseBg = "\x1b[48;2;10;20;30m";
+  const hlBg = "\x1b[48;2;200;50;50m";
+
+  it("no ranges returns baseBg + ansiLine + Ansi.RST (trailing reset!)", () => {
+    const result = injectBg("hello", [], baseBg, hlBg);
+    expect(result).toBe(baseBg + "hello" + Ansi.RST);
+  });
+
+  it("single range with concrete example", () => {
+    // "hello" with highlight on [2,4] → "he" + highlight "ll" + "o"
+    const result = injectBg("hello", [[2, 4]], baseBg, hlBg);
+    expect(result).toBe(
+      baseBg + "he" + hlBg + "ll" + baseBg + "o" + Ansi.RST
+    );
+  });
+
+  it("overlapping ranges merged", () => {
+    // [[1, 4], [3, 6]] should merge to [[1, 6]]
+    const result = injectBg("abcdef", [[1, 4], [3, 6]], baseBg, hlBg);
+    // "a" is base, "bcdef" is highlighted
+    expect(result).toBe(
+      baseBg + "a" + hlBg + "bcdef" + Ansi.RST
+    );
+  });
+
+  it("\\x1b[0m triggers bg re-injection", () => {
+    // When a reset appears mid-string, bg should be re-injected after it
+    const ansiLine = "he\x1b[0mllo";
+    const result = injectBg(ansiLine, [[2, 4]], baseBg, hlBg);
+    // After \x1b[0m, the bg should be re-injected
+    expect(result).toContain(baseBg);
+    // The reset should still be present
+    expect(result).toContain("\x1b[0m");
+  });
+});
+
+// ── plainWordDiff ───────────────────────────────────────────────────────────
+
+describe("plainWordDiff", () => {
+  const dbg: DiffBg = Ansi.DEFAULT_DIFF_BG;
+
+  it("removed text gets del bg", () => {
+    const result = plainWordDiff("hello world", "hello", dbg);
+    expect(result.old).toContain(dbg.bgDelW);
+    expect(result.old).toContain("world");
+    expect(result.new).toBe("hello");
+  });
+
+  it("added text gets add bg", () => {
+    const result = plainWordDiff("hello", "hello world", dbg);
+    expect(result.new).toContain(dbg.bgAddW);
+    expect(result.new).toContain("world");
+    // diffWords treats the space as unchanged, so old includes trailing space
+    expect(result.old).toBe("hello ");
+  });
+
+  it("unchanged passed through", () => {
+    const result = plainWordDiff("hello", "hello", dbg);
+    expect(result.old).toBe("hello");
+    expect(result.new).toBe("hello");
+  });
+});

--- a/packages/diff/vitest.config.ts
+++ b/packages/diff/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/footer/src/cost-accumulator.test.ts
+++ b/packages/footer/src/cost-accumulator.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { CostAccumulator } from "./cost-accumulator.js";
+import { getBus, Events } from "@pi-archimedes/core/bus";
+
+// ── globalThis cleanup ──────────────────────────────────────────────────────
+
+const BUS_KEY = Symbol.for("archimedes:bus");
+const QUEUE_KEY = Symbol.for("archimedes:busQueue");
+
+afterEach(() => {
+  delete (globalThis as Record<symbol, unknown>)[BUS_KEY];
+  delete (globalThis as Record<symbol, unknown>)[QUEUE_KEY];
+});
+
+// ── CostAccumulator ─────────────────────────────────────────────────────────
+
+describe("CostAccumulator", () => {
+  let accumulator: CostAccumulator;
+
+  beforeEach(() => {
+    accumulator = new CostAccumulator();
+    accumulator.subscribe();
+  });
+
+  it("accumulates input tokens from cost events", () => {
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 100, outputTokens: 50 });
+    expect(accumulator.inputTokens).toBe(100);
+    expect(accumulator.outputTokens).toBe(50);
+  });
+
+  it("accumulates cache read/write tokens", () => {
+    getBus().emit(Events.COST_UPDATE, {
+      cacheReadTokens: 200,
+      cacheWriteTokens: 100,
+    });
+    expect(accumulator.cacheReadTokens).toBe(200);
+    expect(accumulator.cacheWriteTokens).toBe(100);
+  });
+
+  it("accumulates cost", () => {
+    getBus().emit(Events.COST_UPDATE, { cost: 0.015 });
+    expect(accumulator.cost).toBe(0.015);
+  });
+
+  it("multiple cost updates accumulate correctly", () => {
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 100, cost: 0.01 });
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 200, cost: 0.02 });
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 300, cost: 0.03 });
+    expect(accumulator.inputTokens).toBe(600);
+    expect(accumulator.cost).toBe(0.06);
+  });
+
+  it("missing fields in payload default to 0", () => {
+    getBus().emit(Events.COST_UPDATE, {});
+    expect(accumulator.inputTokens).toBe(0);
+    expect(accumulator.outputTokens).toBe(0);
+    expect(accumulator.cacheReadTokens).toBe(0);
+    expect(accumulator.cacheWriteTokens).toBe(0);
+    expect(accumulator.cost).toBe(0);
+  });
+
+  it("reset zeroes all counters", () => {
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 100, cost: 0.01 });
+    accumulator.reset();
+    expect(accumulator.inputTokens).toBe(0);
+    expect(accumulator.outputTokens).toBe(0);
+    expect(accumulator.cacheReadTokens).toBe(0);
+    expect(accumulator.cacheWriteTokens).toBe(0);
+    expect(accumulator.cost).toBe(0);
+  });
+
+  it("dispose unsubscribes — subsequent events not accumulated", () => {
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 100 });
+    accumulator.dispose();
+    getBus().emit(Events.COST_UPDATE, { inputTokens: 500 });
+    expect(accumulator.inputTokens).toBe(100);
+  });
+
+  it("subsequent events not accumulated after dispose", () => {
+    getBus().emit(Events.COST_UPDATE, { cost: 0.01 });
+    accumulator.dispose();
+    getBus().emit(Events.COST_UPDATE, { cost: 0.05 });
+    expect(accumulator.cost).toBe(0.01);
+  });
+});

--- a/packages/footer/src/utils/format.test.ts
+++ b/packages/footer/src/utils/format.test.ts
@@ -53,8 +53,11 @@ describe("formatContextBar", () => {
     expect(result).not.toBe("");
     // Should contain the context window icon and "0%"
     expect(result).toContain("0%");
-    // Should contain empty segments (━) but no filled segments
+    // Should contain bar segments (━) — all empty, no filled portion
     expect(result).toContain("━━━");
+    // Must NOT contain higher percentage labels (50%, 100%, etc.)
+    expect(result).not.toContain("50%");
+    expect(result).not.toContain("100%");
   });
 
   it("50% produces half-filled bar", () => {

--- a/packages/footer/src/utils/format.test.ts
+++ b/packages/footer/src/utils/format.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatTokenCount,
+  formatContextBar,
+  formatGitStatusIndicators,
+  formatThinkingIndicator,
+} from "./format.js";
+import type { ColorFn } from "./icons.js";
+
+// ── Mock ColorFn ────────────────────────────────────────────────────────────
+// Passthrough — we test structure, not actual coloring.
+const mockColor: ColorFn = (_token, text) => text;
+
+// ── formatTokenCount ────────────────────────────────────────────────────────
+
+describe("formatTokenCount", () => {
+  it("returns '0' for zero", () => {
+    expect(formatTokenCount(0)).toBe("0");
+  });
+
+  it("returns raw number below 1K", () => {
+    expect(formatTokenCount(500)).toBe("500");
+  });
+
+  it("returns '1.0k' for exactly 1024", () => {
+    expect(formatTokenCount(1024)).toBe("1.0k");
+  });
+
+  it("returns '10k' for 10240", () => {
+    expect(formatTokenCount(10240)).toBe("10k");
+  });
+
+  it("returns '1.0M' for exactly 1M", () => {
+    expect(formatTokenCount(1048576)).toBe("1.0M");
+  });
+
+  it("returns '10M' for 10M", () => {
+    expect(formatTokenCount(10485760)).toBe("10M");
+  });
+});
+
+// ── formatContextBar ────────────────────────────────────────────────────────
+
+describe("formatContextBar", () => {
+  it("returns empty string when availableSpace <= 2", () => {
+    expect(formatContextBar(mockColor, 50, 0)).toBe("");
+    expect(formatContextBar(mockColor, 50, 1)).toBe("");
+    expect(formatContextBar(mockColor, 50, 2)).toBe("");
+  });
+
+  it("0% produces bar of empty segments (not empty string)", () => {
+    const result = formatContextBar(mockColor, 0, 10);
+    expect(result).not.toBe("");
+    // Should contain the context window icon and "0%"
+    expect(result).toContain("0%");
+    // Should contain empty segments (━) but no filled segments
+    expect(result).toContain("━━━");
+  });
+
+  it("50% produces half-filled bar", () => {
+    const result = formatContextBar(mockColor, 50, 10);
+    expect(result).not.toBe("");
+    expect(result).toContain("50%");
+  });
+
+  it("100% produces full bar", () => {
+    const result = formatContextBar(mockColor, 100, 10);
+    expect(result).not.toBe("");
+    expect(result).toContain("100%");
+  });
+
+  it("returns bar with icon and percentage", () => {
+    const result = formatContextBar(mockColor, 75, 10);
+    expect(result).toContain("75%");
+  });
+});
+
+// ── formatGitStatusIndicators ───────────────────────────────────────────────
+
+describe("formatGitStatusIndicators", () => {
+  const emptyStatus = {
+    staged: 0,
+    unstaged: 0,
+    untracked: 0,
+    ahead: 0,
+    behind: 0,
+  };
+
+  it("zero counts returns empty string", () => {
+    expect(formatGitStatusIndicators(emptyStatus, mockColor)).toBe("");
+  });
+
+  it("staged > 0 shows indicator", () => {
+    const result = formatGitStatusIndicators(
+      { ...emptyStatus, staged: 3 },
+      mockColor,
+    );
+    expect(result).toContain("●3");
+  });
+
+  it("multiple counts shows all indicators", () => {
+    const result = formatGitStatusIndicators(
+      { ...emptyStatus, staged: 2, unstaged: 5, untracked: 1 },
+      mockColor,
+    );
+    expect(result).toContain("●2");
+    expect(result).toContain("~5");
+    expect(result).toContain("U1");
+  });
+
+  it("ahead and behind show indicators", () => {
+    const result = formatGitStatusIndicators(
+      { ...emptyStatus, ahead: 3, behind: 1 },
+      mockColor,
+    );
+    expect(result).toContain("↑3");
+    expect(result).toContain("↓1");
+  });
+});
+
+// ── formatThinkingIndicator ─────────────────────────────────────────────────
+
+describe("formatThinkingIndicator", () => {
+  it("off returns empty string", () => {
+    expect(formatThinkingIndicator("off", mockColor)).toBe("");
+  });
+
+  it("other levels return indicator with level name", () => {
+    expect(formatThinkingIndicator("minimal", mockColor)).toBe("◐ minimal");
+    expect(formatThinkingIndicator("low", mockColor)).toBe("◐ low");
+    expect(formatThinkingIndicator("medium", mockColor)).toBe("◐ medium");
+    expect(formatThinkingIndicator("high", mockColor)).toBe("◐ high");
+    expect(formatThinkingIndicator("xhigh", mockColor)).toBe("◐ xhigh");
+  });
+});

--- a/packages/footer/vitest.config.ts
+++ b/packages/footer/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/image-paste/vitest.config.ts
+++ b/packages/image-paste/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/notify/vitest.config.ts
+++ b/packages/notify/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/subagent/vitest.config.ts
+++ b/packages/subagent/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/packages/todo/vitest.config.ts
+++ b/packages/todo/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0)
 
   meta:
     dependencies:
@@ -328,6 +332,162 @@ packages:
     resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
     engines: {node: '>=22.19.0'}
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
@@ -336,6 +496,9 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
@@ -436,6 +599,131 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@shikijs/cli@4.2.0':
     resolution: {integrity: sha512-YFxkcYcsgkuhioj54p3e9eJ0qZJWTNuebgvBgHZhLUZ7l+rN0VHx2F3BYGjmwHhNUVwdi2EfEkAteO/6IrEQCw==}
     engines: {node: '>=20'}
@@ -515,8 +803,17 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/diff@7.0.2':
     resolution: {integrity: sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -536,6 +833,35 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -543,6 +869,10 @@ packages:
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -564,12 +894,20 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -580,6 +918,10 @@ packages:
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -601,6 +943,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -615,6 +961,21 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -625,6 +986,15 @@ packages:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -632,6 +1002,11 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -695,6 +1070,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -711,9 +1089,15 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -748,6 +1132,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -795,6 +1184,24 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -822,6 +1229,11 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -837,17 +1249,55 @@ packages:
     resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -894,6 +1344,79 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -901,6 +1424,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   ws@8.21.0:
@@ -1236,6 +1764,84 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.6.2
@@ -1246,6 +1852,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
@@ -1323,6 +1931,81 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
 
   '@shikijs/cli@4.2.0':
     dependencies:
@@ -1427,7 +2110,16 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/diff@7.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -1447,9 +2139,53 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   agent-base@7.1.4: {}
 
   ansis@4.3.1: {}
+
+  assertion-error@2.0.1: {}
 
   balanced-match@4.0.4: {}
 
@@ -1465,15 +2201,27 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  cac@6.7.14: {}
+
   cac@7.0.0: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
+
+  check-error@2.1.3: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -1489,6 +2237,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   dequal@2.0.3: {}
 
   devlop@1.1.0:
@@ -1500,6 +2250,43 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -1515,6 +2302,10 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -1523,6 +2314,9 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  fsevents@2.3.3:
+    optional: true
 
   gaxios@7.1.4:
     dependencies:
@@ -1609,6 +2403,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@9.0.1: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -1631,7 +2427,13 @@ snapshots:
 
   long@5.3.2: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@11.5.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
 
@@ -1672,6 +2474,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.15: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -1708,6 +2512,20 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -1746,6 +2564,37 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   safe-buffer@5.2.1: {}
 
   shebang-command@2.0.0:
@@ -1765,16 +2614,43 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
+  source-map-js@1.2.1: {}
+
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strnum@2.3.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   trim-lines@3.0.1: {}
 
@@ -1823,11 +2699,92 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
+
+  vitest@3.2.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.21.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: [
+      "packages/core",
+      "packages/diff",
+      "packages/footer",
+      "packages/subagent",
+      "packages/todo",
+      "packages/notify",
+      "packages/ask",
+      "packages/image-paste",
+    ],
+    passWithNoTests: true,
+  },
+});
+
+// Note: meta is excluded — it is the orchestrator (depends on all packages) and
+// has no pure-logic functions to test in isolation.


### PR DESCRIPTION
## Summary

Add Vitest test infrastructure and pure-logic unit tests across the monorepo.

### Changes
- **Vitest workspace config** — root `vitest.config.ts` with `test.projects` array, per-package configs for all 8 packages
- **Core tests** (84 tests) — `color.test.ts` (53), `text.test.ts` (24), `bus.test.ts` (9)
- **Diff tests** (58 tests) — `width.test.ts` (13), `manip.test.ts` (33), `word-diff.test.ts` (12)
- **Footer tests** (25 tests) — `format.test.ts` (17), `cost-accumulator.test.ts` (8)
- **CI** — added `pnpm test` step to `ci.yml` after typecheck

### Test coverage
| Package | Files | Tests |
|---------|-------|-------|
| core | 3 | 84 |
| diff | 3 | 58 |
| footer | 2 | 25 |
| **Total** | **8** | **169** |

### Not tested (future work)
- ask, image-paste, notify, subagent, todo — these require TUI mocking or extension harness
- meta — orchestrator only, no pure-logic functions

## Test plan
- [ ] `pnpm test` — 169/169 pass
- [ ] `pnpm -r exec -- tsc --noEmit` — clean across all packages
- [ ] CI green on push to this branch
