### PR TITLE
feat(subagent): expose child Pi session ID in results

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,6 +18,7 @@
 | 13 | [Lazy-load and profile startup](done/plan-014-lazy-load-and-profiling.md) | ✅ COMPLETED (PR #21) | 2026-07-20 |
 | 14 | [Agents local JSON for model overrides](done/plan-015-agents-local-json.md) | ✅ COMPLETED | 2026-07-27 |
 | 16 | [Subagent agent→model mirror fix + agent discovery](done/plan-016-subagent-model-mirror.md) | ✅ COMPLETED (squash `9ae002a`) | 2026-07-28 |
+| 17 | [Expose subagent Pi session IDs](done/2026-08-05-subagent-session-id.md) | ✅ COMPLETED | 2026-08-05 |
 
 > **Notes:**
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.
@@ -25,6 +26,6 @@
 
 ## Quick Stats
 
-- Total Plans: 16
-- Completed: 16
+- Total Plans: 17
+- Completed: 17
 - In Progress: 0

--- a/docs/plans/done/2026-08-05-subagent-session-id.md
+++ b/docs/plans/done/2026-08-05-subagent-session-id.md
@@ -1,0 +1,88 @@
+# Expose subagent Pi session IDs
+
+**Status:** COMPLETED
+
+**Created:** 2026-08-05
+
+## Goal
+
+Expose the logical Pi session UUID already created for each spawned subagent as optional `SubagentResult.childSessionId`.
+
+## Previous behavior
+
+Each executed subagent task launches its own fresh one-shot process:
+
+```text
+pi --mode json --no-session -p <task>
+```
+
+`--no-session` disables transcript persistence, not logical session identity. Pi still creates an in-memory UUID and emits it in the initial JSON event:
+
+```json
+{"type":"session","id":"<uuid>","timestamp":"...","cwd":"..."}
+```
+
+Before this change, `streamEvents` ignored that event. Results therefore had no deterministic key for joining a child execution to telemetry grouped by its Pi session.
+
+## Final design
+
+- Retain `--no-session` and all existing spawn behavior.
+- Capture a nonempty string `id` from Pi's JSON `session` event.
+- Store it in stream state and return it as optional `SubagentResult.childSessionId`.
+- Omit the field when the child exits before emitting a valid session event.
+- Keep the field out of high-frequency progress updates.
+- Use the Pi session UUID as the only external correlation key; do not add another invocation ID or a vendor-specific trace ID.
+
+## Compatibility and boundaries
+
+The field is additive and optional. Existing consumers that ignore it remain compatible.
+
+Unchanged behavior includes process arguments, environment inheritance, Windows spawning, IPC, cancellation, startup timeout, socket cleanup, progress payloads, usage and cost accounting, and parallel result ordering.
+
+This change does not:
+
+- persist child transcripts or remove `--no-session`;
+- add parent session IDs or distributed trace context;
+- couple Archimedes to Langfuse or another telemetry vendor; or
+- expose one-click trace URLs.
+
+## Changed surfaces
+
+- `packages/subagent/src/types.ts`
+- `packages/subagent/src/stream.ts`
+- `packages/subagent/src/stream.test.ts`
+- `packages/subagent/README.md`
+- `docs/plans/README.md`
+
+## Verification
+
+CI-equivalent checks:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm -r exec -- tsc --noEmit
+corepack pnpm test
+```
+
+Additional focused checks:
+
+```bash
+corepack pnpm --dir packages/subagent exec tsc --noEmit
+corepack pnpm --dir packages/subagent exec vitest run src/stream.test.ts
+```
+
+Results:
+
+- all 9 workspace package typechecks passed;
+- 2 focused stream tests passed;
+- all 223 repository tests passed; and
+- a manual one-shot run returned the exact child Pi session ID and used it to find the child's single external trace.
+
+## Acceptance criteria
+
+- [x] A valid JSON `session.id` is captured exactly.
+- [x] Missing or non-string session IDs are ignored.
+- [x] The final result contains the captured optional `childSessionId`.
+- [x] Failure before the session header leaves the field undefined.
+- [x] Progress shape and process, platform, cancellation, and ordering behavior remain unchanged.
+- [x] Focused, package, and repository checks pass.

--- a/packages/subagent/README.md
+++ b/packages/subagent/README.md
@@ -9,6 +9,7 @@ Subagent dispatch with live TUI streaming and cost tracking for the [Pi coding a
 - **Agent discovery** — auto-discovers agents from `.pi/agents/*.md` files at project, user, and global scope
 - **Per-agent model override** — each subagent can use its own model, falling back to the parent's selection
 - **Cost tracking** — detailed token usage (input, output, cache read/write) and cost per subagent, emitted through the core bus for the footer to consume
+- **Trace correlation** — results expose the ephemeral child's logical Pi session UUID as optional `childSessionId` when Pi emits a valid session event
 - **`/agents` command** — full CRUD TUI for managing agent definitions with model picker, tool picker, and cross-scope collision warnings (available via the meta package)
 
 ## Screenshots

--- a/packages/subagent/src/stream.test.ts
+++ b/packages/subagent/src/stream.test.ts
@@ -1,0 +1,47 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { streamEvents } from "./stream.js";
+
+type FakeChild = ChildProcess & { stdout: PassThrough; stderr: PassThrough };
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  Object.assign(child, {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: () => true,
+  });
+  return child;
+}
+
+async function finishWith(events: Array<Record<string, unknown>>) {
+  const child = fakeChild();
+  const result = streamEvents(child);
+  for (const event of events) {
+    child.stdout.write(`${JSON.stringify(event)}\n`);
+  }
+  child.emit("close", 0);
+  return result;
+}
+
+describe("streamEvents session identity", () => {
+  it("returns the logical child Pi session ID", async () => {
+    const result = await finishWith([{
+      type: "session",
+      id: "00000000-0000-7000-8000-000000000003",
+    }]);
+
+    expect(result.childSessionId).toBe("00000000-0000-7000-8000-000000000003");
+  });
+
+  it("omits the child session ID when no valid session event arrives", async () => {
+    const result = await finishWith([
+      { type: "session" },
+      { type: "session", id: 42 },
+    ]);
+
+    expect(result.childSessionId).toBeUndefined();
+  });
+});

--- a/packages/subagent/src/stream.ts
+++ b/packages/subagent/src/stream.ts
@@ -127,6 +127,12 @@ export function streamEvents(
       clearStartupTimer();
 
       switch (event.type) {
+        case "session": {
+          if (typeof event.id === "string" && event.id) {
+            state.childSessionId = event.id;
+          }
+          break;
+        }
         case "tool_execution_start": {
           handleToolStart(state, event);
           emitProgress();
@@ -163,7 +169,7 @@ export function streamEvents(
           handleAgentEnd(state, event);
           break;
         }
-        // Ignore: session, agent_start, message_start, message_update, turn_end, tool_execution_update
+        // Ignore: agent_start, message_start, message_update, turn_end, tool_execution_update
       }
     });
 
@@ -183,6 +189,7 @@ export function streamEvents(
       const result: SubagentResult = {
         agent: callbacks.agent ?? "subagent",
         task: callbacks.task ?? "",
+        ...(state.childSessionId ? { childSessionId: state.childSessionId } : {}),
         exitCode,
         model: state.model,
         usage: {

--- a/packages/subagent/src/types.ts
+++ b/packages/subagent/src/types.ts
@@ -34,6 +34,8 @@ export interface SubagentProgress {
 export interface SubagentResult {
   agent: string;
   task: string;
+  /** Logical Pi session UUID for this spawned subagent process. */
+  childSessionId?: string;
   exitCode: number;
   usage: SubagentUsage;
   model: string | undefined;
@@ -57,6 +59,7 @@ export interface SubagentDetails {
 
 /** Mutable state during streaming — shared between stream.ts and handlers.ts */
 export interface StreamState {
+  childSessionId?: string;
   toolCount: number;
   turnCount: number;
   totalInput: number;


### PR DESCRIPTION
## Summary

Archimedes results currently omit the logical session ID of the child Pi process. This PR exposes that existing ID as optional `SubagentResult.childSessionId`. The subagent stream captures Pi's initial JSON `session.id`, returns it without modification, and documents the new result metadata as a vendor-neutral external correlation key.

## Motivation

Each subagent task launches its own fresh `pi --mode json --no-session -p <task>` process. `--no-session` disables transcript persistence, but Pi still creates an in-memory logical session UUID and emits it in the initial JSON `session` event.

Before this PR, Archimedes ignored that event and its package documentation did not claim session or trace correlation support. Callers therefore had no deterministic key for joining a result to external telemetry grouped by the child Pi session.

## Compatibility

- `--no-session` remains unchanged; no child transcripts are persisted.
- `childSessionId` is additive and optional; it is absent if the process exits before a valid session event.
- Spawn arguments and environment, Windows behavior, IPC, cancellation, timeouts, progress payloads, usage accounting, and parallel result ordering are unchanged.
- No extra invocation ID, parent-session transport, distributed trace context, or vendor trace ID is added.

## Testing

CI-equivalent checks:

- `corepack pnpm install --frozen-lockfile` — passed with pinned pnpm 10
- `corepack pnpm -r exec -- tsc --noEmit` — passed across all 9 workspace packages
- `corepack pnpm test` — 223 passed

Additional focused checks:

- `corepack pnpm --dir packages/subagent exec tsc --noEmit` — passed
- `corepack pnpm --dir packages/subagent exec vitest run src/stream.test.ts` — 2 passed
- manual one-shot run — returned `childSessionId` exactly matched the child Pi session and enabled exact lookup of its single child trace

The completed design record is under `docs/plans/done/2026-08-05-subagent-session-id.md`, and `docs/plans/README.md` records it as completed. Package release remains a separate maintainer action.

Companion: [pi-langfuse #9](https://github.com/gooyoung/pi-langfuse/pull/9) uses Pi's public logical session ID for ephemeral roots.

## Development disclosure

This PR was developed with assistance from AI tooling. I reviewed the changes in full and take responsibility for their correctness.
