### PR TITLE
fix: support ask prompts in RPC clients

### DIFF
--- a/docs/plans/2026-07-10-ask-rpc-fallback.md
+++ b/docs/plans/2026-07-10-ask-rpc-fallback.md
@@ -1,0 +1,352 @@
+# Ask RPC Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `@pi-archimedes/ask` show host-native question UI in Pi RPC clients while preserving its existing rich TUI and headless subagent behavior.
+
+**Architecture:** Add a focused RPC question flow that translates Archimedes questions into Pi's supported `select` and `input` extension UI methods. Route only `ctx.mode === "rpc"` through that fallback; TUI continues to use the existing custom picker/tabs, and JSON/print subagents continue to use the existing socket bridge.
+
+**Tech Stack:** TypeScript, Pi extension API, `@earendil-works/pi-coding-agent`, Vitest, pnpm.
+
+## Global Constraints
+
+- Users who do not install `@pi-archimedes/ask` are unaffected.
+- Do not change Superconductor or require a Superconductor-specific protocol.
+- Preserve the current TUI `ctx.ui.custom()` experience without visual or behavioral changes.
+- Preserve the current headless `PI_SUBAGENT_SOCKET` request/response path.
+- RPC multi-question flows may be sequential rather than tabbed.
+- RPC multi-select must support toggling choices, an explicit Done action, cancellation, and Other text input.
+- Do not add package dependencies.
+
+---
+
+### Task 1: RPC-native question flow
+
+**Files:**
+- Create: `packages/ask/src/rpc.ts`
+- Create: `packages/ask/src/rpc.test.ts`
+- Modify: `packages/ask/src/index.ts`
+
+**Interfaces:**
+- Consumes: `AskQuestion`, `AskSelection`, `appendRecommendedTagToOptionLabels()`, `buildSingleSelectionResult()`, `buildMultiSelectionResult()`, and `ExtensionUIContext`.
+- Produces: `askQuestionsWithRpcUi(ui, questions): Promise<{ cancelled: boolean; selections: AskSelection[] }>`.
+- Preserves: the existing `ask` tool schema and `buildAskSessionContent()` result format.
+
+- [ ] **Step 1: Write failing RPC fallback tests**
+
+Create `packages/ask/src/rpc.test.ts` with a queue-backed fake UI and these durable cases:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { askQuestionsWithRpcUi } from "./rpc.js";
+import type { AskQuestion } from "./selection.js";
+
+function fakeUi(selectAnswers: Array<string | undefined>, inputAnswers: Array<string | undefined> = []) {
+  const selectCalls: Array<{ title: string; options: string[] }> = [];
+  const inputCalls: Array<{ title: string; placeholder?: string }> = [];
+  const ui = {
+    async select(title: string, options: string[]) {
+      selectCalls.push({ title, options });
+      return selectAnswers.shift();
+    },
+    async input(title: string, placeholder?: string) {
+      inputCalls.push({ title, placeholder });
+      return inputAnswers.shift();
+    },
+    async custom() {
+      throw new Error("RPC fallback must not call custom()");
+    },
+  } as unknown as ExtensionUIContext;
+  return { ui, selectCalls, inputCalls };
+}
+
+const single: AskQuestion = {
+  id: "approach",
+  question: "Which approach?",
+  description: "Choose the safest option.",
+  options: [{ label: "Minimal" }, { label: "Broad" }],
+  recommended: 0,
+};
+
+describe("askQuestionsWithRpcUi", () => {
+  it("returns a single native selection and preserves description context", async () => {
+    const { ui, selectCalls } = fakeUi(["Minimal (Recommended)"]);
+    const result = await askQuestionsWithRpcUi(ui, [single]);
+    expect(result).toEqual({ cancelled: false, selections: [{ selectedOptions: ["Minimal"] }] });
+    expect(selectCalls[0]?.title).toContain("Which approach?");
+    expect(selectCalls[0]?.title).toContain("Choose the safest option.");
+  });
+
+  it("collects Other text through input", async () => {
+    const { ui } = fakeUi(["Other (type your own)"], ["A custom answer"]);
+    await expect(askQuestionsWithRpcUi(ui, [single])).resolves.toEqual({
+      cancelled: false,
+      selections: [{ selectedOptions: [], customInput: "A custom answer" }],
+    });
+  });
+
+  it("returns aligned empty selections when a sequential flow is cancelled", async () => {
+    const second = { ...single, id: "second", question: "Second?" };
+    const { ui } = fakeUi(["Minimal (Recommended)", undefined]);
+    await expect(askQuestionsWithRpcUi(ui, [single, second])).resolves.toEqual({
+      cancelled: true,
+      selections: [{ selectedOptions: ["Minimal"] }, { selectedOptions: [] }],
+    });
+  });
+
+  it("toggles RPC multi-select options and finishes explicitly", async () => {
+    const multi = { ...single, multi: true };
+    const { ui } = fakeUi(["☐ Minimal (Recommended)", "☐ Broad", "✓ Done"]);
+    await expect(askQuestionsWithRpcUi(ui, [multi])).resolves.toEqual({
+      cancelled: false,
+      selections: [{ selectedOptions: ["Minimal", "Broad"] }],
+    });
+  });
+
+  it("collects Other text during RPC multi-select", async () => {
+    const multi = { ...single, multi: true };
+    const { ui } = fakeUi(["☐ Other (type your own)", "✓ Done"], ["Custom"]);
+    await expect(askQuestionsWithRpcUi(ui, [multi])).resolves.toEqual({
+      cancelled: false,
+      selections: [{ selectedOptions: [], customInput: "Custom" }],
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm the missing-module failure**
+
+Run:
+
+```bash
+cd packages/ask
+corepack pnpm exec vitest run src/rpc.test.ts
+```
+
+Expected: FAIL because `./rpc.js` does not exist.
+
+- [ ] **Step 3: Implement the minimal RPC flow**
+
+Create `packages/ask/src/rpc.ts` with:
+
+```ts
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import {
+  OTHER_OPTION,
+  appendRecommendedTagToOptionLabels,
+  buildMultiSelectionResult,
+  buildSingleSelectionResult,
+  type AskQuestion,
+  type AskSelection,
+} from "./selection.js";
+
+const DONE_OPTION = "✓ Done";
+
+function questionTitle(question: AskQuestion): string {
+  const description = question.description?.trim();
+  return description ? `${question.question}\n\n${description}` : question.question;
+}
+
+async function askSingle(ui: ExtensionUIContext, question: AskQuestion): Promise<AskSelection | undefined> {
+  const labels = appendRecommendedTagToOptionLabels(
+    question.options.map((option) => option.label),
+    question.recommended,
+  );
+  const selected = await ui.select(questionTitle(question), [...labels, OTHER_OPTION]);
+  if (!selected) return undefined;
+  if (selected !== OTHER_OPTION) return buildSingleSelectionResult(selected);
+  const custom = await ui.input(question.question, "Type your answer");
+  if (!custom?.trim()) return undefined;
+  return buildSingleSelectionResult(OTHER_OPTION, custom);
+}
+
+async function askMulti(ui: ExtensionUIContext, question: AskQuestion): Promise<AskSelection | undefined> {
+  const labels = [
+    ...appendRecommendedTagToOptionLabels(
+      question.options.map((option) => option.label),
+      question.recommended,
+    ),
+    OTHER_OPTION,
+  ];
+  const otherIndex = labels.length - 1;
+  const selected = new Set<number>();
+  const notes = Array(labels.length).fill("") as string[];
+
+  while (true) {
+    const choices = labels.map((label, index) => `${selected.has(index) ? "☑" : "☐"} ${label}`);
+    if (selected.size > 0) choices.unshift(DONE_OPTION);
+    const choice = await ui.select(questionTitle(question), choices);
+    if (!choice) return undefined;
+    if (choice === DONE_OPTION) {
+      return buildMultiSelectionResult(labels, [...selected], notes, otherIndex);
+    }
+    const index = choices.indexOf(choice) - (selected.size > 0 ? 1 : 0);
+    if (index < 0 || index >= labels.length) continue;
+    if (index === otherIndex) {
+      const custom = await ui.input(question.question, "Type your answer");
+      if (custom?.trim()) {
+        notes[index] = custom;
+        selected.add(index);
+      }
+      continue;
+    }
+    if (selected.has(index)) selected.delete(index);
+    else selected.add(index);
+  }
+}
+
+export async function askQuestionsWithRpcUi(
+  ui: ExtensionUIContext,
+  questions: AskQuestion[],
+): Promise<{ cancelled: boolean; selections: AskSelection[] }> {
+  const selections: AskSelection[] = [];
+  for (const question of questions) {
+    const selection = question.multi ? await askMulti(ui, question) : await askSingle(ui, question);
+    if (!selection) {
+      while (selections.length < questions.length) selections.push({ selectedOptions: [] });
+      return { cancelled: true, selections };
+    }
+    selections.push(selection);
+  }
+  return { cancelled: false, selections };
+}
+```
+
+If the exact `ExtensionUIContext.select()` option type in the installed Pi peer rejects `string[]`, retain the same behavior while using the repository's accepted option type; do not widen with `any`.
+
+- [ ] **Step 4: Route only RPC contexts through the fallback**
+
+In `packages/ask/src/index.ts`:
+
+1. Import `askQuestionsWithRpcUi`.
+2. Add a shared helper that receives an `ExtensionContext` and `AskQuestion[]`.
+3. Return `askQuestionsWithRpcUi(ctx.ui, questions)` when `ctx.mode === "rpc"`.
+4. Preserve the existing single-picker and tabbed TUI branches for every other UI mode.
+5. Use the shared helper in both `handleAskRequest()` (subagent questions relayed to the parent) and the main `ask` tool execution.
+6. Keep the existing `!ctx.hasUI` socket branch before the RPC/TUI flow.
+7. Preserve one-question `AskToolDetails` fields (`id`, `question`, `options`, `selectedOptions`) and multi-question `results` output.
+
+The helper shape should be:
+
+```ts
+async function collectSelections(
+  ctx: ExtensionContext,
+  questions: AskQuestion[],
+): Promise<{ cancelled: boolean; selections: AskSelection[] }> {
+  if (ctx.mode === "rpc") return askQuestionsWithRpcUi(ctx.ui, questions);
+  if (questions.length === 1) {
+    const question = questions[0]!;
+    if (question.multi) return askQuestionsWithTabs(ctx.ui, questions);
+    const selection = await askSingleQuestionWithInlineNote(ctx.ui, question);
+    return {
+      cancelled: selection.selectedOptions.length === 0 && !selection.customInput,
+      selections: [selection],
+    };
+  }
+  return askQuestionsWithTabs(ctx.ui, questions);
+}
+```
+
+- [ ] **Step 5: Run focused tests and type-check the package**
+
+Run independently:
+
+```bash
+cd packages/ask
+corepack pnpm exec vitest run src/rpc.test.ts
+npx tsc --noEmit
+```
+
+Expected: 5 tests pass; TypeScript exits 0.
+
+- [ ] **Step 6: Run the full JavaScript test suite**
+
+Run from the repository root:
+
+```bash
+corepack pnpm test
+```
+
+Expected: all existing 180 tests plus the new RPC tests pass.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add packages/ask/src/index.ts packages/ask/src/rpc.ts packages/ask/src/rpc.test.ts
+git commit -m "fix: support ask prompts in RPC clients"
+```
+
+---
+
+### Task 2: Document compatibility and prepare the upstream PR
+
+**Files:**
+- Modify: `packages/ask/README.md`
+- Modify: `docs/plans/README.md`
+- Modify: `docs/plans/2026-07-10-ask-rpc-fallback.md`
+
+**Interfaces:**
+- Consumes: the RPC behavior delivered by Task 1.
+- Produces: user-facing compatibility documentation and a reviewable pull request.
+
+- [ ] **Step 1: Document RPC behavior and limitations**
+
+Add a `## RPC clients` section to `packages/ask/README.md`:
+
+```md
+## RPC clients
+
+In Pi RPC mode, `ask` uses Pi's standard extension UI protocol so embedding clients can render native question controls. Single-choice questions use `select`, custom answers use `input`, multiple questions are shown sequentially, and multi-select questions use a toggle-and-Done flow.
+
+Interactive terminal sessions keep the richer tabbed interface with inline note editing. RPC mode does not provide the custom terminal component API, so ordinary-option inline notes are not available there.
+```
+
+- [ ] **Step 2: Verify docs and final diff**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat upstream/main...HEAD
+git status --short
+```
+
+Expected: no whitespace errors; only ask implementation/tests/docs and plan tracking files are changed.
+
+- [ ] **Step 3: Mark the plan complete**
+
+Move the plan's row in `docs/plans/README.md` from In Progress to Completed, update its status to `✅ COMPLETED`, and check every completed checkbox in this plan.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add packages/ask/README.md docs/plans/README.md docs/plans/2026-07-10-ask-rpc-fallback.md
+git commit -m "docs: describe ask RPC fallback"
+```
+
+- [ ] **Step 5: Push and open the upstream PR**
+
+```bash
+git push -u origin fix/ask-rpc-fallback
+gh pr create \
+  --repo danielcherubini/pi-archimedes \
+  --base main \
+  --head haveanicedavid:fix/ask-rpc-fallback \
+  --title "fix: support ask prompts in RPC clients" \
+  --body $'## Summary\n- add an RPC-native select/input fallback for the ask tool\n- preserve the existing TUI and headless subagent paths\n- cover single, Other, sequential cancellation, and multi-select flows\n\n## Verification\n- `cd packages/ask && corepack pnpm exec vitest run src/rpc.test.ts`\n- `cd packages/ask && npx tsc --noEmit`\n- `corepack pnpm test`'
+```
+
+Expected: PR targets `danielcherubini/pi-archimedes:main` from `haveanicedavid:fix/ask-rpc-fallback`.
+
+---
+
+## Post-release local migration
+
+After upstream merges and publishes a release containing this fallback:
+
+1. Install global `npm:@pi-archimedes/ask` and `npm:@pi-archimedes/subagent`.
+2. Remove `~/.pi/agent/extensions/subagent/` (the legacy bundled-example symlinks).
+3. Remove the three legacy chain-only prompt symlinks under `~/.pi/agent/prompts/`.
+4. Preserve all files under `~/.pi/agent/agents/` and unrelated packages/extensions.
+5. Verify a terminal ask, a native-chat ask, and one subagent-to-parent ask before considering the migration complete.

--- a/docs/plans/2026-07-10-ask-rpc-fallback.md
+++ b/docs/plans/2026-07-10-ask-rpc-fallback.md
@@ -32,7 +32,7 @@
 - Produces: `askQuestionsWithRpcUi(ui, questions): Promise<{ cancelled: boolean; selections: AskSelection[] }>`.
 - Preserves: the existing `ask` tool schema and `buildAskSessionContent()` result format.
 
-- [ ] **Step 1: Write failing RPC fallback tests**
+- [x] **Step 1: Write failing RPC fallback tests**
 
 Create `packages/ask/src/rpc.test.ts` with a queue-backed fake UI and these durable cases:
 
@@ -115,7 +115,7 @@ describe("askQuestionsWithRpcUi", () => {
 });
 ```
 
-- [ ] **Step 2: Run the focused test and confirm the missing-module failure**
+- [x] **Step 2: Run the focused test and confirm the missing-module failure**
 
 Run:
 
@@ -126,7 +126,7 @@ corepack pnpm exec vitest run src/rpc.test.ts
 
 Expected: FAIL because `./rpc.js` does not exist.
 
-- [ ] **Step 3: Implement the minimal RPC flow**
+- [x] **Step 3: Implement the minimal RPC flow**
 
 Create `packages/ask/src/rpc.ts` with:
 
@@ -215,7 +215,7 @@ export async function askQuestionsWithRpcUi(
 
 If the exact `ExtensionUIContext.select()` option type in the installed Pi peer rejects `string[]`, retain the same behavior while using the repository's accepted option type; do not widen with `any`.
 
-- [ ] **Step 4: Route only RPC contexts through the fallback**
+- [x] **Step 4: Route only RPC contexts through the fallback**
 
 In `packages/ask/src/index.ts`:
 
@@ -248,7 +248,7 @@ async function collectSelections(
 }
 ```
 
-- [ ] **Step 5: Run focused tests and type-check the package**
+- [x] **Step 5: Run focused tests and type-check the package**
 
 Run independently:
 
@@ -260,7 +260,7 @@ npx tsc --noEmit
 
 Expected: 5 tests pass; TypeScript exits 0.
 
-- [ ] **Step 6: Run the full JavaScript test suite**
+- [x] **Step 6: Run the full JavaScript test suite**
 
 Run from the repository root:
 
@@ -270,7 +270,7 @@ corepack pnpm test
 
 Expected: all existing 180 tests plus the new RPC tests pass.
 
-- [ ] **Step 7: Commit the implementation**
+- [x] **Step 7: Commit the implementation**
 
 ```bash
 git add packages/ask/src/index.ts packages/ask/src/rpc.ts packages/ask/src/rpc.test.ts
@@ -290,7 +290,7 @@ git commit -m "fix: support ask prompts in RPC clients"
 - Consumes: the RPC behavior delivered by Task 1.
 - Produces: user-facing compatibility documentation and a reviewable pull request.
 
-- [ ] **Step 1: Document RPC behavior and limitations**
+- [x] **Step 1: Document RPC behavior and limitations**
 
 Add a `## RPC clients` section to `packages/ask/README.md`:
 
@@ -302,7 +302,7 @@ In Pi RPC mode, `ask` uses Pi's standard extension UI protocol so embedding clie
 Interactive terminal sessions keep the richer tabbed interface with inline note editing. RPC mode does not provide the custom terminal component API, so ordinary-option inline notes are not available there.
 ```
 
-- [ ] **Step 2: Verify docs and final diff**
+- [x] **Step 2: Verify docs and final diff**
 
 Run:
 
@@ -314,18 +314,18 @@ git status --short
 
 Expected: no whitespace errors; only ask implementation/tests/docs and plan tracking files are changed.
 
-- [ ] **Step 3: Mark the plan complete**
+- [x] **Step 3: Mark the plan complete**
 
 Move the plan's row in `docs/plans/README.md` from In Progress to Completed, update its status to `✅ COMPLETED`, and check every completed checkbox in this plan.
 
-- [ ] **Step 4: Commit documentation**
+- [x] **Step 4: Commit documentation**
 
 ```bash
 git add packages/ask/README.md docs/plans/README.md docs/plans/2026-07-10-ask-rpc-fallback.md
 git commit -m "docs: describe ask RPC fallback"
 ```
 
-- [ ] **Step 5: Push and open the upstream PR**
+- [x] **Step 5: Push and open the upstream PR**
 
 ```bash
 git push -u origin fix/ask-rpc-fallback

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,9 +19,11 @@
 
 ## In Progress
 
-| Plan | Status | Created | |
+| Plan | Status | Created |
+|---|---|---|
+| [Ask RPC fallback](2026-07-10-ask-rpc-fallback.md) | 🚧 IN PROGRESS | 2026-07-10 |
 
 ## Quick Stats
 
-- Total Plans: 13
+- Total Plans: 14
 - Completed: 13

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,8 @@
 ## Completed Plans
 
 | Plan | Status | Created |
+|---|---|---|
+| [Ask RPC fallback](2026-07-10-ask-rpc-fallback.md) | ✅ COMPLETED | 2026-07-10 |
 | [Fix Windows Spawn and Terminal Clamping](plans/2026-07-05-fix-windows-spawn-and-terminal-clamp.md) | ✅ COMPLETED (PR #18) | 2026-07-05 |
 | [Add Tests](plans/2026-07-05-add-tests.md) | ✅ COMPLETED (PR #17) | 2026-07-05 |
 | [Stacked, flicker-free parallel subagent rendering](plans/2026-07-04-stacked-parallel-subagents.md) | ✅ COMPLETED (PR #16) | 2026-07-04 |
@@ -21,9 +23,8 @@
 
 | Plan | Status | Created |
 |---|---|---|
-| [Ask RPC fallback](2026-07-10-ask-rpc-fallback.md) | 🚧 IN PROGRESS | 2026-07-10 |
 
 ## Quick Stats
 
 - Total Plans: 14
-- Completed: 13
+- Completed: 14

--- a/packages/ask/README.md
+++ b/packages/ask/README.md
@@ -19,6 +19,12 @@ pi install @pi-archimedes/ask
 
 ![ask from a subagent](../../docs/images/ask-subagent.png)
 
+## RPC clients
+
+In Pi RPC mode, `ask` uses Pi's standard extension UI protocol so embedding clients can render native question controls. Single-choice questions use `select`, custom answers use `input`, multiple questions are shown sequentially, and multi-select questions use a toggle-and-Done flow.
+
+Interactive terminal sessions keep the richer tabbed interface with inline note editing. RPC mode does not provide the custom terminal component API, so ordinary-option inline notes are not available there.
+
 ## Dependencies
 
 Depends on [`@pi-archimedes/core`](../core) for the shared event bus used to relay subagent questions.

--- a/packages/ask/README.md
+++ b/packages/ask/README.md
@@ -21,7 +21,7 @@ pi install @pi-archimedes/ask
 
 ## RPC clients
 
-In Pi RPC mode, `ask` uses Pi's standard extension UI protocol so embedding clients can render native question controls. Single-choice questions use `select`, custom answers use `input`, multiple questions are shown sequentially, and multi-select questions use a toggle-and-Done flow.
+In Pi RPC mode, `ask` uses Pi's standard extension UI protocol so embedding clients can render native question controls. RPC support requires Pi 0.78.1 or newer. Single-choice questions use `select`, custom answers use `input`, multiple questions are shown sequentially, and multi-select questions use a toggle-and-Done flow.
 
 Interactive terminal sessions keep the richer tabbed interface with inline note editing. RPC mode does not provide the custom terminal component API, so ordinary-option inline notes are not available there.
 

--- a/packages/ask/package.json
+++ b/packages/ask/package.json
@@ -14,7 +14,7 @@
     "@pi-archimedes/core": "workspace:*"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.1.0",
+    "@earendil-works/pi-coding-agent": ">=0.78.1",
     "@earendil-works/pi-tui": ">=0.1.0",
     "typebox": ">=1.1.0"
   },

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { OTHER_OPTION, type AskQuestion, type AskSelection } from "./selection.js";
 import { askSingleQuestionWithInlineNote } from "./picker.js";
 import { askQuestionsWithTabs } from "./dialog.js";
+import { askQuestionsWithRpcUi } from "./rpc.js";
 
 const OptionItemSchema = Type.Object({
 	label: Type.String({ description: "Display label" }),
@@ -189,6 +190,23 @@ Ask the user for clarification when a choice materially affects the outcome.
 - Do NOT include an 'Other' option; UI adds it automatically.
 `.trim();
 
+async function collectSelections(
+	ctx: ExtensionContext,
+	questions: AskQuestion[],
+): Promise<{ cancelled: boolean; selections: AskSelection[] }> {
+	if ("mode" in ctx && ctx.mode === "rpc") return askQuestionsWithRpcUi(ctx.ui, questions);
+	if (questions.length === 1) {
+		const question = questions[0]!;
+		if (question.multi) return askQuestionsWithTabs(ctx.ui, questions);
+		const selection = await askSingleQuestionWithInlineNote(ctx.ui, question);
+		return {
+			cancelled: selection.selectedOptions.length === 0 && !selection.customInput,
+			selections: [selection],
+		};
+	}
+	return askQuestionsWithTabs(ctx.ui, questions);
+}
+
 export function registerAsk(pi: ExtensionAPI) {
 	const unsubscribes: Array<() => void> = [];
 	let currentCtx: ExtensionContext | undefined;
@@ -237,29 +255,9 @@ export function registerAsk(pi: ExtensionAPI) {
 		let selections: AskSelection[] = [];
 
 		try {
-			if (questions.length === 1) {
-				const q = questions[0]!;
-				if (q.multi) {
-					// Multi-select single question routes to the tabs dialog (picker doesn't support multi)
-					const res = await askQuestionsWithTabs(currentCtx.ui, questions);
-					cancelled = res.cancelled;
-					selections = res.selections;
-				} else {
-					const input: { question: string; description?: string; options: typeof q.options; recommended?: number } = {
-						question: q.question,
-						options: q.options,
-					};
-					if (q.description && q.description.trim().length > 0) input.description = q.description;
-					if (q.recommended != null) input.recommended = q.recommended;
-					const sel = await askSingleQuestionWithInlineNote(currentCtx.ui, input);
-					selections = [sel];
-					cancelled = sel.selectedOptions.length === 0 && !sel.customInput;
-				}
-			} else {
-				const res = await askQuestionsWithTabs(currentCtx.ui, questions);
-				cancelled = res.cancelled;
-				selections = res.selections;
-			}
+			const result = await collectSelections(currentCtx, questions);
+			cancelled = result.cancelled;
+			selections = result.selections;
 		} catch {
 			cancelled = true;
 			selections = questions.map(() => ({ selectedOptions: [] }));
@@ -389,11 +387,12 @@ export function registerAsk(pi: ExtensionAPI) {
 			// Emit bus event so notify (if installed) can schedule a desktop notification
 			getBus().emit(Events.ASK_REQUEST, { source: "main", requestId: randomUUID(), questions: params.questions });
 
+			const questions = params.questions as AskQuestion[];
+			const collected = await collectSelections(ctx, questions);
+
 			if (params.questions.length === 1) {
 				const q = params.questions[0]!;
-				const selection = q.multi
-					? (await askQuestionsWithTabs(ctx.ui, [q as AskQuestion])).selections[0] ?? { selectedOptions: [] }
-					: await askSingleQuestionWithInlineNote(ctx.ui, q as AskQuestion);
+				const selection = collected.selections[0] ?? { selectedOptions: [] };
 				const optionLabels = q.options.map((option) => option.label);
 				const desc = q.description && q.description.trim().length > 0 ? q.description : undefined;
 
@@ -425,10 +424,9 @@ export function registerAsk(pi: ExtensionAPI) {
 			}
 
 			const results: QuestionResult[] = [];
-			const tabResult = await askQuestionsWithTabs(ctx.ui, params.questions as AskQuestion[]);
 			for (let i = 0; i < params.questions.length; i++) {
 				const q = params.questions[i]!;
-				const selection = tabResult.selections[i] ?? { selectedOptions: [] };
+				const selection = collected.selections[i] ?? { selectedOptions: [] };
 				const desc = q.description && q.description.trim().length > 0 ? q.description : undefined;
 				results.push({
 					id: q.id,

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -3,7 +3,7 @@ import { Type, type Static } from "typebox";
 import { getBus, Events } from "@pi-archimedes/core/bus";
 import { connect } from "node:net";
 import { randomUUID } from "node:crypto";
-import { OTHER_OPTION, type AskQuestion, type AskSelection } from "./selection.js";
+import { OTHER_OPTION, hasAnsweredSelections, type AskQuestion, type AskSelection } from "./selection.js";
 import { askSingleQuestionWithInlineNote } from "./picker.js";
 import { askQuestionsWithTabs } from "./dialog.js";
 import { askQuestionsWithRpcUi } from "./rpc.js";
@@ -364,7 +364,7 @@ export function registerAsk(pi: ExtensionAPI) {
 					};
 				});
 
-				if (response.cancelled && results.every((r) => r.selectedOptions.length === 0)) {
+				if (response.cancelled && !hasAnsweredSelections(results)) {
 					return {
 						content: [{ type: "text", text: "User cancelled the question." }],
 						details: { results, customInput: undefined, description: undefined } satisfies AskToolDetails,

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -194,7 +194,7 @@ async function collectSelections(
 	ctx: ExtensionContext,
 	questions: AskQuestion[],
 ): Promise<{ cancelled: boolean; selections: AskSelection[] }> {
-	if ("mode" in ctx && ctx.mode === "rpc") return askQuestionsWithRpcUi(ctx.ui, questions);
+	if (ctx.mode === "rpc") return askQuestionsWithRpcUi(ctx.ui, questions);
 	if (questions.length === 1) {
 		const question = questions[0]!;
 		if (question.multi) return askQuestionsWithTabs(ctx.ui, questions);

--- a/packages/ask/src/rpc.test.ts
+++ b/packages/ask/src/rpc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { askQuestionsWithRpcUi } from "./rpc.js";
-import type { AskQuestion } from "./selection.js";
+import { hasAnsweredSelections, type AskQuestion } from "./selection.js";
 
 function fakeUi(selectAnswers: Array<string | undefined>, inputAnswers: Array<string | undefined> = []) {
 	const selectCalls: Array<{ title: string; options: string[] }> = [];
@@ -56,6 +56,18 @@ describe("askQuestionsWithRpcUi", () => {
 			cancelled: true,
 			selections: [{ selectedOptions: ["Minimal"] }, { selectedOptions: [] }],
 		});
+	});
+
+	it("treats an earlier custom-only answer as answered when a later RPC question is cancelled", async () => {
+		const second = { ...single, id: "second", question: "Second?" };
+		const { ui } = fakeUi(["Other (type your own)", undefined], ["Use a custom approach"]);
+		const result = await askQuestionsWithRpcUi(ui, [single, second]);
+
+		expect(result).toEqual({
+			cancelled: true,
+			selections: [{ selectedOptions: [], customInput: "Use a custom approach" }, { selectedOptions: [] }],
+		});
+		expect(hasAnsweredSelections(result.selections)).toBe(true);
 	});
 
 	it("toggles RPC multi-select options and finishes explicitly", async () => {

--- a/packages/ask/src/rpc.test.ts
+++ b/packages/ask/src/rpc.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { askQuestionsWithRpcUi } from "./rpc.js";
+import type { AskQuestion } from "./selection.js";
+
+function fakeUi(selectAnswers: Array<string | undefined>, inputAnswers: Array<string | undefined> = []) {
+	const selectCalls: Array<{ title: string; options: string[] }> = [];
+	const inputCalls: Array<{ title: string; placeholder?: string }> = [];
+	const ui = {
+		async select(title: string, options: string[]) {
+			selectCalls.push({ title, options });
+			return selectAnswers.shift();
+		},
+		async input(title: string, placeholder?: string) {
+			const inputCall: { title: string; placeholder?: string } = { title };
+			if (placeholder !== undefined) inputCall.placeholder = placeholder;
+			inputCalls.push(inputCall);
+			return inputAnswers.shift();
+		},
+		async custom() {
+			throw new Error("RPC fallback must not call custom()");
+		},
+	} as unknown as ExtensionUIContext;
+	return { ui, selectCalls, inputCalls };
+}
+
+const single: AskQuestion = {
+	id: "approach",
+	question: "Which approach?",
+	description: "Choose the safest option.",
+	options: [{ label: "Minimal" }, { label: "Broad" }],
+	recommended: 0,
+};
+
+describe("askQuestionsWithRpcUi", () => {
+	it("returns a single native selection and preserves description context", async () => {
+		const { ui, selectCalls } = fakeUi(["Minimal (Recommended)"]);
+		const result = await askQuestionsWithRpcUi(ui, [single]);
+		expect(result).toEqual({ cancelled: false, selections: [{ selectedOptions: ["Minimal"] }] });
+		expect(selectCalls[0]?.title).toContain("Which approach?");
+		expect(selectCalls[0]?.title).toContain("Choose the safest option.");
+	});
+
+	it("collects Other text through input", async () => {
+		const { ui } = fakeUi(["Other (type your own)"], ["A custom answer"]);
+		await expect(askQuestionsWithRpcUi(ui, [single])).resolves.toEqual({
+			cancelled: false,
+			selections: [{ selectedOptions: [], customInput: "A custom answer" }],
+		});
+	});
+
+	it("returns aligned empty selections when a sequential flow is cancelled", async () => {
+		const second = { ...single, id: "second", question: "Second?" };
+		const { ui } = fakeUi(["Minimal (Recommended)", undefined]);
+		await expect(askQuestionsWithRpcUi(ui, [single, second])).resolves.toEqual({
+			cancelled: true,
+			selections: [{ selectedOptions: ["Minimal"] }, { selectedOptions: [] }],
+		});
+	});
+
+	it("toggles RPC multi-select options and finishes explicitly", async () => {
+		const multi = { ...single, multi: true };
+		const { ui } = fakeUi(["☐ Minimal (Recommended)", "☐ Broad", "✓ Done"]);
+		await expect(askQuestionsWithRpcUi(ui, [multi])).resolves.toEqual({
+			cancelled: false,
+			selections: [{ selectedOptions: ["Minimal", "Broad"] }],
+		});
+	});
+
+	it("collects Other text during RPC multi-select", async () => {
+		const multi = { ...single, multi: true };
+		const { ui } = fakeUi(["☐ Other (type your own)", "✓ Done"], ["Custom"]);
+		await expect(askQuestionsWithRpcUi(ui, [multi])).resolves.toEqual({
+			cancelled: false,
+			selections: [{ selectedOptions: [], customInput: "Custom" }],
+		});
+	});
+});

--- a/packages/ask/src/rpc.test.ts
+++ b/packages/ask/src/rpc.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ExtensionUIContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { registerAsk } from "./index.js";
 import { askQuestionsWithRpcUi } from "./rpc.js";
 import { hasAnsweredSelections, type AskQuestion } from "./selection.js";
 
 function fakeUi(selectAnswers: Array<string | undefined>, inputAnswers: Array<string | undefined> = []) {
 	const selectCalls: Array<{ title: string; options: string[] }> = [];
 	const inputCalls: Array<{ title: string; placeholder?: string }> = [];
+	let customCalls = 0;
 	const ui = {
 		async select(title: string, options: string[]) {
 			selectCalls.push({ title, options });
@@ -18,10 +20,11 @@ function fakeUi(selectAnswers: Array<string | undefined>, inputAnswers: Array<st
 			return inputAnswers.shift();
 		},
 		async custom() {
+			customCalls += 1;
 			throw new Error("RPC fallback must not call custom()");
 		},
 	} as unknown as ExtensionUIContext;
-	return { ui, selectCalls, inputCalls };
+	return { ui, selectCalls, inputCalls, get customCalls() { return customCalls; } };
 }
 
 const single: AskQuestion = {
@@ -31,6 +34,39 @@ const single: AskQuestion = {
 	options: [{ label: "Minimal" }, { label: "Broad" }],
 	recommended: 0,
 };
+
+describe("registered ask tool RPC routing", () => {
+	it("uses native select and input without calling custom UI in RPC mode", async () => {
+		let askTool: ToolDefinition<any, any, any> | undefined;
+		const pi = {
+			on() {},
+			registerTool(tool: ToolDefinition<any, any, any>) {
+				askTool = tool;
+			},
+		};
+		registerAsk(pi as unknown as ExtensionAPI);
+
+		const fake = fakeUi(["Other (type your own)"], ["Use the RPC-native path"]);
+		const rpcCtx = { mode: "rpc" as const, hasUI: true, ui: fake.ui } satisfies Pick<ExtensionContext, "mode" | "hasUI" | "ui">;
+
+		const result = await askTool?.execute(
+			"tool-call-1",
+			{ questions: [single] },
+			undefined,
+			undefined,
+			rpcCtx as unknown as ExtensionContext,
+		);
+
+		expect(result?.content[0]).toEqual(expect.objectContaining({ type: "text" }));
+		expect(fake.selectCalls).toHaveLength(1);
+		expect(fake.inputCalls).toHaveLength(1);
+		expect(fake.customCalls).toBe(0);
+		expect(result?.details).toEqual(expect.objectContaining({
+			customInput: "Use the RPC-native path",
+			selectedOptions: [],
+		}));
+	});
+});
 
 describe("askQuestionsWithRpcUi", () => {
 	it("returns a single native selection and preserves description context", async () => {

--- a/packages/ask/src/rpc.test.ts
+++ b/packages/ask/src/rpc.test.ts
@@ -67,6 +67,28 @@ describe("askQuestionsWithRpcUi", () => {
 		});
 	});
 
+	it("toggles a checked RPC multi-select option off", async () => {
+		const multi = { ...single, multi: true };
+		const { ui } = fakeUi(["☐ Minimal (Recommended)", "☑ Minimal (Recommended)", "☐ Broad", "✓ Done"]);
+		await expect(askQuestionsWithRpcUi(ui, [multi])).resolves.toEqual({
+			cancelled: false,
+			selections: [{ selectedOptions: ["Broad"] }],
+		});
+	});
+
+	it("toggles checked Other off without prompting again", async () => {
+		const multi = { ...single, multi: true };
+		const { ui, inputCalls } = fakeUi(
+			["☐ Other (type your own)", "☑ Other (type your own)", "☐ Broad", "✓ Done"],
+			["Custom"],
+		);
+		await expect(askQuestionsWithRpcUi(ui, [multi])).resolves.toEqual({
+			cancelled: false,
+			selections: [{ selectedOptions: ["Broad"] }],
+		});
+		expect(inputCalls).toHaveLength(1);
+	});
+
 	it("collects Other text during RPC multi-select", async () => {
 		const multi = { ...single, multi: true };
 		const { ui } = fakeUi(["☐ Other (type your own)", "✓ Done"], ["Custom"]);

--- a/packages/ask/src/rpc.ts
+++ b/packages/ask/src/rpc.ts
@@ -50,6 +50,11 @@ async function askMulti(ui: ExtensionUIContext, question: AskQuestion): Promise<
 		}
 		const index = choices.indexOf(choice) - (selected.size > 0 ? 1 : 0);
 		if (index < 0 || index >= labels.length) continue;
+		if (selected.has(index)) {
+			selected.delete(index);
+			notes[index] = "";
+			continue;
+		}
 		if (index === otherIndex) {
 			const custom = await ui.input(question.question, "Type your answer");
 			if (custom?.trim()) {
@@ -58,8 +63,7 @@ async function askMulti(ui: ExtensionUIContext, question: AskQuestion): Promise<
 			}
 			continue;
 		}
-		if (selected.has(index)) selected.delete(index);
-		else selected.add(index);
+		selected.add(index);
 	}
 }
 

--- a/packages/ask/src/rpc.ts
+++ b/packages/ask/src/rpc.ts
@@ -1,0 +1,80 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import {
+	OTHER_OPTION,
+	appendRecommendedTagToOptionLabels,
+	buildMultiSelectionResult,
+	buildSingleSelectionResult,
+	type AskQuestion,
+	type AskSelection,
+} from "./selection.js";
+
+const DONE_OPTION = "✓ Done";
+
+function questionTitle(question: AskQuestion): string {
+	const description = question.description?.trim();
+	return description ? `${question.question}\n\n${description}` : question.question;
+}
+
+async function askSingle(ui: ExtensionUIContext, question: AskQuestion): Promise<AskSelection | undefined> {
+	const labels = appendRecommendedTagToOptionLabels(
+		question.options.map((option) => option.label),
+		question.recommended,
+	);
+	const selected = await ui.select(questionTitle(question), [...labels, OTHER_OPTION]);
+	if (!selected) return undefined;
+	if (selected !== OTHER_OPTION) return buildSingleSelectionResult(selected);
+	const custom = await ui.input(question.question, "Type your answer");
+	if (!custom?.trim()) return undefined;
+	return buildSingleSelectionResult(OTHER_OPTION, custom);
+}
+
+async function askMulti(ui: ExtensionUIContext, question: AskQuestion): Promise<AskSelection | undefined> {
+	const labels = [
+		...appendRecommendedTagToOptionLabels(
+			question.options.map((option) => option.label),
+			question.recommended,
+		),
+		OTHER_OPTION,
+	];
+	const otherIndex = labels.length - 1;
+	const selected = new Set<number>();
+	const notes = Array(labels.length).fill("") as string[];
+
+	while (true) {
+		const choices = labels.map((label, index) => `${selected.has(index) ? "☑" : "☐"} ${label}`);
+		if (selected.size > 0) choices.unshift(DONE_OPTION);
+		const choice = await ui.select(questionTitle(question), choices);
+		if (!choice) return undefined;
+		if (choice === DONE_OPTION) {
+			return buildMultiSelectionResult(labels, [...selected], notes, otherIndex);
+		}
+		const index = choices.indexOf(choice) - (selected.size > 0 ? 1 : 0);
+		if (index < 0 || index >= labels.length) continue;
+		if (index === otherIndex) {
+			const custom = await ui.input(question.question, "Type your answer");
+			if (custom?.trim()) {
+				notes[index] = custom;
+				selected.add(index);
+			}
+			continue;
+		}
+		if (selected.has(index)) selected.delete(index);
+		else selected.add(index);
+	}
+}
+
+export async function askQuestionsWithRpcUi(
+	ui: ExtensionUIContext,
+	questions: AskQuestion[],
+): Promise<{ cancelled: boolean; selections: AskSelection[] }> {
+	const selections: AskSelection[] = [];
+	for (const question of questions) {
+		const selection = question.multi ? await askMulti(ui, question) : await askSingle(ui, question);
+		if (!selection) {
+			while (selections.length < questions.length) selections.push({ selectedOptions: [] });
+			return { cancelled: true, selections };
+		}
+		selections.push(selection);
+	}
+	return { cancelled: false, selections };
+}

--- a/packages/ask/src/selection.ts
+++ b/packages/ask/src/selection.ts
@@ -19,6 +19,19 @@ export interface AskSelection {
 	customInput?: string;
 }
 
+interface AnsweredSelectionLike {
+	selectedOptions: readonly string[];
+	customInput?: string | undefined;
+}
+
+export function hasAnsweredSelection(selection: AnsweredSelectionLike): boolean {
+	return selection.selectedOptions.length > 0 || Boolean(selection.customInput?.trim());
+}
+
+export function hasAnsweredSelections(selections: ReadonlyArray<AnsweredSelectionLike>): boolean {
+	return selections.some(hasAnsweredSelection);
+}
+
 export function appendRecommendedTagToOptionLabels(
 	optionLabels: string[],
 	recommendedOptionIndex?: number,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,11 +52,11 @@ importers:
   packages/ask:
     dependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: '>=0.1.0'
-        version: 0.78.0(ws@8.21.0)(zod@4.4.3)
+        specifier: '>=0.78.1'
+        version: 0.80.6(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: '>=0.1.0'
-        version: 0.78.0
+        version: 0.80.6
       '@pi-archimedes/core':
         specifier: workspace:*
         version: link:../core
@@ -318,8 +318,17 @@ packages:
     resolution: {integrity: sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
+    engines: {node: '>=22.19.0'}
+
   '@earendil-works/pi-ai@0.78.0':
     resolution: {integrity: sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -328,8 +337,17 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
+  '@earendil-works/pi-coding-agent@0.80.6':
+    resolution: {integrity: sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@earendil-works/pi-tui@0.78.0':
     resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.80.6':
+    resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.28.1':
@@ -566,8 +584,24 @@ packages:
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1104,6 +1138,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
@@ -1237,6 +1276,11 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1321,6 +1365,10 @@ packages:
 
   undici@8.3.0:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unist-util-is@6.0.1:
@@ -1710,12 +1758,47 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.80.6(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.78.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0
       '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.80.6(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -1759,10 +1842,45 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-coding-agent@0.80.6(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.6
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-tui@0.78.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
+
+  '@earendil-works/pi-tui@0.80.6':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1908,7 +2026,23 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@nodable/entities@2.1.1': {}
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -2437,6 +2571,8 @@ snapshots:
 
   marked@15.0.12: {}
 
+  marked@18.0.5: {}
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -2597,6 +2733,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  semver@7.8.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2665,6 +2803,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@8.3.0: {}
+
+  undici@8.5.0: {}
 
   unist-util-is@6.0.1:
     dependencies:


### PR DESCRIPTION
EDIT: Apologies here, Sol decided to PR into the main REPO instead of my project super.engineering 😅 

(Feel free to reopen or ping me if it seems useful)

## Summary
- add an RPC-native select/input fallback for the ask tool
- preserve the existing TUI and headless subagent paths
- cover single, Other, sequential cancellation, and multi-select flows

## Verification
- `cd packages/ask && corepack pnpm exec vitest run src/rpc.test.ts`
- `cd packages/ask && npx tsc --noEmit`
- `corepack pnpm test`