### PR TITLE
fix(core): preserve markdown transform pipeline in thinking renderer patch (restores Mermaid)

### DIFF
--- a/packages/core/src/thinking/patch.ts
+++ b/packages/core/src/thinking/patch.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { AssistantMessageComponent, VERSION } from "@earendil-works/pi-coding-agent";
-import { Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
+import { Markdown, type MarkdownOptions, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import { buildMutedMarkdownTheme } from "./theme.js";
 
 // The label we prepend to visible thinking content.
@@ -99,12 +99,52 @@ export function patchThinkingRenderer(getTheme: () => Theme): void {
       return mutedTheme;
     };
 
+    // Pi's native updateContent passes a `transform` (createMarkdownTransform)
+    // to Markdown so the markdown-transformer pipeline runs — that is what
+    // renders Mermaid blocks to ASCII and applies any extension transformers.
+    // We must preserve it here, otherwise those transformers are silently
+    // dropped when this patch replaces updateContent.
+    //
+    // NOTE: the `transform` option was added to @earendil-works/pi-tui in
+    // 0.84.1. The repo's lockfile pins 0.78.0 whose types lack the field, so we
+    // extend the options type locally; at runtime the field is ignored by very
+    // old pi-tui and honored by 0.84.1+ (which is where Mermaid rendering and
+    // the bug both exist).
+    type MarkdownOptionsWithTransform = MarkdownOptions & {
+      transform?: (markdown: string, availableWidth: number) => string;
+    };
+    const transformFor =
+      (messageType: "assistant" | "assistant-thinking") =>
+      (markdown: string, availableWidth: number): string => {
+        let out = markdown;
+        for (const transformer of (this as any).markdownTransformers ?? []) {
+          try {
+            const transformed = transformer(out, {
+              messageType,
+              isStreaming: this.isStreaming,
+              availableWidth,
+            });
+            if (typeof transformed === "string") out = transformed;
+          } catch {
+            // Keep the current markdown and continue with the next transformer.
+          }
+        }
+        return out;
+      };
+
     // Render content in order.
     for (let i = 0; i < message.content.length; i++) {
       const content = message.content[i];
       if (content.type === "text" && content.text.trim()) {
         this.contentContainer.addChild(
-          new Markdown(content.text.trim(), 1, 0, this.markdownTheme),
+          new Markdown(
+            content.text.trim(),
+            1,
+            0,
+            this.markdownTheme,
+            undefined,
+            { transform: transformFor("assistant") } as MarkdownOptionsWithTransform,
+          ),
         );
       } else if (content.type === "thinking" && content.thinking.trim()) {
         const hasVisibleContentAfter = message.content
@@ -133,10 +173,17 @@ export function patchThinkingRenderer(getTheme: () => Theme): void {
           if (!t) continue;
           const muted = ensureMuted();
           this.contentContainer.addChild(
-            new Markdown(thinkingContent, 1, 0, muted ?? this.markdownTheme, {
-              color: (text: string) => t.fg("thinkingText", text),
-              italic: true,
-            }),
+            new Markdown(
+              thinkingContent,
+              1,
+              0,
+              muted ?? this.markdownTheme,
+              {
+                color: (text: string) => t.fg("thinkingText", text),
+                italic: true,
+              },
+              { transform: transformFor("assistant-thinking") } as MarkdownOptionsWithTransform,
+            ),
           );
           if (hasVisibleContentAfter) {
             this.contentContainer.addChild(new Spacer(1));


### PR DESCRIPTION
## Summary

When `pi-archimedes` is active, Pi's native **Mermaid rendering stops working**: ```mermaid``` code blocks in assistant responses render as raw text instead of ASCII diagrams. The same root cause also silently disables every other markdown transformer registered by extensions.

## Root cause

`@pi-archimedes/core`'s `patchThinkingRenderer()` (in `packages/core/src/thinking/patch.ts`, called from `registerCore()` on `session_start`) replaces `AssistantMessageComponent.prototype.updateContent` with a version that constructs `Markdown` **without** the `transform` option:

```ts
this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, this.markdownTheme));
```

Pi's **native** `updateContent` passes it:

```ts
new Markdown(..., { transform: createMarkdownTransform("assistant", this.isStreaming, this.markdownTransformers) });
```

`createMarkdownTransform` (Pi core) iterates `markdownTransformers`, which includes Pi's **Mermaid transformer** (`grok-mermaid` → ASCII diagrams) plus any extension transformers. Because the archimedes patch drops `transform`, that pipeline never runs — Mermaid and other markdown transformers are silently lost.

> Note: `markdown.mermaid` is still `"final"` in settings, so this is easy to miss — nothing errors, blocks just render as plain code fences.

## Fix

Added a `transformFor(messageType)` helper that iterates `this.markdownTransformers` (mirroring Pi's `createMarkdownTransform`) and pass it to **both** the text and thinking `Markdown` calls. This preserves archimedes's muted-thinking styling **and** restores the Mermaid / transformer rendering.

```ts
const transformFor = (messageType: "assistant" | "assistant-thinking") =>
  (markdown: string, availableWidth: number): string => {
    let out = markdown;
    for (const transformer of (this as any).markdownTransformers ?? []) {
      try {
        const transformed = transformer(out, { messageType, isStreaming: this.isStreaming, availableWidth });
        if (typeof transformed === "string") out = transformed;
      } catch { /* keep current markdown */ }
    }
    return out;
  };
```

## Note on the `transform` option & types

The `transform` option was added to `@earendil-works/pi-tui` in **0.84.1**. The repo's lockfile pins `0.78.0`, whose `MarkdownOptions` type lacks the field — so the options object is cast to a locally-extended type (`MarkdownOptionsWithTransform`). At runtime:
- `pi-tui < 0.84.1`: `transform` is ignored (no Mermaid ASCII rendering there anyway),
- `pi-tui >= 0.84.1`: `transform` is honored, and this bug is fixed.

I'd suggest also bumping the repo's `@earendil-works/pi-tui` peer/dev dependency to `>=0.84.1` to drop the cast — happy to do that here if preferred.

## Type-check

`pnpm -r exec -- tsc --noEmit` passes.
