### PR TITLE
test: add pure logic tests for 21 untested files

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -21,7 +21,7 @@
 | 17 | [Splash Screen Pi 0.84.0 Compatibility](done/plan-017-splash-screen-pi-084.md) | ✅ COMPLETED | 2026-07-29 |
 | 18 | [Expose subagent Pi session IDs](done/2026-08-05-subagent-session-id.md) | ✅ COMPLETED | 2026-08-05 |
 | 19 | [README overhaul](done/plan-019-readme-overhaul.md) | ✅ COMPLETED (PR #27) | 2026-08-09 |
-| 20 | [Pure logic tests](plan-020-pure-logic-tests.md) | 📋 IN PROGRESS | 2026-08-10 |
+| 20 | [Pure logic tests](plan-020-pure-logic-tests.md) | ✅ COMPLETED (PR #28) | 2026-08-10 |
 
 > **Notes:**
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.
@@ -30,5 +30,5 @@
 ## Quick Stats
 
 - Total Plans: 19
-- Completed: 18
-- In Progress: 1
+- Completed: 19
+- In Progress: 0

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -21,6 +21,7 @@
 | 17 | [Splash Screen Pi 0.84.0 Compatibility](done/plan-017-splash-screen-pi-084.md) | ✅ COMPLETED | 2026-07-29 |
 | 18 | [Expose subagent Pi session IDs](done/2026-08-05-subagent-session-id.md) | ✅ COMPLETED | 2026-08-05 |
 | 19 | [README overhaul](done/plan-019-readme-overhaul.md) | ✅ COMPLETED (PR #27) | 2026-08-09 |
+| 20 | [Pure logic tests](plan-020-pure-logic-tests.md) | 📋 IN PROGRESS | 2026-08-10 |
 
 > **Notes:**
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.
@@ -28,6 +29,6 @@
 
 ## Quick Stats
 
-- Total Plans: 18
+- Total Plans: 19
 - Completed: 18
-- In Progress: 0
+- In Progress: 1

--- a/docs/plans/plan-020-pure-logic-tests.md
+++ b/docs/plans/plan-020-pure-logic-tests.md
@@ -1,0 +1,386 @@
+# Pure Logic Tests Plan
+
+**Goal:** Add unit tests + property-based tests for 21 untested pure-logic files across 6 packages, growing from 223 to ~400 tests.
+**Architecture:** Co-located `*.test.ts` files alongside source, using Vitest (already configured per-package) and fast-check for property-based testing.
+**Tech Stack:** Vitest 3.x, fast-check, TypeScript
+
+---
+
+## Task 1: Add fast-check dependency + Phase 1 easy wins (5 files)
+
+**Context:** fast-check enables property-based testing — instead of hand-writing examples, you declare invariants and the library generates thousands of random inputs (including edge cases like unicode, empty strings, control chars). This task adds the dependency and covers the 5 smallest untested files to build momentum.
+
+**Files:**
+- Modify: `package.json` (root — add devDependencies)
+- Create: `packages/core/src/thinking/transform.test.ts`
+- Create: `packages/core/src/thinking/unindent.test.ts`
+- Create: `packages/core/src/settings-io.test.ts`
+- Create: `packages/core/src/config.test.ts`
+- Create: `packages/subagent/src/cost.test.ts`
+
+**What to implement:**
+
+1. **Root `package.json`:** Add to `devDependencies`:
+   ```json
+   "fast-check": "^4.0.0"
+   ```
+   Run `pnpm install` to resolve. Use `fc.assert(fc.property(...))` directly inside `it()` blocks — no `@fast-check/vitest` wrapper needed.
+
+2. **`thinking/transform.test.ts`** — Test `transformThinkingContent`:
+   - Modifies thinking content on assistant messages
+   - Skips non-assistant messages
+   - Skips empty thinking
+   - Calls `unindentCodeBlocks` on thinking content
+   - Property: after transform, thinking is trimmed
+
+3. **`thinking/unindent.test.ts`** — Test `unindentCodeBlocks`:
+   - Strips common leading whitespace from fenced code blocks
+   - Preserves empty lines structure
+   - Leaves whitespace-only blocks untouched
+   - Handles CRLF → LF normalization
+   - Handles blocks with 0 indent on some lines (no stripping)
+   - Property (fast-check): `unindentCodeBlocks(unindentCodeBlocks(x)) === unindentCodeBlocks(x)` (idempotence)
+   - Property: output never contains `\r\n` (CRLF normalized to LF). Use `fc.fullString()` but filter out lone `\r` from generator to avoid false positives (lone `\r` passes through by design).
+
+4. **`settings-io.test.ts`** — Test `loadConfig` and `saveConfig`:
+   - **CRITICAL:** `SETTINGS_PATH` is computed at module load via `getAgentDir()`, and `node:fs` bindings are captured at import. Use `vi.hoisted` to set `process.env.PI_CODING_AGENT_DIR` before module evaluation, `vi.mock("@earendil-works/pi-coding-agent", ...)` to return a temp dir from `getAgentDir`, and `vi.mock("node:fs")` for all fs operations. Both `vi.mock` calls are hoisted automatically.
+   - `loadConfig` returns defaults when settings missing
+   - `loadConfig` merges settings over defaults
+   - `loadConfig` returns defaults on corrupt JSON
+   - `saveConfig` writes atomically (tmp + rename)
+   - `saveConfig` falls back to direct write on rename failure
+
+5. **`config.test.ts`** — Test `loadCoreConfig` and `saveCoreConfig`:
+   - Mock `loadConfig`/`saveConfig` from settings-io using `vi.mock("../settings-io.js", ...)`
+   - Verifies correct namespace (`archimedes.core`)
+   - Verifies default config shape
+
+6. **`cost.test.ts`** — Test `emitCostUpdate`:
+   - Mock the Bus
+   - Verifies `COST_UPDATE` event emitted with correct source prefix
+   - Verifies usage fields passed through
+
+**Steps:**
+- [ ] Add `fast-check` to root `package.json` devDependencies
+- [ ] Run `pnpm install`
+- [ ] Create `thinking/transform.test.ts` with 4-5 example tests
+- [ ] Create `thinking/unindent.test.ts` with 6-8 example tests + 2 property tests
+- [ ] Create `settings-io.test.ts` with 6-8 tests (mock fs + getAgentDir)
+- [ ] Create `config.test.ts` with 3-4 tests (mock settings-io)
+- [ ] Create `cost.test.ts` with 3-4 tests (mock Bus)
+- [ ] Run `pnpm test` — all tests pass
+- [ ] Run `npx tsc --noEmit` in each modified package — type-check passes
+- [ ] Commit with message: "test: add fast-check + Phase 1 easy wins (5 files)"
+
+**Acceptance criteria:**
+- [ ] All 5 test files pass with `pnpm test`
+- [ ] fast-check property tests run without errors
+- [ ] Type-check passes in all modified packages
+- [ ] Total test count increases by ~25+ tests
+
+---
+
+## Task 2: Phase 2 medium files — thinking/patch, thinking/theme, diff/ansi (4 files)
+
+**Context:** These files contain the core text processing and ANSI manipulation logic. They are the most bug-prone area (text transforms, color parsing) and benefit most from property-based testing.
+
+**Files:**
+- Create: `packages/core/src/thinking/patch.test.ts`
+- Create: `packages/core/src/thinking/theme.test.ts`
+- Create: `packages/diff/src/ansi/codes.test.ts`
+- Create: `packages/diff/src/ansi/colors.test.ts`
+
+**What to implement:**
+
+1. **`thinking/patch.test.ts`** — Test `patchThinkingRenderer`:
+   - This function patches `AssistantMessageComponent.prototype.updateContent` — heavily depends on Pi runtime
+   - Test the guard conditions: returns early when proto is null, updateContent not a function, name mismatch
+   - Test signature detection: skips patch when source lacks expected strings
+   - Test version tracking: re-patches on version change
+   - **CRITICAL:** `patch.ts` marks the prototype via `Symbol.for("archimedes:thinkingPatched")` (global-registry symbol). Each test must use a **fresh mock class** (not a shared one) or delete the symbol keys in `afterEach` to avoid state leaking between tests.
+   - Mock `AssistantMessageComponent` and `VERSION` from pi-coding-agent using `vi.mock("@earendil-works/pi-coding-agent", ...)`
+
+2. **`thinking/theme.test.ts`** — Test `dimAnsiLine` and `buildMutedMarkdownTheme`:
+   - `dimAnsiLine`: rewrites ANSI fg color escapes to dimmed versions
+   - Tests: single escape, multiple escapes, no escapes, non-fg escapes preserved
+   - Tests: cache hit returns same result
+   - Tests: unrecognized escape passed through unchanged
+   - `buildMutedMarkdownTheme`: returns MarkdownTheme with all required fields
+   - Tests: all theme fields are functions
+   - Tests: heading/bold use gold color
+   - Tests: codeBlock uses thinkingText
+   - Property (fast-check): `dimAnsiLine` preserves non-ANSI text content (strip ANSI from both sides and compare)
+   - Property: `dimAnsiLine` never introduces `38;5;` escapes (only produces truecolor `38;2;` output)
+
+3. **`diff/ansi/codes.test.ts`** — Test ANSI code constants and theme resolution:
+   - All exported constants are non-empty strings
+   - `ANSI_RE` matches standard ANSI escapes
+   - `ANSI_CAPTURE_RE` captures parameters
+   - `ANSI_PARAM_CAPTURE_RE` captures numeric params
+   - `themeCacheKey` returns deterministic string for same theme
+   - `themeCacheKey` returns "no-theme" for null/undefined theme
+   - `resolveDiffColors` returns DEFAULT_DIFF_COLORS when no theme
+   - `resolveDiffColors` returns theme-derived colors when theme available
+   - `resetDiffColors` clears cache (subsequent call re-derives)
+   - Property: `themeCacheKey(a) === themeCacheKey(a)` (deterministic)
+
+4. **`diff/ansi/colors.test.ts`** — Test `deriveBgFromTheme`:
+   - `parseAnsiRgb` and `mixBg` are **not exported** — test only through `deriveBgFromTheme`'s public output.
+   - `deriveBgFromTheme` returns DEFAULT_DIFF_BG when no theme (null, undefined, missing getFgAnsi)
+   - `deriveBgFromTheme` derives colors from theme with getFgAnsi
+   - `deriveBgFromTheme` uses bgBase from theme when available (getBgAnsi)
+   - `deriveBgFromTheme` returns DiffBg with all required fields (bgAdd, bgDel, etc.)
+   - Verify that bg colors are ANSI truecolor escapes (`\x1b[48;2;r;g;bm` format)
+   - Verify that divider contains `FG_RULE` character
+   - Property (fast-check): `deriveBgFromTheme` output `rst` always contains `\x1b[0m` (reset)
+
+**Steps:**
+- [ ] Create `thinking/patch.test.ts` with 5-6 tests (mock Pi runtime)
+- [ ] Create `thinking/theme.test.ts` with 8-10 tests + 2 property tests
+- [ ] Create `diff/ansi/codes.test.ts` with 8-10 tests + 1 property test
+- [ ] Create `diff/ansi/colors.test.ts` with 8-10 tests + 3 property tests
+- [ ] Run `pnpm test` — all tests pass
+- [ ] Run `npx tsc --noEmit` in core and diff packages
+- [ ] Commit with message: "test: Phase 2 — thinking/patch, theme, diff/ansi (4 files)"
+
+**Acceptance criteria:**
+- [ ] All 4 test files pass with `pnpm test`
+- [ ] Property tests exercise edge cases (unicode, empty, huge inputs)
+- [ ] Type-check passes in core and diff packages
+- [ ] Total test count increases by ~40+ tests
+
+---
+
+## Task 3: Phase 2 medium files — footer, todo, subagent, ask (6 files)
+
+**Context:** These cover the remaining medium-complexity files across packages. Mix of pure computation (stats, git parsing) and state management (todo, frontmatter).
+
+**Files:**
+- Create: `packages/footer/src/utils/stats.test.ts`
+- Create: `packages/footer/src/utils/git.test.ts`
+- Create: `packages/todo/src/state-manager.test.ts`
+- Create: `packages/subagent/src/frontmatter-io.test.ts`
+- Create: `packages/ask/src/cursor.test.ts`
+- Create: `packages/ask/src/wrap.test.ts`
+
+**What to implement:**
+
+1. **`stats.test.ts`** — Test `getTokenUsageStats`, `invalidateStatsCache`, `getContextWindowInfo`:
+   - Mock `ExtensionContext` with `sessionManager.getEntries()` and `getContextUsage()`
+   - **CRITICAL:** Module-level `runningTotal` and `runningTotalEntryCount` persist across tests. Use strictly increasing entry counts per test (e.g., test 1: 0 entries, test 2: 1 entry, test 3: 2 entries) so the incremental-scan branch triggers correctly. Alternatively, use `vi.resetModules()` + dynamic import per test.
+   - Empty entries returns zero stats
+   - Single assistant message accumulates correctly
+   - Multiple messages sum correctly
+   - Non-assistant messages ignored
+   - Cache returns same result within TTL
+   - Cache invalidated by entry count change
+   - `invalidateStatsCache` clears cache
+   - `getContextWindowInfo` computes percentage correctly
+   - `getContextWindowInfo` handles missing context window
+   - Property: stats are monotonic (adding entries never decreases totals)
+
+2. **`git.test.ts`** — Test `getGitStatus` via mocking `execSync`:
+   - `parseGitOutput` is **not exported** — test through `getGitStatus` by mocking `child_process.execSync`
+   - Use `vi.mock("child_process", ...)` to intercept `execSync`
+   - **CRITICAL:** Module-level `gitStatusCache` and `gitRefreshTimer` persist. Use `vi.useFakeTimers()` and clear timers between tests, or use `vi.resetModules()` + dynamic import.
+   - Parse scored format lines (via mocked execSync output)
+   - Parse unscored format lines
+   - Parse untracked lines
+   - Parse branch summary (ahead/behind)
+   - Empty output returns zero status
+   - Malformed lines ignored gracefully
+   - `getWorktreeBranch` returns null when not in worktree
+   - Property: `getGitStatus` never throws (catches execSync errors gracefully)
+
+3. **`state-manager.test.ts`** — Test `TodoStateManager`:
+   - `read` returns copy (mutations don't affect internal state)
+   - `write` stores todos correctly
+   - `write` with all completed schedules auto-clear
+   - `clear` empties todos
+   - `getStats` computes correct counts
+   - `validate` catches missing fields
+   - `validate` catches invalid status values
+   - `validate` catches non-array input
+   - `validate` accepts valid input
+   - Use `vi.useFakeTimers()` for auto-clear timer tests
+   - Property: `validate(write(x)).valid === true` after write (round-trip)
+
+4. **`frontmatter-io.test.ts`** — Test `validateAgentName`, `serializeAgent`:
+   - `validateAgentName` accepts valid names (3-50 chars, lowercase alnum + hyphens)
+   - `validateAgentName` accepts single char names
+   - `validateAgentName` rejects empty, uppercase, special chars
+   - `serializeAgent` produces valid YAML frontmatter
+   - `serializeAgent` quotes values that need quoting
+   - `serializeAgent` includes optional fields when present
+   - `serializeAgent` omits optional fields when absent
+   - Property: `serializeAgent` output starts with `---\n` and contains a closing `\n---\n` delimiter (output ends with systemPrompt, not `---`)
+
+5. **`cursor.test.ts`** — Test `getLinearCursorIndexFromEditor`:
+   - Single line, cursor at start → 0
+   - Single line, cursor at end → line length
+   - Multi-line, cursor on second line → first line length + 1 + col
+   - Empty editor → 0
+   - Cursor beyond bounds clamped correctly
+   - Property: linear index always >= 0
+   - Property: linear index <= total character count
+
+6. **`wrap.test.ts`** — Test `appendWrappedTextLines`:
+   - Mock `wrapTextWithAnsi` and `truncateToWidth` from pi-tui
+   - Single line within width → no wrapping
+   - Long line → wrapped to specified width
+   - Multiline input → each line wrapped independently
+   - Indent reduces effective wrap width
+   - `formatLine` applied to each wrapped line
+   - Empty text → single empty line added
+   - Property: output lines never exceed `safeWidth` chars
+
+**Steps:**
+- [ ] Create `stats.test.ts` with 8-10 tests (mock ExtensionContext)
+- [ ] Create `git.test.ts` with 6-8 tests (test parseGitOutput directly)
+- [ ] Create `state-manager.test.ts` with 9-10 tests (fake timers for auto-clear)
+- [ ] Create `frontmatter-io.test.ts` with 8-9 tests + 1 property test
+- [ ] Create `cursor.test.ts` with 5-6 tests + 2 property tests
+- [ ] Create `wrap.test.ts` with 6-7 tests + 1 property test
+- [ ] Run `pnpm test` — all tests pass
+- [ ] Run `npx tsc --noEmit` in footer, todo, ask, subagent packages
+- [ ] Commit with message: "test: Phase 2 — footer, todo, subagent, ask (6 files)"
+
+**Acceptance criteria:**
+- [ ] All 6 test files pass with `pnpm test`
+- [ ] Type-check passes in all modified packages
+- [ ] Total test count increases by ~55+ tests
+
+---
+
+## Task 4: Phase 2 medium files — subagent/compact (1 file)
+
+**Context:** `compact.ts` contains the rendering logic for compact subagent display. It has pure functions (`buildActivityLine`, `statusGlyph`) mixed with rendering functions that depend on pi-tui's `Text` component.
+
+**Files:**
+- Create: `packages/subagent/src/compact.test.ts`
+
+**What to implement:**
+
+1. **`compact.test.ts`** — Test `buildActivityLine` and rendering functions:
+   - `buildActivityLine` with error → shows error prefix
+   - `buildActivityLine` with completed status → "✓ Done"
+   - `buildActivityLine` with failed status → "✗ Failed"
+   - `buildActivityLine` with running + current tool → tool name + args
+   - `buildActivityLine` with running + no tool → last tool call
+   - `buildActivityLine` with running + no info → "↳ Starting..."
+   - `buildActivityLine` with final output → first line of output
+   - Mock `Text` component for `renderCompactSingle`, `renderCompactParallel` etc.
+   - Verify `setText` called with expected output structure
+   - Property (fast-check): truncated fields (error, argsPreview, finalOutput first line) never exceed their `truncLine` limits (80 or 60 chars). Use bounded generators (`fc.string({ maxLength: 20 })`) for non-truncated fields like `currentTool` and `lastCall.name` (which are NOT truncated by `buildActivityLine`).
+
+**Steps:**
+- [ ] Create `compact.test.ts` with 10-12 tests + 1 property test
+- [ ] Run `pnpm test` — all tests pass
+- [ ] Run `npx tsc --noEmit` in subagent package
+- [ ] Commit with message: "test: Phase 2 — subagent/compact (1 file)"
+
+**Acceptance criteria:**
+- [ ] Test file passes with `pnpm test`
+- [ ] Type-check passes in subagent package
+- [ ] Total test count increases by ~12+ tests
+
+---
+
+## Task 5: Phase 3 tricky files — startup, diff render/shiki (5 files)
+
+**Context:** These files depend on Pi runtime, Shiki, or TUI components. Use snapshot tests for rendering output and mocks for external dependencies.
+
+**Files:**
+- Create: `packages/core/src/startup/sections.test.ts`
+- Create: `packages/core/src/startup/logo.test.ts`
+- Create: `packages/core/src/startup/version.test.ts`
+- Create: `packages/diff/src/core/diff.test.ts`
+- Create: `packages/diff/src/shiki.test.ts`
+
+**What to implement:**
+
+1. **`sections.test.ts`** — Test section parsing and formatting:
+   - `detectSection` finds section key in text
+   - `detectSection` returns undefined for non-section text
+   - `parseSectionText` extracts items correctly
+   - `parseSectionText` deduplicates items
+   - `parseSectionText` prefers prefixed over bare names
+   - `parseModelScope` extracts model names
+   - `extractName` with various section types
+   - `formatColumns` produces expected output structure
+   - `buildItemWrapper` with revealed/unrevealed states
+   - **CRITICAL:** `sections.ts` imports `TRUECOLOR` from `./logo.js` (computed at module load). Use `vi.mock("./logo.js", () => ({ TRUECOLOR: false }))` to force deterministic output for `formatColumns` tests. Without this, snapshot output differs between local (TRUECOLOR=true) and CI (TRUECOLOR=false).
+   - Mock `Theme` and `visibleWidth` from pi-tui
+   - **NOTE:** `formatColumns` takes `RenderSection[]` (not exported). Use `as const` on the `name` field or cast to satisfy the string-literal union type.
+
+2. **`logo.test.ts`** — Test logo rendering:
+   - `LOGO` is 8 rows × 16 chars each (e.g. `"████████████    "` = 12 blocks + 4 spaces)
+   - **CRITICAL:** `TRUECOLOR` is computed at module load from `process.env`. Use `vi.mock("./logo.js", ...)` to force a fixed `TRUECOLOR` value per test, or use `vi.hoisted` env setup + `vi.resetModules()` + dynamic import. Tests asserting both branches (true/false) must isolate the env value.
+   - `getShinedLogo` returns plain LOGO when TRUECOLOR is false
+   - `getShinedLogo` returns animated frames when TRUECOLOR is true
+   - `computeRevealAt` produces different values per animation style
+   - Test all 9 animation styles produce valid reveal times
+   - Property: `getShinedLogo` output always 8 rows
+   - Property: each row's **visible width** === 16 (strip ANSI escapes before measuring, using `stripAnsi` from `../text.js`)
+
+3. **`version.test.ts`** — Test `compareVersions`:
+   - `compareVersions("1.0.0", "1.0.0")` → 0
+   - `compareVersions("2.0.0", "1.9.9")` → 1
+   - `compareVersions("1.0.0", "2.0.0")` → -1
+   - Handles `v` prefix
+   - Handles partial versions ("1.0" vs "1.0.0")
+   - Property: `compareVersions(a, a) === 0` (reflexive)
+   - Property: `compareVersions(a, b) === -compareVersions(b, a)` (antisymmetric)
+   - Property: transitivity — if a<b and b<c then a<c
+   - **NOTE:** Generate versions via `fc.tuple(fc.nat(), fc.nat(), fc.nat()).map(t => t.join("."))` — not arbitrary strings — to avoid `NaN` from `Number("x")` muddying the properties.
+
+4. **`diff.test.ts`** — Test `parseDiff`:
+   - Identical content → empty lines, zero counts
+   - Single line addition
+   - Single line deletion
+   - Mixed add/delete/context
+   - Multiple hunks with separator
+   - Context lines have both oldNum and newNum
+   - Added lines have only newNum
+   - Deleted lines have only oldNum
+   - Property: `parseDiff(x, x).lines.length === 0` (reflexive)
+   - Property: `parseDiff(a, b).added >= 0 && removed >= 0` (non-negative)
+
+5. **`shiki.test.ts`** — Test `lang` function and cache behavior:
+   - `lang` resolves common extensions correctly
+   - `lang` returns undefined for unknown extensions
+   - `lang` is case-insensitive for extensions
+   - Mock `codeToANSI` to avoid actual Shiki initialization
+   - Test `setConfigGetter` changes theme
+   - Property: `lang(x)` returns consistent result for same extension
+
+**Steps:**
+- [ ] Create `sections.test.ts` with 8-10 tests + snapshot for formatColumns
+- [ ] Create `logo.test.ts` with 6-8 tests + 2 property tests
+- [ ] Create `version.test.ts` with 5-6 tests + 3 property tests
+- [ ] Create `diff.test.ts` with 8-9 tests + 2 property tests
+- [ ] Create `shiki.test.ts` with 5-6 tests + 1 property test
+- [ ] Run `pnpm test` — all tests pass
+- [ ] Run `npx tsc --noEmit` in core and diff packages
+- [ ] Commit with message: "test: Phase 3 — startup, diff render/shiki (5 files)"
+
+**Acceptance criteria:**
+- [ ] All 5 test files pass with `pnpm test`
+- [ ] Snapshot tests capture expected rendering output
+- [ ] Type-check passes in core and diff packages
+- [ ] Total test count increases by ~45+ tests
+
+---
+
+## Summary
+
+| Phase | Files | Estimated Tests | Property Tests |
+|-------|-------|----------------|----------------|
+| 1 (easy) | 5 | ~25 | ~3 |
+| 2 (medium) | 11 | ~110 | ~12 |
+| 3 (tricky) | 5 | ~45 | ~9 |
+| **Total** | **21** | **~180** | **~24** |
+
+Plus existing 223 tests = **~400 total** (conservative estimate; could be higher with thorough property tests).
+
+Each task is independently commitable. Run `pnpm test` after each task to verify.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     ]
   },
   "devDependencies": {
+    "fast-check": "^4.0.0",
+    "typescript": "^7.0.2",
     "vitest": "^3.0.0"
   }
 }

--- a/packages/ask/src/cursor.test.ts
+++ b/packages/ask/src/cursor.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { getLinearCursorIndexFromEditor } from "./cursor.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+interface MockEditor {
+  lines: string[];
+  cursorLine: number;
+  cursorCol: number;
+}
+
+function makeEditor(lines: string[], cursorLine: number, cursorCol: number): MockEditor {
+  return { lines, cursorLine, cursorCol };
+}
+
+function editorFromMock(m: MockEditor) {
+  return {
+    getLines: () => m.lines,
+    getCursor: () => ({ line: m.cursorLine, col: m.cursorCol }),
+  };
+}
+
+// ── getLinearCursorIndexFromEditor ──────────────────────────────────────────
+
+describe("getLinearCursorIndexFromEditor", () => {
+  it("single line, cursor at start → 0", () => {
+    const editor = editorFromMock(makeEditor(["hello"], 0, 0));
+    expect(getLinearCursorIndexFromEditor(editor)).toBe(0);
+  });
+
+  it("single line, cursor at end → line length", () => {
+    const editor = editorFromMock(makeEditor(["hello"], 0, 5));
+    expect(getLinearCursorIndexFromEditor(editor)).toBe(5);
+  });
+
+  it("multi-line, cursor on second line → first line length + 1 + col", () => {
+    const editor = editorFromMock(makeEditor(["hello", "world"], 1, 3));
+    // "hello" (5 chars) + "\n" (1 char) + 3 cols into "world" = 9
+    expect(getLinearCursorIndexFromEditor(editor)).toBe(9);
+  });
+
+  it("empty editor → 0", () => {
+    const editor = editorFromMock(makeEditor([], 0, 0));
+    expect(getLinearCursorIndexFromEditor(editor)).toBe(0);
+  });
+
+  it("cursor beyond bounds clamped correctly", () => {
+    const editor = editorFromMock(makeEditor(["hi"], 10, 100));
+    // Clamped to last line (line 0) and end of line (col 2)
+    expect(getLinearCursorIndexFromEditor(editor)).toBe(2);
+  });
+
+  it("property: linear index always >= 0", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ maxLength: 50 }), { maxLength: 20 }),
+        fc.nat({ max: 100 }),
+        fc.nat({ max: 100 }),
+        (lines, cursorLine, cursorCol) => {
+          const editor = editorFromMock(makeEditor(lines, cursorLine, cursorCol));
+          const result = getLinearCursorIndexFromEditor(editor);
+          if (result < 0) {
+            throw new Error(`Linear index is negative: ${result}`);
+          }
+        },
+      ),
+      { verbose: false },
+    );
+  });
+
+  it("property: linear index <= total character count", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ maxLength: 50 }), { maxLength: 20 }),
+        fc.nat({ max: 100 }),
+        fc.nat({ max: 100 }),
+        (lines, cursorLine, cursorCol) => {
+          const editor = editorFromMock(makeEditor(lines, cursorLine, cursorCol));
+          const result = getLinearCursorIndexFromEditor(editor);
+          const totalChars = lines.reduce((sum, line, i) => sum + line.length + (i < lines.length - 1 ? 1 : 0), 0);
+          if (result > totalChars) {
+            throw new Error(`Linear index ${result} exceeds total chars ${totalChars}`);
+          }
+        },
+      ),
+      { verbose: false },
+    );
+  });
+});

--- a/packages/ask/src/wrap.test.ts
+++ b/packages/ask/src/wrap.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fc from "fast-check";
+
+// ── Mock @earendil-works/pi-tui ────────────────────────────────────────────
+
+vi.mock("@earendil-works/pi-tui", () => ({
+  wrapTextWithAnsi: vi.fn(),
+  truncateToWidth: vi.fn(),
+}));
+
+// Lazy import after mock is set up
+const { wrapTextWithAnsi, truncateToWidth } = await import("@earendil-works/pi-tui");
+
+const { appendWrappedTextLines } = await import("./wrap.js");
+
+describe("appendWrappedTextLines", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: wrapTextWithAnsi returns input as single line (no wrapping needed)
+    vi.mocked(wrapTextWithAnsi).mockImplementation((text: string) => [text]);
+
+    // Default: truncateToWidth returns input unchanged (no truncation needed)
+    vi.mocked(truncateToWidth).mockImplementation((text: string) => text);
+  });
+
+  it("single line within width → no wrapping", () => {
+    const rendered: string[] = [];
+    appendWrappedTextLines(rendered, "hello", 80);
+    expect(rendered).toEqual(["hello"]);
+    expect(wrapTextWithAnsi).toHaveBeenCalledWith("hello", 80);
+  });
+
+  it("long line → wrapped to specified width", () => {
+    vi.mocked(wrapTextWithAnsi).mockReturnValueOnce(["part1", "part2", "part3"]);
+    const rendered: string[] = [];
+    appendWrappedTextLines(rendered, "a very long line of text that needs wrapping", 10);
+    expect(rendered).toEqual(["part1", "part2", "part3"]);
+    expect(wrapTextWithAnsi).toHaveBeenCalledWith("a very long line of text that needs wrapping", 10);
+  });
+
+  it("multiline input → each line wrapped independently", () => {
+    vi.mocked(wrapTextWithAnsi).mockImplementation((text: string) => {
+      if (text === "line1") return ["line1"];
+      if (text === "line2") return ["line2"];
+      return [text];
+    });
+    const rendered: string[] = [];
+    appendWrappedTextLines(rendered, "line1\nline2", 80);
+    expect(rendered).toEqual(["line1", "line2"]);
+    expect(wrapTextWithAnsi).toHaveBeenCalledTimes(2);
+    expect(wrapTextWithAnsi).toHaveBeenNthCalledWith(1, "line1", 80);
+    expect(wrapTextWithAnsi).toHaveBeenNthCalledWith(2, "line2", 80);
+  });
+
+  it("indent reduces effective wrap width", () => {
+    const rendered: string[] = [];
+    appendWrappedTextLines(rendered, "hello", 80, { indent: 4 });
+    expect(wrapTextWithAnsi).toHaveBeenCalledWith("hello", 76);
+    expect(truncateToWidth).toHaveBeenCalledWith("    hello", 80);
+  });
+
+  it("formatLine applied to each wrapped line", () => {
+    vi.mocked(wrapTextWithAnsi).mockReturnValueOnce(["part1", "part2"]);
+    const formatLine = vi.fn((line: string) => `>>${line}<<`);
+    const rendered: string[] = [];
+    appendWrappedTextLines(rendered, "some text", 80, { formatLine });
+    expect(formatLine).toHaveBeenCalledWith("part1");
+    expect(formatLine).toHaveBeenCalledWith("part2");
+    expect(truncateToWidth).toHaveBeenCalledWith(">>part1<<", 80);
+    expect(truncateToWidth).toHaveBeenCalledWith(">>part2<<", 80);
+  });
+
+  it("empty text → single empty line added", () => {
+    const rendered: string[] = [];
+    appendWrappedTextLines(rendered, "", 80);
+    expect(rendered).toEqual([""]);
+  });
+
+  it("property: output lines never exceed safeWidth chars", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ maxLength: 200 }),
+        fc.integer({ min: 1, max: 80 }),
+        fc.integer({ min: 0, max: 20 }),
+        (text, width, indent) => {
+          const safeWidth = Math.max(1, Math.floor(width));
+          const actualIndent = Math.max(0, Math.floor(indent));
+          const wrapWidth = Math.max(1, safeWidth - actualIndent);
+
+          // Mock: wrap returns single line (worst case for truncation)
+          vi.mocked(wrapTextWithAnsi).mockReturnValueOnce([text]);
+          // Mock: truncateToWidth truncates to safeWidth
+          vi.mocked(truncateToWidth).mockImplementation((s: string) => s.slice(0, safeWidth));
+
+          const rendered: string[] = [];
+          appendWrappedTextLines(rendered, text, safeWidth, { indent: actualIndent });
+
+          for (const line of rendered) {
+            if (line.length > safeWidth) {
+              throw new Error(`Line length ${line.length} exceeds safeWidth ${safeWidth}`);
+            }
+          }
+        },
+      ),
+      { verbose: false },
+    );
+  });
+});

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./settings-io.js", () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+const { loadCoreConfig, saveCoreConfig, DEFAULT_CORE_CONFIG, ANIMATION_STYLES } =
+  await import("./config.js");
+const { loadConfig, saveConfig } = await import("./settings-io.js");
+
+describe("loadCoreConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses correct namespace", () => {
+    vi.mocked(loadConfig).mockReturnValue(DEFAULT_CORE_CONFIG);
+    loadCoreConfig();
+    expect(loadConfig).toHaveBeenCalledWith("archimedes.core", DEFAULT_CORE_CONFIG);
+  });
+
+  it("returns default config when no settings exist", () => {
+    vi.mocked(loadConfig).mockReturnValue(DEFAULT_CORE_CONFIG);
+    const result = loadCoreConfig();
+    expect(result).toEqual({
+      mutedTheme: false,
+      codeUnindent: true,
+      labelText: "Thinking...",
+      labelColor: "255,215,0",
+      animationStyle: "vertical-up",
+    });
+  });
+
+  it("passes through merged config from settings-io", () => {
+    const merged = { ...DEFAULT_CORE_CONFIG, mutedTheme: true };
+    vi.mocked(loadConfig).mockReturnValue(merged);
+    const result = loadCoreConfig();
+    expect(result).toEqual(merged);
+  });
+});
+
+describe("saveCoreConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("saves with correct namespace", () => {
+    saveCoreConfig(DEFAULT_CORE_CONFIG);
+    expect(saveConfig).toHaveBeenCalledWith("archimedes.core", DEFAULT_CORE_CONFIG);
+  });
+
+  it("passes config through unchanged", () => {
+    const config = { ...DEFAULT_CORE_CONFIG, mutedTheme: true };
+    saveCoreConfig(config);
+    expect(saveConfig).toHaveBeenCalledWith("archimedes.core", config);
+  });
+});
+
+describe("DEFAULT_CORE_CONFIG", () => {
+  it("has the expected shape", () => {
+    expect(DEFAULT_CORE_CONFIG).toEqual({
+      mutedTheme: false,
+      codeUnindent: true,
+      labelText: "Thinking...",
+      labelColor: "255,215,0",
+      animationStyle: "vertical-up",
+    });
+  });
+});
+
+describe("ANIMATION_STYLES", () => {
+  it("contains all expected styles", () => {
+    expect(ANIMATION_STYLES).toEqual([
+      "diagonal",
+      "top-right",
+      "bottom-left",
+      "bottom-right",
+      "center-out",
+      "wave",
+      "horizontal",
+      "vertical",
+      "vertical-up",
+    ]);
+  });
+});

--- a/packages/core/src/settings-io.test.ts
+++ b/packages/core/src/settings-io.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── hoisted: must use require() since vi.hoisted runs before imports ────────
+
+const { tempDir, fs, join, tmpdir, randomUUID } = vi.hoisted(() => {
+  const fs = require("node:fs");
+  const { join } = require("node:path");
+  const { tmpdir } = require("node:os");
+  const { randomUUID } = require("node:crypto");
+  const dir = join(tmpdir(), `settings-io-test-${randomUUID()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return { tempDir: dir, fs, join, tmpdir, randomUUID };
+});
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  getAgentDir: () => tempDir,
+}));
+
+// Import after mocks are set up
+const { loadConfig, saveConfig } = await import("./settings-io.js");
+
+describe("loadConfig", () => {
+  beforeEach(() => {
+    // Clean up settings file before each test
+    const settingsPath = join(tempDir, "settings.json");
+    if (fs.existsSync(settingsPath)) {
+      fs.unlinkSync(settingsPath);
+    }
+  });
+
+  afterEach(() => {
+    // Clean up temp dir artifacts
+    const settingsPath = join(tempDir, "settings.json");
+    const tmpPath = settingsPath + ".tmp";
+    try { fs.unlinkSync(settingsPath); } catch { /* ignore */ }
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  });
+
+  it("returns defaults when settings missing", () => {
+    const result = loadConfig("test.ns", { foo: "bar", count: 42 });
+    expect(result).toEqual({ foo: "bar", count: 42 });
+  });
+
+  it("merges settings over defaults", () => {
+    const settingsPath = join(tempDir, "settings.json");
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ "test.ns": { foo: "overridden" } }),
+      "utf-8",
+    );
+    const result = loadConfig("test.ns", { foo: "bar", count: 42 });
+    expect(result).toEqual({ foo: "overridden", count: 42 });
+  });
+
+  it("returns defaults on corrupt JSON", () => {
+    const settingsPath = join(tempDir, "settings.json");
+    fs.writeFileSync(settingsPath, "{ invalid json }", "utf-8");
+    const result = loadConfig("test.ns", { foo: "bar", count: 42 });
+    expect(result).toEqual({ foo: "bar", count: 42 });
+  });
+});
+
+describe("saveConfig", () => {
+  beforeEach(() => {
+    const settingsPath = join(tempDir, "settings.json");
+    if (fs.existsSync(settingsPath)) {
+      fs.unlinkSync(settingsPath);
+    }
+  });
+
+  afterEach(() => {
+    const settingsPath = join(tempDir, "settings.json");
+    const tmpPath = settingsPath + ".tmp";
+    try { fs.unlinkSync(settingsPath); } catch { /* ignore */ }
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  });
+
+  it("writes atomically (tmp + rename)", () => {
+    saveConfig("test.ns", { foo: "bar" });
+    const settingsPath = join(tempDir, "settings.json");
+    expect(fs.existsSync(settingsPath)).toBe(true);
+    const tmpPath = settingsPath + ".tmp";
+    expect(fs.existsSync(tmpPath)).toBe(false);
+    const data = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    expect(data["test.ns"]).toEqual({ foo: "bar" });
+  });
+
+  it("persists data for subsequent loads", () => {
+    saveConfig("test.ns", { foo: "bar", count: 42 });
+    const result = loadConfig("test.ns", { foo: "default", count: 0 });
+    expect(result).toEqual({ foo: "bar", count: 42 });
+  });
+
+  it("writes data correctly on success path", () => {
+    saveConfig("test.ns", { foo: "bar" });
+    const settingsPath = join(tempDir, "settings.json");
+    expect(fs.existsSync(settingsPath)).toBe(true);
+    const data = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    expect(data["test.ns"]).toEqual({ foo: "bar" });
+    // No .tmp file should remain after successful rename
+    expect(fs.existsSync(settingsPath + ".tmp")).toBe(false);
+  });
+});

--- a/packages/core/src/startup/logo.test.ts
+++ b/packages/core/src/startup/logo.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fc from "fast-check";
+import { stripAnsi } from "../text.js";
+
+// ── Helpers for dynamic imports with controlled TRUECOLOR ────────────────────
+
+async function importLogoWithTruecolor(truecolor: boolean) {
+	vi.resetModules();
+
+	// Set env before the module loads
+	const origColorterm = process.env.COLORTERM;
+	const origTerm = process.env.TERM;
+	const origTermProgram = process.env.TERM_PROGRAM;
+	const origWtSession = process.env.WT_SESSION;
+
+	if (truecolor) {
+		process.env.COLORTERM = "truecolor";
+	} else {
+		delete process.env.COLORTERM;
+		process.env.TERM = "xterm";
+		delete process.env.TERM_PROGRAM;
+		delete process.env.WT_SESSION;
+	}
+
+	const mod = await import("./logo.js");
+
+	// Restore env
+	if (origColorterm === undefined) delete process.env.COLORTERM;
+	else process.env.COLORTERM = origColorterm;
+	if (origTerm === undefined) delete process.env.TERM;
+	else process.env.TERM = origTerm;
+	if (origTermProgram === undefined) delete process.env.TERM_PROGRAM;
+	else process.env.TERM_PROGRAM = origTermProgram;
+	if (origWtSession === undefined) delete process.env.WT_SESSION;
+	else process.env.WT_SESSION = origWtSession;
+
+	return mod;
+}
+
+// ── LOGO structure (static, no env dependency) ──────────────────────────────
+
+describe("LOGO structure", () => {
+	it("has 8 rows", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.LOGO.length).toBe(8);
+	});
+
+	it("each row has 16 characters", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		for (const row of mod.LOGO) {
+			expect(row.length).toBe(16);
+		}
+	});
+
+	it("first row is 12 blocks + 4 spaces", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.LOGO[0]).toBe("████████████    ");
+	});
+
+	it("last row is 4 blocks + 6 spaces + 4 blocks", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.LOGO[7]).toBe("████        ████");
+	});
+
+	it("LOGO contains only block chars and spaces", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		for (const row of mod.LOGO) {
+			for (const ch of row) {
+				expect(ch === " " || ch === "█").toBe(true);
+			}
+		}
+	});
+});
+
+// ── Animation constants ──────────────────────────────────────────────────────
+
+describe("animation constants", () => {
+	it("CHAR_FADE_FRAMES is 22", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.CHAR_FADE_FRAMES).toBe(22);
+	});
+
+	it("LOGO_SETTLE_FRAME is 90", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.LOGO_SETTLE_FRAME).toBe(90);
+	});
+
+	it("LOGO_PAD is 0", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.LOGO_PAD).toBe(0);
+	});
+
+	it("LOGO_GAP is 4", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.LOGO_GAP).toBe(4);
+	});
+});
+
+// ── TRUECOLOR detection ──────────────────────────────────────────────────────
+
+describe("TRUECOLOR", () => {
+	it("is true when COLORTERM contains truecolor", async () => {
+		const mod = await importLogoWithTruecolor(true);
+		expect(mod.TRUECOLOR).toBe(true);
+	});
+
+	it("is false when no truecolor env vars set", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		expect(mod.TRUECOLOR).toBe(false);
+	});
+});
+
+// ── getShinedLogo — non-truecolor ────────────────────────────────────────────
+
+describe("getShinedLogo (non-truecolor)", () => {
+	let mod: typeof import("./logo.js");
+
+	beforeEach(async () => {
+		mod = await importLogoWithTruecolor(false);
+	});
+
+	it("returns LOGO unchanged when TRUECOLOR is false", () => {
+		const result = mod.getShinedLogo(0, "wave");
+		expect(result).toBe(mod.LOGO);
+	});
+
+	it("returns LOGO at any frame when TRUECOLOR is false", () => {
+		expect(mod.getShinedLogo(999, "wave")).toBe(mod.LOGO);
+	});
+
+	it("returns 8 rows regardless of frame", () => {
+		expect(mod.getShinedLogo(50, "diagonal").length).toBe(8);
+	});
+});
+
+// ── getShinedLogo — truecolor ────────────────────────────────────────────────
+
+describe("getShinedLogo (truecolor)", () => {
+	let mod: typeof import("./logo.js");
+
+	beforeEach(async () => {
+		mod = await importLogoWithTruecolor(true);
+	});
+
+	it("returns 8 rows", () => {
+		expect(mod.getShinedLogo(0, "wave").length).toBe(8);
+	});
+
+	it("returns different output than LOGO when TRUECOLOR is true", () => {
+		const result = mod.getShinedLogo(50, "wave");
+		expect(result).not.toBe(mod.LOGO);
+	});
+
+	it("early frames show spaces for not-yet-revealed chars", () => {
+		const result = mod.getShinedLogo(0, "vertical");
+		// At frame 0, nothing should be revealed yet
+		for (const row of result) {
+			const stripped = stripAnsi(row);
+			expect(stripped).toMatch(/^[\s]*$/);
+		}
+	});
+
+	it("late frames show all characters revealed", () => {
+		const result = mod.getShinedLogo(200, "vertical");
+		for (let i = 0; i < result.length; i++) {
+			const stripped = stripAnsi(result[i]!);
+			const expected = stripAnsi(mod.LOGO[i]!);
+			expect(stripped).toBe(expected);
+		}
+	});
+
+	it("output contains ANSI gray escapes", () => {
+		const result = mod.getShinedLogo(50, "wave");
+		const joined = result.join("\n");
+		expect(joined).toMatch(/\x1b\[38;2;\d+;\d+;\d+m/);
+	});
+
+	it("default style is wave", () => {
+		const result1 = mod.getShinedLogo(50);
+		const result2 = mod.getShinedLogo(50, "wave");
+		expect(result1).toEqual(result2);
+	});
+});
+
+// ── All animation styles ─────────────────────────────────────────────────────
+
+describe("animation styles", () => {
+	const styles = [
+		"diagonal",
+		"top-right",
+		"bottom-left",
+		"bottom-right",
+		"center-out",
+		"wave",
+		"horizontal",
+		"vertical",
+		"vertical-up",
+	] as const;
+
+	it.each(styles)("style '%s' produces valid reveal times", async (style) => {
+		const mod = await importLogoWithTruecolor(true);
+		const result = mod.getShinedLogo(100, style);
+		expect(result.length).toBe(8);
+		// Each row should be a string
+		for (const row of result) {
+			expect(typeof row).toBe("string");
+		}
+	});
+
+	it.each(styles)("style '%s' fully reveals at high frame count", async (style) => {
+		const mod = await importLogoWithTruecolor(true);
+		const result = mod.getShinedLogo(500, style);
+		for (let i = 0; i < result.length; i++) {
+			const stripped = stripAnsi(result[i]!);
+			const expected = stripAnsi(mod.LOGO[i]!);
+			expect(stripped).toBe(expected);
+		}
+	});
+});
+
+// ── Properties ───────────────────────────────────────────────────────────────
+
+describe("properties", () => {
+	it("getShinedLogo always returns 8 rows (truecolor)", async () => {
+		const mod = await importLogoWithTruecolor(true);
+		fc.assert(
+			fc.property(fc.nat(1000), n => {
+				return mod.getShinedLogo(n, "wave").length === 8;
+			}),
+		);
+	});
+
+	it("each row visible width equals 16 after stripping ANSI (truecolor)", async () => {
+		const mod = await importLogoWithTruecolor(true);
+		fc.assert(
+			fc.property(fc.nat(500), n => {
+				const result = mod.getShinedLogo(n, "diagonal");
+				for (const row of result) {
+					const stripped = stripAnsi(row);
+					// stripAnsi trims, so we check the raw row length instead
+					// The actual row length (including ANSI) may vary, but the
+					// visible content should always be 16 chars
+					// Since stripAnsi trims trailing spaces, check untrimmed
+					const raw = row.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "");
+					if (raw.length !== 16) return false;
+				}
+				return true;
+			}),
+		);
+	});
+
+	it("getShinedLogo returns 8 rows (non-truecolor)", async () => {
+		const mod = await importLogoWithTruecolor(false);
+		fc.assert(
+			fc.property(fc.nat(1000), n => {
+				return mod.getShinedLogo(n, "wave").length === 8;
+			}),
+		);
+	});
+});

--- a/packages/core/src/startup/sections.test.ts
+++ b/packages/core/src/startup/sections.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// Force TRUECOLOR=false so formatColumns output is deterministic across envs
+vi.mock("./logo.js", () => ({ TRUECOLOR: false }));
+
+// Mock pi-tui — visibleWidth and truncateToWidth
+vi.mock("@earendil-works/pi-tui", () => ({
+	visibleWidth: (s: string) => s.length,
+	truncateToWidth: (s: string, w: number) => s.slice(0, w),
+}));
+
+// ── Imports ──────────────────────────────────────────────────────────────────
+
+import {
+	detectSection,
+	parseSectionText,
+	parseModelScope,
+	extractName,
+	formatColumns,
+	buildItemWrapper,
+	SECTION_KEYS,
+	RAMP_FRAMES,
+} from "./sections.js";
+
+// ── detectSection ────────────────────────────────────────────────────────────
+
+describe("detectSection", () => {
+	it("finds Models section key", () => {
+		expect(detectSection("[Models]\nclaude-sonnet")).toBe("Models");
+	});
+
+	it("finds Context section key", () => {
+		expect(detectSection("some text [Context] more")).toBe("Context");
+	});
+
+	it("finds Prompts section key", () => {
+		expect(detectSection("[Prompts]")).toBe("Prompts");
+	});
+
+	it("finds Skills section key", () => {
+		expect(detectSection("Skills: [Skills] list")).toBe("Skills");
+	});
+
+	it("finds Extensions section key", () => {
+		expect(detectSection("[Extensions]\nfoo")).toBe("Extensions");
+	});
+
+	it("finds Themes section key", () => {
+		expect(detectSection("[Themes]\ndark")).toBe("Themes");
+	});
+
+	it("returns undefined for non-section text", () => {
+		expect(detectSection("just some random text")).toBeUndefined();
+	});
+
+	it("returns undefined for empty string", () => {
+		expect(detectSection("")).toBeUndefined();
+	});
+
+	it("returns undefined for bracketed text that is not a section key", () => {
+		expect(detectSection("[NotASection]")).toBeUndefined();
+	});
+
+	it("returns the first matching section key", () => {
+		const text = "[Models]\n[Context]";
+		expect(detectSection(text)).toBe("Models");
+	});
+});
+
+// ── parseSectionText ─────────────────────────────────────────────────────────
+
+describe("parseSectionText", () => {
+	it("extracts items correctly", () => {
+		const text = "[Models]\nclaude-sonnet\ngpt-4";
+		const result = parseSectionText(text);
+		expect(result).not.toBeUndefined();
+		expect(result!.name).toBe("Models");
+		expect(result!.items).toContain("claude-sonnet");
+		expect(result!.items).toContain("gpt-4");
+	});
+
+	it("returns undefined for non-section text", () => {
+		expect(parseSectionText("no section here")).toBeUndefined();
+	});
+
+	it("deduplicates items", () => {
+		const text = "[Models]\nclaude-sonnet\nclaude-sonnet\ngpt-4";
+		const result = parseSectionText(text);
+		expect(result).not.toBeUndefined();
+		const sonnetCount = result!.items.filter(i => i === "claude-sonnet").length;
+		expect(sonnetCount).toBe(1);
+	});
+
+	it("prefers prefixed over bare names", () => {
+		const text = "[Extensions]\nnpm:@foo/bar\n@foo/bar";
+		const result = parseSectionText(text);
+		expect(result).not.toBeUndefined();
+		// Should prefer the prefixed version
+		expect(result!.items.some(i => i.startsWith("npm:"))).toBe(true);
+	});
+
+	it("skips empty lines and bracket lines", () => {
+		const text = "[Themes]\n\ndark\n[Other]\nlight";
+		const result = parseSectionText(text);
+		expect(result).not.toBeUndefined();
+		expect(result!.items).toContain("dark");
+		// "light" is under [Other] which isn't a recognized section,
+		// but since we detected [Themes] first, items under [Other] should be skipped
+	});
+
+	it("handles empty section (no items)", () => {
+		const text = "[Models]";
+		const result = parseSectionText(text);
+		expect(result).not.toBeUndefined();
+		expect(result!.items.length).toBe(0);
+	});
+});
+
+// ── parseModelScope ──────────────────────────────────────────────────────────
+
+describe("parseModelScope", () => {
+	it("extracts model names from 'Model scope:' line", () => {
+		const text = "Model scope: claude-sonnet, gpt-4";
+		const result = parseModelScope(text);
+		expect(result).not.toBeUndefined();
+		expect(result!.name).toBe("Models");
+		expect(result!.items).toContain("claude-sonnet");
+		expect(result!.items).toContain("gpt-4");
+	});
+
+	it("strips keyboard shortcut hints", () => {
+		const text = "Model scope: claude-sonnet (Ctrl+1), gpt-4 (Ctrl+2)";
+		const result = parseModelScope(text);
+		expect(result).not.toBeUndefined();
+		expect(result!.items).toContain("claude-sonnet");
+		expect(result!.items).not.toContain("(Ctrl+1)");
+	});
+
+	it("returns undefined when no Model scope line", () => {
+		expect(parseModelScope("some random text")).toBeUndefined();
+	});
+
+	it("returns undefined for empty items", () => {
+		expect(parseModelScope("Model scope:  ")).toBeUndefined();
+	});
+
+	it("handles single model", () => {
+		const result = parseModelScope("Model scope: only-one");
+		expect(result).not.toBeUndefined();
+		expect(result!.items).toEqual(["only-one"]);
+	});
+});
+
+// ── extractName ──────────────────────────────────────────────────────────────
+
+describe("extractName", () => {
+	it("extracts Models name from path", () => {
+		expect(extractName("/path/to/claude-sonnet", "Models")).toBe("claude-sonnet");
+	});
+
+	it("extracts Themes name from path", () => {
+		expect(extractName("/path/to/dark-theme", "Themes")).toBe("dark-theme");
+	});
+
+	it("extracts Prompts name (strips extension)", () => {
+		expect(extractName("/path/to/my-prompt.ts", "Prompts")).toBe("my-prompt");
+	});
+
+	it("extracts Context name (basename only)", () => {
+		expect(extractName("/path/to/context-file.md", "Context")).toBe("context-file.md");
+	});
+
+	it("extracts Skills name from SKILL.md path", () => {
+		expect(extractName("/path/to/my-skill/SKILL.md", "Skills")).toBe("my-skill");
+	});
+
+	it("extracts Skills name from SKILL.ts path", () => {
+		expect(extractName("/path/to/my-skill/SKILL.ts", "Skills")).toBe("my-skill");
+	});
+
+	it("handles npm: prefix for Extensions", () => {
+		expect(extractName("npm:@foo/bar", "Extensions")).toBe("npm:bar");
+	});
+
+	it("handles git: prefix for Extensions", () => {
+		expect(extractName("git:github.com/user/repo", "Extensions")).toBe("git:repo");
+	});
+
+	it("strips file extensions for Models", () => {
+		expect(extractName("/path/to/model.ts", "Models")).toBe("model");
+	});
+
+	it("handles simple name without path", () => {
+		expect(extractName("simple-name", "Models")).toBe("simple-name");
+	});
+});
+
+// ── formatColumns ────────────────────────────────────────────────────────────
+
+describe("formatColumns", () => {
+	const mockTheme = {
+		fg: (token: string, text: string) => text,
+		getFgAnsi: (token: string) => "",
+	} as any;
+
+	const mockRef = {
+		frame: 100,
+		revealed: true,
+		revealedAt: 0,
+		scaffoldAt: 0,
+		settled: true,
+	};
+
+	it("returns empty array for empty sections", () => {
+		expect(formatColumns([], mockTheme, 80, mockRef)).toEqual([]);
+	});
+
+	it("returns empty array for sections with no items", () => {
+		const sections = [{ name: "Models" as const, items: [] }];
+		expect(formatColumns(sections, mockTheme, 80, mockRef)).toEqual([]);
+	});
+
+	it("formats a single section with items", () => {
+		const sections = [{ name: "Models" as const, items: ["claude-sonnet", "gpt-4"] }];
+		const result = formatColumns(sections, mockTheme, 80, mockRef);
+		expect(result.length).toBeGreaterThan(0);
+		// Should contain the section header
+		expect(result.some(line => line.includes("[Models]"))).toBe(true);
+	});
+
+	it("formats multiple sections", () => {
+		const sections = [
+			{ name: "Models" as const, items: ["claude"] },
+			{ name: "Themes" as const, items: ["dark"] },
+		];
+		const result = formatColumns(sections, mockTheme, 80, mockRef);
+		expect(result.some(line => line.includes("[Models]"))).toBe(true);
+		expect(result.some(line => line.includes("[Themes]"))).toBe(true);
+	});
+
+	it("adds blank line after Version section", () => {
+		const sections = [{ name: "Version" as const, items: ["1.0.0"] }];
+		const result = formatColumns(sections, mockTheme, 80, mockRef);
+		expect(result).toContain("");
+	});
+
+	it("wraps items to new lines when exceeding width", () => {
+		const longItems = Array.from({ length: 20 }, (_, i) => `model-${i}`);
+		const sections = [{ name: "Models" as const, items: longItems }];
+		const result = formatColumns(sections, mockTheme, 40, mockRef);
+		// With narrow width, items should wrap to multiple lines
+		expect(result.length).toBeGreaterThan(1);
+	});
+
+	it("handles unrevealed state", () => {
+		const sections = [{ name: "Models" as const, items: ["test"] }];
+		const unrevealedRef = { ...mockRef, revealed: false };
+		const result = formatColumns(sections, mockTheme, 80, unrevealedRef);
+		expect(result.length).toBeGreaterThan(0);
+	});
+});
+
+// ── buildItemWrapper ─────────────────────────────────────────────────────────
+
+describe("buildItemWrapper", () => {
+	const muted = (t: string) => `\x1b[90m${t}\x1b[0m`;
+
+	it("returns identity function when not revealed", () => {
+		const wrapper = buildItemWrapper(0, false, undefined, undefined, muted);
+		expect(wrapper("hello")).toBe("hello");
+	});
+
+	it("returns muted function when no RGB data", () => {
+		const wrapper = buildItemWrapper(10, true, undefined, undefined, muted);
+		expect(wrapper("hello")).toBe(muted("hello"));
+	});
+
+	it("returns muted function when ramp is complete", () => {
+		const startRgb = [20, 20, 20] as [number, number, number];
+		const mutedRgb = [100, 100, 100] as [number, number, number];
+		const wrapper = buildItemWrapper(RAMP_FRAMES, true, startRgb, mutedRgb, muted);
+		expect(wrapper("hello")).toBe(muted("hello"));
+	});
+
+	it("returns rgb-colored function during ramp", () => {
+		const startRgb = [20, 20, 20] as [number, number, number];
+		const mutedRgb = [200, 200, 200] as [number, number, number];
+		const wrapper = buildItemWrapper(1, true, startRgb, mutedRgb, muted);
+		const result = wrapper("hello");
+		// Should be a truecolor ANSI escape, not the muted fallback
+		expect(result).toMatch(/\x1b\[38;2;\d+;\d+;\d+mhello\x1b\[0m/);
+		expect(result).not.toContain("\x1b[90m");
+	});
+
+	it("lerps colors correctly at midpoint", () => {
+		const startRgb = [0, 0, 0] as [number, number, number];
+		const endRgb = [200, 200, 200] as [number, number, number];
+		// At exactly RAMP_FRAMES / 2, t = 0.5, eased = 0.75
+		const midAge = Math.floor(RAMP_FRAMES / 2);
+		const wrapper = buildItemWrapper(midAge, true, startRgb, endRgb, muted);
+		const result = wrapper("x");
+		// eased = 1 - (1-0.5)^2 = 0.75
+		// lerp(0, 200, 0.75) = 150
+		expect(result).toContain("\x1b[38;2;150;150;150mx\x1b[0m");
+	});
+
+	it("returns muted when mutedRgb is undefined", () => {
+		const startRgb = [20, 20, 20] as [number, number, number];
+		const wrapper = buildItemWrapper(5, true, startRgb, undefined, muted);
+		expect(wrapper("hello")).toBe(muted("hello"));
+	});
+});

--- a/packages/core/src/startup/sections.test.ts
+++ b/packages/core/src/startup/sections.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 // Force TRUECOLOR=false so formatColumns output is deterministic across envs
-vi.mock("./logo.js", () => ({ TRUECOLOR: false }));
+vi.mock("./logo.js", async (importOriginal) => ({ ...(await importOriginal()), TRUECOLOR: false }));
 
 // Mock pi-tui — visibleWidth and truncateToWidth
 vi.mock("@earendil-works/pi-tui", () => ({

--- a/packages/core/src/startup/version.test.ts
+++ b/packages/core/src/startup/version.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { compareVersions } from "./version.js";
+
+// ── Version generator for property tests ─────────────────────────────────────
+
+const versionArb = fc.tuple(fc.nat(100), fc.nat(100), fc.nat(100)).map(
+	([major, minor, patch]) => `${major}.${minor}.${patch}`,
+);
+
+// ── compareVersions ──────────────────────────────────────────────────────────
+
+describe("compareVersions", () => {
+	it('returns 0 for equal versions', () => {
+		expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+	});
+
+	it('returns 1 when first version is greater', () => {
+		expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+	});
+
+	it('returns -1 when second version is greater', () => {
+		expect(compareVersions("1.0.0", "2.0.0")).toBe(-1);
+	});
+
+	it("handles v prefix on first argument", () => {
+		expect(compareVersions("v1.2.3", "1.2.3")).toBe(0);
+	});
+
+	it("handles v prefix on second argument", () => {
+		expect(compareVersions("1.2.3", "v1.2.3")).toBe(0);
+	});
+
+	it("handles v prefix on both arguments", () => {
+		expect(compareVersions("v2.0.0", "v1.0.0")).toBe(1);
+	});
+
+	it("handles partial versions (2 parts vs 3 parts)", () => {
+		expect(compareVersions("1.0", "1.0.0")).toBe(0);
+	});
+
+	it("handles partial versions with difference", () => {
+		expect(compareVersions("1.1", "1.0.5")).toBe(1);
+	});
+
+	it("handles zero-padded versions", () => {
+		expect(compareVersions("01.02.03", "1.2.3")).toBe(0);
+	});
+
+	it("compares minor version correctly", () => {
+		expect(compareVersions("1.2.0", "1.1.9")).toBe(1);
+		expect(compareVersions("1.1.0", "1.2.0")).toBe(-1);
+	});
+
+	it("compares patch version correctly", () => {
+		expect(compareVersions("1.0.5", "1.0.3")).toBe(1);
+		expect(compareVersions("1.0.3", "1.0.5")).toBe(-1);
+	});
+
+	it("handles all-zero versions", () => {
+		expect(compareVersions("0.0.0", "0.0.0")).toBe(0);
+	});
+
+	// ── Property tests ───────────────────────────────────────────────────
+
+	it("property: reflexive — compareVersions(a, a) === 0", () => {
+		fc.assert(
+			fc.property(versionArb, a => {
+				return compareVersions(a, a) === 0;
+			}),
+		);
+	});
+
+	it("property: antisymmetric — compareVersions(a, b) === -compareVersions(b, a)", () => {
+		fc.assert(
+			fc.property(versionArb, versionArb, (a, b) => {
+				return compareVersions(a, b) === -compareVersions(b, a);
+			}),
+		);
+	});
+
+	it("property: transitivity — if a<b and b<c then a<c", () => {
+		fc.assert(
+			fc.property(
+				fc.tuple(versionArb, versionArb, versionArb),
+				([a, b, c]) => {
+					const ab = compareVersions(a, b);
+					const bc = compareVersions(b, c);
+					const ac = compareVersions(a, c);
+					if (ab < 0 && bc < 0) {
+						return ac < 0;
+					}
+					return true;
+				},
+			),
+		);
+	});
+});

--- a/packages/core/src/thinking/patch.test.ts
+++ b/packages/core/src/thinking/patch.test.ts
@@ -40,7 +40,8 @@ describe("patchThinkingRenderer", () => {
 
 		const patch = await importPatch();
 		patch(() => ({} as any));
-		// No patching should occur — proto is null
+		// Prototype must still be null — no patching occurred
+		expect(MockClass.prototype).toBeNull();
 	});
 
 	it("returns early when updateContent is not a function", async () => {
@@ -55,6 +56,8 @@ describe("patchThinkingRenderer", () => {
 
 		const patch = await importPatch();
 		patch(() => ({} as any));
+		// PATCHED_KEY must NOT be set — early return before patching
+		expect(MockClass.prototype[PATCHED_KEY]).toBeUndefined();
 	});
 
 	it("returns early when class name does not match", async () => {
@@ -69,7 +72,8 @@ describe("patchThinkingRenderer", () => {
 
 		const patch = await importPatch();
 		patch(() => ({} as any));
-		// Name is "WrongName", not "AssistantMessageComponent" — should skip
+		// PATCHED_KEY must NOT be set — name mismatch causes early return
+		expect(WrongName.prototype[PATCHED_KEY]).toBeUndefined();
 	});
 
 	it("returns early when source lacks thinking check", async () => {
@@ -87,7 +91,8 @@ describe("patchThinkingRenderer", () => {
 
 		const patch = await importPatch();
 		patch(() => ({} as any));
-		// Signature mismatch — no thinking check in source
+		// PATCHED_KEY must NOT be set — signature mismatch causes early return
+		expect(MockClass.prototype[PATCHED_KEY]).toBeUndefined();
 	});
 
 	it("returns early when source lacks markdownTheme reference", async () => {
@@ -107,7 +112,8 @@ describe("patchThinkingRenderer", () => {
 
 		const patch = await importPatch();
 		patch(() => ({} as any));
-		// Signature mismatch — no markdownTheme in source
+		// PATCHED_KEY must NOT be set — signature mismatch causes early return
+		expect(MockClass.prototype[PATCHED_KEY]).toBeUndefined();
 	});
 
 	it("patches successfully when signature matches", async () => {
@@ -209,10 +215,13 @@ describe("patchThinkingRenderer", () => {
 		// First patch
 		patch(() => ({} as any));
 		expect(MockClass.prototype[PATCHED_KEY]).toBe(true);
+		const first = MockClass.prototype.updateContent;
 
-		// Second patch (same version) — should still re-patch the function
+		// Second patch (same version) — must produce a new function
 		patch(() => ({} as any));
 		expect(MockClass.prototype[PATCHED_KEY]).toBe(true);
 		expect(MockClass.prototype[PATCH_VERSION_KEY]).toBe("1.0.0");
+		// The patched function must be a new closure (not the same reference)
+		expect(MockClass.prototype.updateContent).not.toBe(first);
 	});
 });

--- a/packages/core/src/thinking/patch.test.ts
+++ b/packages/core/src/thinking/patch.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// Symbols used by patch.ts to mark patched prototypes
+const PATCHED_KEY = Symbol.for("archimedes:thinkingPatched");
+const PATCH_VERSION_KEY = Symbol.for("archimedes:thinkingPatchVersion");
+
+// Dynamic import after mocking the pi-coding-agent module
+async function importPatch() {
+	vi.resetModules();
+	const mod = await import("./patch.js");
+	return mod.patchThinkingRenderer;
+}
+
+describe("patchThinkingRenderer", () => {
+	afterEach(() => {
+		vi.resetModules();
+	});
+
+	it("returns early when AssistantMessageComponent is undefined", async () => {
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: undefined,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		// Should not throw
+		patch(() => ({} as any));
+	});
+
+	it("returns early when prototype is null", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype = null;
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+		// No patching should occur — proto is null
+	});
+
+	it("returns early when updateContent is not a function", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = "not a function";
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+	});
+
+	it("returns early when class name does not match", async () => {
+		const WrongName = function () {};
+		WrongName.prototype.updateContent = function () {};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: WrongName,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+		// Name is "WrongName", not "AssistantMessageComponent" — should skip
+	});
+
+	it("returns early when source lacks thinking check", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = function updateContent() {
+			// Does NOT contain: content.type === "thinking"
+			this.doSomething();
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+		// Signature mismatch — no thinking check in source
+	});
+
+	it("returns early when source lacks markdownTheme reference", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = function updateContent() {
+			// Has thinking check but no markdownTheme
+			if (this.content.type === "thinking") {
+				this.render();
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+		// Signature mismatch — no markdownTheme in source
+	});
+
+	it("patches successfully when signature matches", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = function updateContent() {
+			if (this.content.type === "thinking") {
+				this.markdownTheme.codeBlockIndent = "";
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+
+		// The prototype should be marked as patched
+		expect(MockClass.prototype[PATCHED_KEY]).toBe(true);
+		expect(MockClass.prototype[PATCH_VERSION_KEY]).toBe("1.0.0");
+	});
+
+	it("marks prototype with correct version", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = function updateContent() {
+			if (this.content.type === "thinking") {
+				this.markdownTheme.codeBlockIndent = "";
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "2.5.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+		patch(() => ({} as any));
+
+		expect(MockClass.prototype[PATCH_VERSION_KEY]).toBe("2.5.0");
+	});
+
+	it("re-patches when version changes", async () => {
+		// First patch with version 1.0.0
+		const MockClassV1 = function AssistantMessageComponent() {};
+		MockClassV1.prototype.updateContent = function updateContent() {
+			if (this.content.type === "thinking") {
+				this.markdownTheme.codeBlockIndent = "";
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClassV1,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patchV1 = await importPatch();
+		patchV1(() => ({} as any));
+		expect(MockClassV1.prototype[PATCH_VERSION_KEY]).toBe("1.0.0");
+
+		// Now simulate a version change with a fresh class
+		const MockClassV2 = function AssistantMessageComponent() {};
+		MockClassV2.prototype.updateContent = function updateContent() {
+			if (this.content.type === "thinking") {
+				this.markdownTheme.codeBlockIndent = "";
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClassV2,
+			VERSION: "2.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patchV2 = await importPatch();
+		patchV2(() => ({} as any));
+		expect(MockClassV2.prototype[PATCH_VERSION_KEY]).toBe("2.0.0");
+	});
+
+	it("re-patches on same version to update getTheme closure", async () => {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = function updateContent() {
+			if (this.content.type === "thinking") {
+				this.markdownTheme.codeBlockIndent = "";
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const patch = await importPatch();
+
+		// First patch
+		patch(() => ({} as any));
+		expect(MockClass.prototype[PATCHED_KEY]).toBe(true);
+
+		// Second patch (same version) — should still re-patch the function
+		patch(() => ({} as any));
+		expect(MockClass.prototype[PATCHED_KEY]).toBe(true);
+		expect(MockClass.prototype[PATCH_VERSION_KEY]).toBe("1.0.0");
+	});
+});

--- a/packages/core/src/thinking/theme.test.ts
+++ b/packages/core/src/thinking/theme.test.ts
@@ -195,15 +195,17 @@ describe("buildMutedMarkdownTheme", () => {
 		expect(joined).toMatch(/\x1b\[38;2;\d+;\d+;\d+m/);
 	});
 
-	it("accepts custom saturationFactor", () => {
-		const theme1 = buildMutedMarkdownTheme(mockTheme as any, { saturationFactor: 0.3 });
-		const theme2 = buildMutedMarkdownTheme(mockTheme as any, { saturationFactor: 0.7 });
-		// Different saturation factors should produce different outputs
-		const code1 = theme1.highlightCode!("test", "plaintext").join("");
-		const code2 = theme2.highlightCode!("test", "plaintext").join("");
-		// They may or may not differ depending on input, but both should be valid
-		expect(typeof code1).toBe("string");
-		expect(typeof code2).toBe("string");
+	it("different saturationFactor produces different dimmed output", () => {
+		const cache = new Map<string, string>();
+		const input = "\x1b[38;2;255;128;64mhello";
+		const resultLow = dimAnsiLine(input, 0.4, 0.3, cache);
+		const cache2 = new Map<string, string>();
+		const resultHigh = dimAnsiLine(input, 0.4, 0.7, cache2);
+		// Same input with different saturation factors must produce different escapes
+		expect(resultLow).not.toBe(resultHigh);
+		// Both must still be valid truecolor fg escapes
+		expect(resultLow).toMatch(/\x1b\[38;2;\d+;\d+;\d+mhello/);
+		expect(resultHigh).toMatch(/\x1b\[38;2;\d+;\d+;\d+mhello/);
 	});
 
 	it("accepts custom codeDefaultLightness", () => {

--- a/packages/core/src/thinking/theme.test.ts
+++ b/packages/core/src/thinking/theme.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { dimAnsiLine, buildMutedMarkdownTheme } from "./theme.js";
+import { stripAnsi } from "../text.js";
+
+// ── dimAnsiLine ──────────────────────────────────────────────────────────────
+
+describe("dimAnsiLine", () => {
+	const makeCache = () => new Map<string, string>();
+
+	it("dims a single truecolor fg escape", () => {
+		const cache = makeCache();
+		const input = "\x1b[38;2;255;128;64mhello";
+		const result = dimAnsiLine(input, 0.4, 0.5, cache);
+		// Output should still be a truecolor fg escape (38;2;...)
+		expect(result).toMatch(/\x1b\[38;2;\d+;\d+;\d+mhello/);
+		// But the color should be different (dimmed)
+		expect(result).not.toBe(input);
+	});
+
+	it("dims multiple fg escapes in one line", () => {
+		const cache = makeCache();
+		const input = "\x1b[38;2;255;0;0mred\x1b[38;2;0;0;255mblue";
+		const result = dimAnsiLine(input, 0.4, 0.5, cache);
+		// Both escapes should be rewritten to dimmed versions
+		expect(result).not.toContain("\x1b[38;2;255;0;0m");
+		expect(result).not.toContain("\x1b[38;2;0;0;255m");
+		// Text content preserved
+		expect(stripAnsi(result)).toBe("redblue");
+	});
+
+	it("leaves lines with no fg escapes unchanged", () => {
+		const cache = makeCache();
+		const input = "plain text without escapes";
+		const result = dimAnsiLine(input, 0.4, 0.5, cache);
+		expect(result).toBe(input);
+	});
+
+	it("preserves non-fg escapes (bold, italic, reset)", () => {
+		const cache = makeCache();
+		const input = "\x1b[1mbold\x1b[0m \x1b[3mitalic\x1b[23m";
+		const result = dimAnsiLine(input, 0.4, 0.5, cache);
+		expect(result).toContain("\x1b[1m");
+		expect(result).toContain("\x1b[0m");
+		expect(result).toContain("\x1b[3m");
+		expect(result).toContain("\x1b[23m");
+	});
+
+	it("cache hit returns same result", () => {
+		const cache = makeCache();
+		const escape = "\x1b[38;2;200;100;50m";
+		const input = `${escape}text`;
+		const first = dimAnsiLine(input, 0.4, 0.5, cache);
+		const second = dimAnsiLine(input, 0.4, 0.5, cache);
+		expect(first).toBe(second);
+		// Cache should have the entry
+		expect(cache.has(escape)).toBe(true);
+	});
+
+	it("passes through unrecognized escapes unchanged", () => {
+		const cache = makeCache();
+		// A bg escape (48;2;...) should not be matched by FG_COLOR_ESCAPE_RE
+		const input = "\x1b[48;2;10;10;10mbg text";
+		const result = dimAnsiLine(input, 0.4, 0.5, cache);
+		expect(result).toBe(input);
+	});
+
+	it("dims 256-palette fg escapes to truecolor", () => {
+		const cache = makeCache();
+		const input = "\x1b[38;5;196mred"; // 256-palette red
+		const result = dimAnsiLine(input, 0.4, 0.5, cache);
+		// Output should be truecolor (38;2;...), not 256-palette
+		expect(result).toMatch(/\x1b\[38;2;\d+;\d+;\d+mred/);
+		expect(result).not.toContain("\x1b[38;5;");
+	});
+
+	it("handles empty string", () => {
+		const cache = makeCache();
+		expect(dimAnsiLine("", 0.4, 0.5, cache)).toBe("");
+	});
+
+	it("property: preserves non-ANSI text content", () => {
+		fc.assert(
+			fc.property(
+				fc.string({ maxLength: 200 }),
+				(s) => {
+					const cache = makeCache();
+					const result = dimAnsiLine(s, 0.4, 0.5, cache);
+					return stripAnsi(s) === stripAnsi(result);
+				},
+			),
+		);
+	});
+
+	it("property: never introduces 38;5; escapes (only produces truecolor 38;2;)", () => {
+		fc.assert(
+			fc.property(
+				fc.string({ maxLength: 200 }),
+				(s) => {
+					const cache = makeCache();
+					const result = dimAnsiLine(s, 0.4, 0.5, cache);
+					// Any 38;5; in output must have been in the input
+					// (dimAnsiLine only produces 38;2; output)
+					const inputHas256 = s.includes("38;5;");
+					const outputHas256 = result.includes("38;5;");
+					// If input didn't have 38;5;, output shouldn't either
+					// (because we only dim via truecolor)
+					if (!inputHas256) {
+						return !outputHas256;
+					}
+					// If input had 38;5;, they get replaced with 38;2;
+					// So output should NOT have 38;5; either
+					return !outputHas256;
+				},
+			),
+		);
+	});
+});
+
+// ── buildMutedMarkdownTheme ──────────────────────────────────────────────────
+
+describe("buildMutedMarkdownTheme", () => {
+	const mockTheme = {
+		fg: (token: string, text: string) => `\x1b[38;2;180;180;180m${text}\x1b[0m`,
+		getFgAnsi: (token: string) => "\x1b[38;2;180;180;180m",
+		italic: (text: string) => `\x1b[3m${text}\x1b[23m`,
+	};
+
+	it("returns MarkdownTheme with all required fields", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		expect(typeof theme.codeBlockIndent).toBe("string");
+		expect(typeof theme.heading).toBe("function");
+		expect(typeof theme.link).toBe("function");
+		expect(typeof theme.linkUrl).toBe("function");
+		expect(typeof theme.code).toBe("function");
+		expect(typeof theme.codeBlock).toBe("function");
+		expect(typeof theme.codeBlockBorder).toBe("function");
+		expect(typeof theme.quote).toBe("function");
+		expect(typeof theme.quoteBorder).toBe("function");
+		expect(typeof theme.hr).toBe("function");
+		expect(typeof theme.listBullet).toBe("function");
+		expect(typeof theme.bold).toBe("function");
+		expect(typeof theme.italic).toBe("function");
+		expect(typeof theme.strikethrough).toBe("function");
+		expect(typeof theme.underline).toBe("function");
+		expect(typeof theme.highlightCode).toBe("function");
+	});
+
+	it("heading uses gold color (#FFD700)", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		const result = theme.heading("Title");
+		// Gold is #FFD700 = rgb(255, 215, 0)
+		expect(result).toContain("\x1b[38;2;255;215;0m");
+		expect(result).toContain("Title");
+	});
+
+	it("bold uses gold color (#FFD700)", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		const result = theme.bold("Strong");
+		expect(result).toContain("\x1b[38;2;255;215;0m");
+		expect(result).toContain("Strong");
+	});
+
+	it("codeBlock uses thinkingText", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		const result = theme.codeBlock("code here");
+		expect(result).toContain("code here");
+	});
+
+	it("italic wraps with ANSI italic codes", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		const result = theme.italic("slanted");
+		expect(result).toContain("\x1b[3m");
+		expect(result).toContain("\x1b[23m");
+		expect(result).toContain("slanted");
+	});
+
+	it("codeBlockIndent is empty string", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		expect(theme.codeBlockIndent).toBe("");
+	});
+
+	it("highlightCode returns array of strings", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		const result = theme.highlightCode!("const x = 1;", "javascript");
+		expect(Array.isArray(result)).toBe(true);
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	it("highlightCode dims ANSI escapes in output", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any);
+		const result = theme.highlightCode!("const x = 1;", "javascript");
+		// Output should contain dimmed truecolor escapes
+		const joined = result.join("\n");
+		expect(joined).toMatch(/\x1b\[38;2;\d+;\d+;\d+m/);
+	});
+
+	it("accepts custom saturationFactor", () => {
+		const theme1 = buildMutedMarkdownTheme(mockTheme as any, { saturationFactor: 0.3 });
+		const theme2 = buildMutedMarkdownTheme(mockTheme as any, { saturationFactor: 0.7 });
+		// Different saturation factors should produce different outputs
+		const code1 = theme1.highlightCode!("test", "plaintext").join("");
+		const code2 = theme2.highlightCode!("test", "plaintext").join("");
+		// They may or may not differ depending on input, but both should be valid
+		expect(typeof code1).toBe("string");
+		expect(typeof code2).toBe("string");
+	});
+
+	it("accepts custom codeDefaultLightness", () => {
+		const theme = buildMutedMarkdownTheme(mockTheme as any, { codeDefaultLightness: 0.9 });
+		const result = theme.highlightCode!("test", "plaintext");
+		expect(Array.isArray(result)).toBe(true);
+	});
+});

--- a/packages/core/src/thinking/transform.test.ts
+++ b/packages/core/src/thinking/transform.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { transformThinkingContent } from "./transform.js";
+
+describe("transformThinkingContent", () => {
+  it("modifies thinking content on assistant messages", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        { type: "thinking" as const, thinking: "  some thinking  " },
+      ],
+    };
+    transformThinkingContent(message);
+    expect(message.content[0]!.thinking).toBe("some thinking");
+  });
+
+  it("skips non-assistant messages", () => {
+    const message = {
+      role: "user" as const,
+      content: [
+        { type: "thinking" as const, thinking: "  should not change  " },
+      ],
+    };
+    transformThinkingContent(message);
+    expect(message.content[0]!.thinking).toBe("  should not change  ");
+  });
+
+  it("skips empty thinking", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        { type: "thinking" as const, thinking: "   " },
+      ],
+    };
+    transformThinkingContent(message);
+    expect(message.content[0]!.thinking).toBe("   ");
+  });
+
+  it("skips thinking with undefined value", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        { type: "thinking" as const } as { type: string; thinking?: string },
+      ],
+    };
+    transformThinkingContent(message);
+    expect(message.content[0]!.thinking).toBeUndefined();
+  });
+
+  it("calls unindentCodeBlocks on thinking content", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        {
+          type: "thinking" as const,
+          thinking: "```\n    indented code\n    more code\n```",
+        },
+      ],
+    };
+    transformThinkingContent(message);
+    expect(message.content[0]!.thinking).toBe("```\nindented code\nmore code\n```");
+  });
+
+  it("handles mixed content types", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: "some text" },
+        { type: "thinking" as const, thinking: "  thinking content  " },
+        { type: "text" as const, text: "more text" },
+      ],
+    };
+    transformThinkingContent(message);
+    expect(message.content[0]).toEqual({ type: "text", text: "some text" });
+    expect(message.content[1]!.thinking).toBe("thinking content");
+    expect(message.content[2]).toEqual({ type: "text", text: "more text" });
+  });
+
+  it("after transform, thinking is trimmed", () => {
+    const message = {
+      role: "assistant" as const,
+      content: [
+        { type: "thinking" as const, thinking: "  hello world  " },
+      ],
+    };
+    transformThinkingContent(message);
+    const thinking = message.content[0]!.thinking;
+    expect(thinking).toBe(thinking?.trim());
+  });
+});

--- a/packages/core/src/thinking/unindent.test.ts
+++ b/packages/core/src/thinking/unindent.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { unindentCodeBlocks } from "./unindent.js";
+
+describe("unindentCodeBlocks", () => {
+  it("strips common leading whitespace from fenced code blocks", () => {
+    const input = "```\n    line1\n    line2\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\nline1\nline2\n```");
+  });
+
+  it("preserves empty lines structure", () => {
+    const input = "```\n    line1\n\n    line2\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\nline1\n\nline2\n```");
+  });
+
+  it("leaves whitespace-only blocks untouched", () => {
+    const input = "```\n    \n    \n```";
+    expect(unindentCodeBlocks(input)).toBe("```\n    \n    \n```");
+  });
+
+  it("handles CRLF → LF normalization", () => {
+    const input = "```\r\n    line1\r\n    line2\r\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\nline1\nline2\n```");
+  });
+
+  it("handles blocks with 0 indent on some lines (no stripping)", () => {
+    const input = "```\n    indented\nnotindented\n    indented\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\n    indented\nnotindented\n    indented\n```");
+  });
+
+  it("strips trailing empty lines from code blocks", () => {
+    const input = "```\n    line1\n    line2\n\n\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\nline1\nline2\n```");
+  });
+
+  it("handles language tags", () => {
+    const input = "```python\n    def foo():\n        pass\n```";
+    expect(unindentCodeBlocks(input)).toBe("```python\ndef foo():\n    pass\n```");
+  });
+
+  it("leaves text outside code blocks unchanged", () => {
+    const input = "Some text\n```\n    code\n```\nMore text";
+    expect(unindentCodeBlocks(input)).toBe("Some text\n```\ncode\n```\nMore text");
+  });
+
+  it("handles multiple code blocks", () => {
+    const input = "```\n    block1\n```\n```\n    block2\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\nblock1\n```\n```\nblock2\n```");
+  });
+
+  it("handles empty code blocks with content", () => {
+    const input = "```\n```";
+    expect(unindentCodeBlocks(input)).toBe("```\n```");
+  });
+
+  it("property: idempotence — unindentCodeBlocks(unindentCodeBlocks(x)) === unindentCodeBlocks(x)", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 500 }), (s) => {
+        const once = unindentCodeBlocks(s);
+        const twice = unindentCodeBlocks(once);
+        return once === twice;
+      }),
+    );
+  });
+
+  it("property: output never contains CRLF (\\r\\n)", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 500 }), (s) => {
+        const result = unindentCodeBlocks(s);
+        return !result.includes("\r\n");
+      }),
+    );
+  });
+});

--- a/packages/diff/src/ansi/codes.test.ts
+++ b/packages/diff/src/ansi/codes.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import {
+	RST,
+	BOLD,
+	DIM,
+	FG_ADD,
+	FG_DEL,
+	FG_DIM,
+	FG_LNUM,
+	FG_RULE,
+	FG_SAFE_MUTED,
+	FG_STRIPE,
+	BORDER_BAR,
+	ANSI_RE,
+	ANSI_CAPTURE_RE,
+	ANSI_PARAM_CAPTURE_RE,
+	DEFAULT_DIFF_COLORS,
+	DEFAULT_DIFF_BG,
+	themeCacheKey,
+	resolveDiffColors,
+	resetDiffColors,
+} from "./codes.js";
+
+// ── Exported constants ──────────────────────────────────────────────────────
+
+describe("ANSI constants", () => {
+	it("all exported constants are non-empty strings", () => {
+		expect(typeof RST).toBe("string");
+		expect(RST.length).toBeGreaterThan(0);
+		expect(typeof BOLD).toBe("string");
+		expect(BOLD.length).toBeGreaterThan(0);
+		expect(typeof DIM).toBe("string");
+		expect(DIM.length).toBeGreaterThan(0);
+		expect(typeof FG_ADD).toBe("string");
+		expect(FG_ADD.length).toBeGreaterThan(0);
+		expect(typeof FG_DEL).toBe("string");
+		expect(FG_DEL.length).toBeGreaterThan(0);
+		expect(typeof FG_DIM).toBe("string");
+		expect(FG_DIM.length).toBeGreaterThan(0);
+		expect(typeof FG_LNUM).toBe("string");
+		expect(FG_LNUM.length).toBeGreaterThan(0);
+		expect(typeof FG_RULE).toBe("string");
+		expect(FG_RULE.length).toBeGreaterThan(0);
+		expect(typeof FG_SAFE_MUTED).toBe("string");
+		expect(FG_SAFE_MUTED.length).toBeGreaterThan(0);
+		expect(typeof FG_STRIPE).toBe("string");
+		expect(FG_STRIPE.length).toBeGreaterThan(0);
+		expect(typeof BORDER_BAR).toBe("string");
+		expect(BORDER_BAR.length).toBeGreaterThan(0);
+	});
+
+	it("RST is reset escape", () => {
+		expect(RST).toBe("\x1b[0m");
+	});
+
+	it("BOLD is bold escape", () => {
+		expect(BOLD).toBe("\x1b[1m");
+	});
+
+	it("DIM is dim escape", () => {
+		expect(DIM).toBe("\x1b[2m");
+	});
+
+	it("FG_ADD is truecolor green-ish", () => {
+		expect(FG_ADD).toBe("\x1b[38;2;100;180;120m");
+	});
+
+	it("FG_DEL is truecolor red-ish", () => {
+		expect(FG_DEL).toBe("\x1b[38;2;200;100;100m");
+	});
+});
+
+// ── Regex patterns ──────────────────────────────────────────────────────────
+
+describe("ANSI_RE", () => {
+	it("matches standard ANSI escapes", () => {
+		// Use exec on a copy to avoid lastIndex state issues with global flag
+		const re = new RegExp(ANSI_RE.source, "g");
+		expect(re.test("\x1b[0m")).toBe(true);
+		re.lastIndex = 0;
+		expect(re.test("\x1b[31m")).toBe(true);
+		re.lastIndex = 0;
+		expect(re.test("\x1b[38;2;255;128;64m")).toBe(true);
+	});
+
+	it("matches multiple escapes in a string", () => {
+		const matches = "\x1b[31mred\x1b[0m".match(ANSI_RE);
+		expect(matches).toHaveLength(2);
+	});
+
+	it("does not match plain text", () => {
+		expect("hello world".match(ANSI_RE)).toBeNull();
+	});
+});
+
+describe("ANSI_CAPTURE_RE", () => {
+	it("captures parameters between [ and m", () => {
+		// Use exec() for capture groups with global regex
+		const re = new RegExp(ANSI_CAPTURE_RE.source, "g");
+		const match = re.exec("\x1b[38;2;255;128;64m");
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe("38;2;255;128;64");
+	});
+
+	it("captures empty params for reset", () => {
+		const re = new RegExp(ANSI_CAPTURE_RE.source, "g");
+		const match = re.exec("\x1b[0m");
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe("0");
+	});
+});
+
+describe("ANSI_PARAM_CAPTURE_RE", () => {
+	it("captures numeric params", () => {
+		const re = new RegExp(ANSI_PARAM_CAPTURE_RE.source, "g");
+		const match = re.exec("\x1b[38;2;255;128;64m");
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe("38;2;255;128;64");
+	});
+
+	it("captures simple numeric code", () => {
+		const re = new RegExp(ANSI_PARAM_CAPTURE_RE.source, "g");
+		const match = re.exec("\x1b[31m");
+		expect(match).not.toBeNull();
+		expect(match![1]).toBe("31");
+	});
+});
+
+// ── DEFAULT_DIFF_COLORS ─────────────────────────────────────────────────────
+
+describe("DEFAULT_DIFF_COLORS", () => {
+	it("has all required fields", () => {
+		expect(DEFAULT_DIFF_COLORS.fgAdd).toBe(FG_ADD);
+		expect(DEFAULT_DIFF_COLORS.fgDel).toBe(FG_DEL);
+		expect(DEFAULT_DIFF_COLORS.fgCtx).toBe(FG_DIM);
+	});
+});
+
+// ── themeCacheKey ───────────────────────────────────────────────────────────
+
+describe("themeCacheKey", () => {
+	it("returns 'no-theme' for null theme", () => {
+		expect(themeCacheKey(null)).toBe("no-theme");
+	});
+
+	it("returns 'no-theme' for undefined theme", () => {
+		expect(themeCacheKey(undefined)).toBe("no-theme");
+	});
+
+	it("returns 'no-theme' for theme without fg", () => {
+		expect(themeCacheKey({})).toBe("no-theme");
+	});
+
+	it("returns deterministic string for same theme", () => {
+		const theme = {
+			fg: (token: string, fallback: string) => `fg-${token}`,
+			bg: (token: string, fallback: string) => `bg-${token}`,
+		};
+		const key1 = themeCacheKey(theme);
+		const key2 = themeCacheKey(theme);
+		expect(key1).toBe(key2);
+		expect(typeof key1).toBe("string");
+		expect(key1.length).toBeGreaterThan(0);
+	});
+
+	it("property: deterministic — themeCacheKey(a) === themeCacheKey(a)", () => {
+		fc.assert(
+			fc.property(
+				fc.record({
+					fg: fc.constant((t: string, f: string) => `${t}-${f}`),
+					bg: fc.constant((t: string, f: string) => `bg-${t}`),
+				}),
+				(theme) => {
+					const key1 = themeCacheKey(theme);
+					const key2 = themeCacheKey(theme);
+					return key1 === key2;
+				},
+			),
+		);
+	});
+});
+
+// ── resolveDiffColors ───────────────────────────────────────────────────────
+
+describe("resolveDiffColors", () => {
+	it("returns DEFAULT_DIFF_COLORS when no theme", () => {
+		resetDiffColors();
+		const result = resolveDiffColors(undefined);
+		expect(result).toEqual(DEFAULT_DIFF_COLORS);
+	});
+
+	it("returns DEFAULT_DIFF_COLORS when theme lacks getFgAnsi", () => {
+		resetDiffColors();
+		const result = resolveDiffColors({ fg: () => "" });
+		expect(result).toEqual(DEFAULT_DIFF_COLORS);
+	});
+
+	it("returns theme-derived colors when theme has getFgAnsi", () => {
+		resetDiffColors();
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;50;200;50m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;50;50m";
+				if (token === "toolDiffContext") return "\x1b[38;2;100;100;100m";
+				return "";
+			},
+		};
+		const result = resolveDiffColors(theme);
+		expect(result.fgAdd).toBe("\x1b[38;2;50;200;50m");
+		expect(result.fgDel).toBe("\x1b[38;2;200;50;50m");
+		expect(result.fgCtx).toBe("\x1b[38;2;100;100;100m");
+	});
+
+	it("falls back to defaults when getFgAnsi returns empty string", () => {
+		resetDiffColors();
+		const theme = {
+			getFgAnsi: () => "",
+		};
+		const result = resolveDiffColors(theme);
+		expect(result.fgAdd).toBe(FG_ADD);
+		expect(result.fgDel).toBe(FG_DEL);
+		expect(result.fgCtx).toBe(FG_DIM);
+	});
+});
+
+// ── resetDiffColors ─────────────────────────────────────────────────────────
+
+describe("resetDiffColors", () => {
+	it("clears cache so subsequent call re-derives", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;50;200;50m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;50;50m";
+				if (token === "toolDiffContext") return "\x1b[38;2;100;100;100m";
+				return "";
+			},
+		};
+
+		// First call derives colors
+		const result1 = resolveDiffColors(theme);
+		expect(result1.fgAdd).toBe("\x1b[38;2;50;200;50m");
+
+		// Reset clears cache
+		resetDiffColors();
+
+		// Now change the theme
+		const newTheme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;10;100;10m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;100;10;10m";
+				if (token === "toolDiffContext") return "\x1b[38;2;50;50;50m";
+				return "";
+			},
+		};
+
+		// After reset, new theme should be picked up
+		const result2 = resolveDiffColors(newTheme);
+		expect(result2.fgAdd).toBe("\x1b[38;2;10;100;10m");
+	});
+});

--- a/packages/diff/src/ansi/colors.test.ts
+++ b/packages/diff/src/ansi/colors.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { deriveBgFromTheme } from "./colors.js";
+import { DEFAULT_DIFF_BG, FG_RULE } from "./codes.js";
+
+// ── deriveBgFromTheme ───────────────────────────────────────────────────────
+
+describe("deriveBgFromTheme", () => {
+	it("returns DEFAULT_DIFF_BG when theme is null", () => {
+		const result = deriveBgFromTheme(null);
+		expect(result).toEqual(DEFAULT_DIFF_BG);
+	});
+
+	it("returns DEFAULT_DIFF_BG when theme is undefined", () => {
+		const result = deriveBgFromTheme(undefined);
+		expect(result).toEqual(DEFAULT_DIFF_BG);
+	});
+
+	it("returns DEFAULT_DIFF_BG when theme lacks getFgAnsi", () => {
+		const result = deriveBgFromTheme({});
+		expect(result).toEqual(DEFAULT_DIFF_BG);
+	});
+
+	it("returns DEFAULT_DIFF_BG when getFgAnsi returns non-parseable values", () => {
+		const theme = {
+			getFgAnsi: () => "not-an-ansi-code",
+		};
+		const result = deriveBgFromTheme(theme);
+		expect(result).toEqual(DEFAULT_DIFF_BG);
+	});
+
+	it("derives colors from theme with valid getFgAnsi", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		// bgAdd should be a mix of black (base) + green accent at 0.08 intensity
+		expect(result.bgAdd).toMatch(/\x1b\[48;2;\d+;\d+;\d+m/);
+		expect(result.bgDel).toMatch(/\x1b\[48;2;\d+;\d+;\d+m/);
+		// Should differ from defaults since we have a theme
+		expect(result.bgAdd).not.toBe(DEFAULT_DIFF_BG.bgAdd);
+	});
+
+	it("uses bgBase from theme when getBgAnsi is available", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+			getBgAnsi: (token: string) => {
+				if (token === "toolSuccessBg") return "\x1b[48;2;20;40;30m";
+				if (token === "toolErrorBg") return "\x1b[48;2;40;20;20m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		// bgBase should come from the theme's success bg
+		expect(result.bgBase).toBe("\x1b[48;2;20;40;30m");
+		// bgEmpty should equal bgBase
+		expect(result.bgEmpty).toBe(result.bgBase);
+	});
+
+	it("returns DiffBg with all required fields", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		expect(typeof result.bgAdd).toBe("string");
+		expect(typeof result.bgDel).toBe("string");
+		expect(typeof result.bgAddW).toBe("string");
+		expect(typeof result.bgDelW).toBe("string");
+		expect(typeof result.bgGutterAdd).toBe("string");
+		expect(typeof result.bgGutterDel).toBe("string");
+		expect(typeof result.bgEmpty).toBe("string");
+		expect(typeof result.bgBase).toBe("string");
+		expect(typeof result.rst).toBe("string");
+		expect(typeof result.divider).toBe("string");
+	});
+
+	it("bg colors are ANSI truecolor escapes (48;2;r;g;b format)", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		const bgFields = [
+			result.bgAdd,
+			result.bgDel,
+			result.bgAddW,
+			result.bgDelW,
+			result.bgGutterAdd,
+			result.bgGutterDel,
+		];
+		for (const bg of bgFields) {
+			expect(bg).toMatch(/\x1b\[48;2;\d+;\d+;\d+m/);
+		}
+	});
+
+	it("divider contains FG_RULE character", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		expect(result.divider).toContain(FG_RULE);
+	});
+
+	it("rst is reset when no bgBase from theme", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		// Without getBgAnsi, bgBase is \x1b[49m, so rst is just \x1b[0m
+		expect(result.rst).toBe("\x1b[0m");
+	});
+
+	it("rst includes bgBase reset when theme provides getBgAnsi", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+			getBgAnsi: (token: string) => {
+				if (token === "toolSuccessBg") return "\x1b[48;2;20;40;30m";
+				return "";
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		// With getBgAnsi, rst should be \x1b[0m + bgBase
+		expect(result.rst).toBe("\x1b[0m\x1b[48;2;20;40;30m");
+	});
+
+	it("handles getFgAnsi that throws gracefully", () => {
+		const theme = {
+			getFgAnsi: () => {
+				throw new Error("theme error");
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		expect(result).toEqual(DEFAULT_DIFF_BG);
+	});
+
+	it("handles getBgAnsi that throws gracefully", () => {
+		const theme = {
+			getFgAnsi: (token: string) => {
+				if (token === "toolDiffAdded") return "\x1b[38;2;100;200;150m";
+				if (token === "toolDiffRemoved") return "\x1b[38;2;200;100;100m";
+				return "";
+			},
+			getBgAnsi: () => {
+				throw new Error("bg error");
+			},
+		};
+		const result = deriveBgFromTheme(theme);
+		// Should still produce valid output, falling back to default bgBase
+		expect(result.bgBase).toBe("\x1b[49m");
+		expect(result.rst).toBe("\x1b[0m");
+	});
+
+	it("property: rst always contains reset escape", () => {
+		fc.assert(
+			fc.property(
+				fc.array(
+					fc.tuple(
+						fc.constant("toolDiffAdded"),
+						fc.string({ maxLength: 20 }),
+					),
+					{ minLength: 0, maxLength: 5 },
+				),
+				(pairs) => {
+					const map = new Map(pairs);
+					const theme = {
+						getFgAnsi: (token: any) => map.get(token) || "",
+					};
+					const result = deriveBgFromTheme(theme);
+					return result.rst.includes("\x1b[0m");
+				},
+			),
+		);
+	});
+
+	it("property: all bg fields are valid truecolor bg escapes or defaults", () => {
+		fc.assert(
+			fc.property(
+				fc.string({ maxLength: 50 }),
+				(addColor) => {
+					const theme = {
+						getFgAnsi: (token: string) => {
+							if (token === "toolDiffAdded") return addColor;
+							if (token === "toolDiffRemoved") return addColor;
+							return "";
+						},
+					};
+					const result = deriveBgFromTheme(theme);
+					// Either we get valid truecolor bg escapes, or we get defaults
+					const isTruecolorBg = (s: string) => /\x1b\[48;2;\d+;\d+;\d+m/.test(s);
+					const allValid = [
+						result.bgAdd,
+						result.bgDel,
+						result.bgAddW,
+						result.bgDelW,
+						result.bgGutterAdd,
+						result.bgGutterDel,
+					].every((bg) => isTruecolorBg(bg));
+					const isDefault = result === DEFAULT_DIFF_BG || result.bgAdd === DEFAULT_DIFF_BG.bgAdd;
+					return allValid || isDefault;
+				},
+			),
+		);
+	});
+
+	it("property: divider always contains the rule character", () => {
+		fc.assert(
+			fc.property(
+				fc.string({ maxLength: 100 }),
+				(rawColor) => {
+					const theme = {
+						getFgAnsi: () => rawColor,
+					};
+					const result = deriveBgFromTheme(theme);
+					return result.divider.includes(FG_RULE);
+				},
+			),
+		);
+	});
+});

--- a/packages/diff/src/core/diff.test.ts
+++ b/packages/diff/src/core/diff.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { parseDiff } from "./diff.js";
+
+// ── Multiline string generator for property tests ────────────────────────────
+
+const lineArb = fc.string({ maxLength: 80 });
+const multilineArb = fc.array(lineArb, { maxLength: 20 }).map(lines => lines.join("\n"));
+
+// ── parseDiff ────────────────────────────────────────────────────────────────
+
+describe("parseDiff", () => {
+	it("identical content returns empty lines and zero counts", () => {
+		const content = "line1\nline2\nline3";
+		const result = parseDiff(content, content);
+		expect(result.lines).toEqual([]);
+		expect(result.added).toBe(0);
+		expect(result.removed).toBe(0);
+		expect(result.chars).toBe(0);
+	});
+
+	it("single line addition", () => {
+		const old = "line1\n";
+		const newContent = "line1\nline2\n";
+		const result = parseDiff(old, newContent);
+		expect(result.added).toBe(1);
+		expect(result.removed).toBe(0);
+		const addLine = result.lines.find(l => l.type === "add");
+		expect(addLine).not.toBeUndefined();
+		expect(addLine!.content).toBe("line2");
+	});
+
+	it("single line deletion", () => {
+		const old = "line1\nline2\n";
+		const newContent = "line1\n";
+		const result = parseDiff(old, newContent);
+		expect(result.added).toBe(0);
+		expect(result.removed).toBe(1);
+		const delLine = result.lines.find(l => l.type === "del");
+		expect(delLine).not.toBeUndefined();
+		expect(delLine!.content).toBe("line2");
+	});
+
+	it("mixed add/delete/context", () => {
+		const old = "line1\nline2\nline3";
+		const newContent = "line1\nmodified\nline3\nline4";
+		const result = parseDiff(old, newContent);
+		expect(result.added).toBeGreaterThan(0);
+		expect(result.removed).toBeGreaterThan(0);
+		expect(result.lines.some(l => l.type === "ctx")).toBe(true);
+		expect(result.lines.some(l => l.type === "add")).toBe(true);
+		expect(result.lines.some(l => l.type === "del")).toBe(true);
+	});
+
+	it("multiple hunks produce separator", () => {
+		// Create content with changes far apart to trigger multiple hunks
+		const old = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np";
+		const newContent = "A\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\nP";
+		const result = parseDiff(old, newContent);
+		// With context=3, changes at start and end should create 2 hunks with a separator
+		expect(result.lines.some(l => l.type === "sep")).toBe(true);
+	});
+
+	it("context lines have both oldNum and newNum", () => {
+		const old = "line1\nline2\nline3";
+		const newContent = "line1\nmodified\nline3";
+		const result = parseDiff(old, newContent);
+		const ctxLines = result.lines.filter(l => l.type === "ctx");
+		for (const line of ctxLines) {
+			expect(line.oldNum).not.toBeNull();
+			expect(line.newNum).not.toBeNull();
+		}
+	});
+
+	it("added lines have only newNum", () => {
+		const old = "line1";
+		const newContent = "line1\nadded";
+		const result = parseDiff(old, newContent);
+		const addLines = result.lines.filter(l => l.type === "add");
+		for (const line of addLines) {
+			expect(line.oldNum).toBeNull();
+			expect(line.newNum).not.toBeNull();
+		}
+	});
+
+	it("deleted lines have only oldNum", () => {
+		const old = "line1\ndeleted";
+		const newContent = "line1";
+		const result = parseDiff(old, newContent);
+		const delLines = result.lines.filter(l => l.type === "del");
+		for (const line of delLines) {
+			expect(line.oldNum).not.toBeNull();
+			expect(line.newNum).toBeNull();
+		}
+	});
+
+	it("separator lines have null oldNum", () => {
+		const old = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np";
+		const newContent = "A\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\nP";
+		const result = parseDiff(old, newContent);
+		const sepLines = result.lines.filter(l => l.type === "sep");
+		for (const line of sepLines) {
+			expect(line.oldNum).toBeNull();
+		}
+	});
+
+	it("chars equals oldContent.length + newContent.length", () => {
+		const old = "hello";
+		const newContent = "world!!";
+		const result = parseDiff(old, newContent);
+		expect(result.chars).toBe(old.length + newContent.length);
+	});
+
+	it("handles empty strings", () => {
+		const result = parseDiff("", "");
+		expect(result.lines).toEqual([]);
+		expect(result.added).toBe(0);
+		expect(result.removed).toBe(0);
+	});
+
+	it("handles adding to empty", () => {
+		const result = parseDiff("", "new line");
+		expect(result.added).toBe(1);
+		expect(result.removed).toBe(0);
+	});
+
+	it("handles removing everything", () => {
+		const result = parseDiff("old line", "");
+		expect(result.added).toBe(0);
+		expect(result.removed).toBe(1);
+	});
+
+	// ── Property tests ───────────────────────────────────────────────────
+
+	it("property: reflexive — parseDiff(x, x).lines.length === 0", () => {
+		fc.assert(
+			fc.property(multilineArb, x => {
+				const result = parseDiff(x, x);
+				return result.lines.length === 0;
+			}),
+		);
+	});
+
+	it("property: non-negative — added >= 0 && removed >= 0", () => {
+		fc.assert(
+			fc.property(multilineArb, multilineArb, (a, b) => {
+				const result = parseDiff(a, b);
+				return result.added >= 0 && result.removed >= 0;
+			}),
+		);
+	});
+
+	it("property: chars equals sum of input lengths", () => {
+		fc.assert(
+			fc.property(multilineArb, multilineArb, (a, b) => {
+				const result = parseDiff(a, b);
+				if (a === b) {
+					return result.chars === 0;
+				}
+				return result.chars === a.length + b.length;
+			}),
+		);
+	});
+});

--- a/packages/diff/src/shiki.test.ts
+++ b/packages/diff/src/shiki.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fc from "fast-check";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock @shikijs/cli to avoid actual Shiki initialization
+vi.mock("@shikijs/cli", () => ({
+	codeToANSI: vi.fn().mockResolvedValue("mocked"),
+}));
+
+// Mock the ANSI normalization
+vi.mock("./ansi/index.js", () => ({
+	normalizeShikiContrast: vi.fn((s: string[]) => s),
+}));
+
+// ── Imports ──────────────────────────────────────────────────────────────────
+
+import { lang, setConfigGetter } from "./shiki.js";
+
+// ── lang ─────────────────────────────────────────────────────────────────────
+
+describe("lang", () => {
+	it("resolves .ts to typescript", () => {
+		expect(lang("file.ts")).toBe("typescript");
+	});
+
+	it("resolves .tsx to tsx", () => {
+		expect(lang("file.tsx")).toBe("tsx");
+	});
+
+	it("resolves .js to javascript", () => {
+		expect(lang("file.js")).toBe("javascript");
+	});
+
+	it("resolves .jsx to jsx", () => {
+		expect(lang("file.jsx")).toBe("jsx");
+	});
+
+	it("resolves .mjs to javascript", () => {
+		expect(lang("file.mjs")).toBe("javascript");
+	});
+
+	it("resolves .cjs to javascript", () => {
+		expect(lang("file.cjs")).toBe("javascript");
+	});
+
+	it("resolves .py to python", () => {
+		expect(lang("script.py")).toBe("python");
+	});
+
+	it("resolves .rb to ruby", () => {
+		expect(lang("script.rb")).toBe("ruby");
+	});
+
+	it("resolves .rs to rust", () => {
+		expect(lang("lib.rs")).toBe("rust");
+	});
+
+	it("resolves .go to go", () => {
+		expect(lang("main.go")).toBe("go");
+	});
+
+	it("resolves .java to java", () => {
+		expect(lang("Main.java")).toBe("java");
+	});
+
+	it("resolves .c to c", () => {
+		expect(lang("main.c")).toBe("c");
+	});
+
+	it("resolves .cpp to cpp", () => {
+		expect(lang("main.cpp")).toBe("cpp");
+	});
+
+	it("resolves .h to c", () => {
+		expect(lang("header.h")).toBe("c");
+	});
+
+	it("resolves .hpp to cpp", () => {
+		expect(lang("header.hpp")).toBe("cpp");
+	});
+
+	it("resolves .cs to csharp", () => {
+		expect(lang("Program.cs")).toBe("csharp");
+	});
+
+	it("resolves .swift to swift", () => {
+		expect(lang("main.swift")).toBe("swift");
+	});
+
+	it("resolves .kt to kotlin", () => {
+		expect(lang("Main.kt")).toBe("kotlin");
+	});
+
+	it("resolves .html to html", () => {
+		expect(lang("index.html")).toBe("html");
+	});
+
+	it("resolves .css to css", () => {
+		expect(lang("styles.css")).toBe("css");
+	});
+
+	it("resolves .scss to scss", () => {
+		expect(lang("styles.scss")).toBe("scss");
+	});
+
+	it("resolves .json to json", () => {
+		expect(lang("package.json")).toBe("json");
+	});
+
+	it("resolves .yaml to yaml", () => {
+		expect(lang("config.yaml")).toBe("yaml");
+	});
+
+	it("resolves .yml to yaml", () => {
+		expect(lang("config.yml")).toBe("yaml");
+	});
+
+	it("resolves .toml to toml", () => {
+		expect(lang("Cargo.toml")).toBe("toml");
+	});
+
+	it("resolves .md to markdown", () => {
+		expect(lang("README.md")).toBe("markdown");
+	});
+
+	it("resolves .sql to sql", () => {
+		expect(lang("query.sql")).toBe("sql");
+	});
+
+	it("resolves .sh to bash", () => {
+		expect(lang("script.sh")).toBe("bash");
+	});
+
+	it("resolves .bash to bash", () => {
+		expect(lang("script.bash")).toBe("bash");
+	});
+
+	it("resolves .zsh to bash", () => {
+		expect(lang("script.zsh")).toBe("bash");
+	});
+
+	it("resolves .lua to lua", () => {
+		expect(lang("init.lua")).toBe("lua");
+	});
+
+	it("resolves .php to php", () => {
+		expect(lang("index.php")).toBe("php");
+	});
+
+	it("resolves .dart to dart", () => {
+		expect(lang("main.dart")).toBe("dart");
+	});
+
+	it("resolves .xml to xml", () => {
+		expect(lang("config.xml")).toBe("xml");
+	});
+
+	it("resolves .graphql to graphql", () => {
+		expect(lang("schema.graphql")).toBe("graphql");
+	});
+
+	it("resolves .svelte to svelte", () => {
+		expect(lang("App.svelte")).toBe("svelte");
+	});
+
+	it("resolves .vue to vue", () => {
+		expect(lang("App.vue")).toBe("vue");
+	});
+
+	it("returns undefined for unknown extensions", () => {
+		expect(lang("file.unknown")).toBeUndefined();
+	});
+
+	it("returns undefined for no extension", () => {
+		expect(lang("Makefile")).toBeUndefined();
+	});
+
+	it("returns undefined for empty string", () => {
+		expect(lang("")).toBeUndefined();
+	});
+
+	it("is case-insensitive for extensions", () => {
+		expect(lang("file.TS")).toBe("typescript");
+		expect(lang("file.Ts")).toBe("typescript");
+		expect(lang("file.PY")).toBe("python");
+		expect(lang("file.JS")).toBe("javascript");
+	});
+
+	it("handles deep paths", () => {
+		expect(lang("/some/deep/path/to/file.ts")).toBe("typescript");
+	});
+
+	it("handles paths with dots in filename", () => {
+		expect(lang("my.file.name.ts")).toBe("typescript");
+	});
+
+	// ── Property tests ───────────────────────────────────────────────────
+
+	it("property: lang(x) returns consistent result for same extension", () => {
+		fc.assert(
+			fc.property(
+				fc.string({ minLength: 1, maxLength: 100 }),
+				filename => {
+					const result1 = lang(filename);
+					const result2 = lang(filename);
+					return result1 === result2;
+				},
+			),
+		);
+	});
+
+	it("property: lang only returns known languages or undefined", () => {
+		const knownLanguages = new Set([
+			"typescript", "tsx", "javascript", "jsx", "python", "ruby",
+			"rust", "go", "java", "c", "cpp", "csharp", "swift", "kotlin",
+			"html", "css", "scss", "json", "yaml", "toml", "markdown",
+			"sql", "bash", "lua", "php", "dart", "xml", "graphql",
+			"svelte", "vue",
+		]);
+
+		fc.assert(
+			fc.property(
+				fc.string({ minLength: 1, maxLength: 100 }),
+				filename => {
+					const result = lang(filename);
+					return result === undefined || knownLanguages.has(result);
+				},
+			),
+		);
+	});
+});
+
+// ── setConfigGetter ──────────────────────────────────────────────────────────
+
+describe("setConfigGetter", () => {
+	it("changes the config getter", async () => {
+		// Import hlBlock to test config getter effect
+		const { hlBlock } = await import("./shiki.js");
+
+		setConfigGetter(() => ({ diffTheme: "github-light" }));
+
+		// The config getter should now return the new theme
+		// We can't directly inspect _getConfig, but we can verify hlBlock
+		// doesn't throw and uses the new config
+		const result = await hlBlock("const x = 1;", "javascript");
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it("accepts custom theme", async () => {
+		setConfigGetter(() => ({ diffTheme: "nord" }));
+
+		const { hlBlock } = await import("./shiki.js");
+		const result = await hlBlock("print('hello')", "python");
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it("restores default behavior after setting", () => {
+		setConfigGetter(() => ({ diffTheme: "github-dark" }));
+		// Should not throw
+		expect(() => setConfigGetter(() => ({ diffTheme: "one-dark" }))).not.toThrow();
+	});
+});

--- a/packages/footer/src/utils/git.test.ts
+++ b/packages/footer/src/utils/git.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as fc from "fast-check";
+
+// ── Type alias ──────────────────────────────────────────────────────────────
+
+interface GitStatus {
+  staged: number;
+  unstaged: number;
+  untracked: number;
+  ahead: number;
+  behind: number;
+}
+
+// ── Tests (vi.resetModules + dynamic import to isolate module state) ────────
+
+describe("getGitStatus", () => {
+  let getGitStatus: () => GitStatus;
+  let getWorktreeBranch: () => string | null;
+
+  async function loadModule(mockExecSync: ReturnType<typeof vi.fn>) {
+    vi.resetModules();
+
+    vi.doMock("child_process", () => ({
+      execSync: mockExecSync,
+    }));
+
+    vi.doMock("fs", () => ({
+      realpathSync: vi.fn((p: string) => p),
+    }));
+
+    const mod = await import("./git.js");
+    getGitStatus = mod.getGitStatus;
+    getWorktreeBranch = mod.getWorktreeBranch;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("empty output returns zero status", async () => {
+    const mockExecSync = vi.fn(() => "");
+    await loadModule(mockExecSync);
+    const result = getGitStatus();
+    expect(result).toEqual({ staged: 0, unstaged: 0, untracked: 0, ahead: 0, behind: 0 });
+  });
+
+  it("parse scored format lines", async () => {
+    const mockExecSync = vi.fn(() => "1 AM file1.txt\n1  M file2.txt\n");
+    await loadModule(mockExecSync);
+    const result = getGitStatus();
+    // AM: index=A (staged), workTree=M (unstaged) → 1 staged, 1 unstaged
+    // " M": index=space (not staged), workTree=M (unstaged) → 1 unstaged
+    expect(result.staged).toBe(1);
+    expect(result.unstaged).toBe(2);
+  });
+
+  it("parse unscored format lines (note: trim() strips leading space)", async () => {
+    // NOTE: parseGitOutput calls output.trim() which strips leading whitespace.
+    // So " M file.txt" becomes "M file.txt" after trim, and the regex
+    // /^(..) / matches "M " → indexField='M' (staged), workTreeField='f'.
+    // This is a known quirk of the implementation. We test the actual behavior.
+    const mockExecSync = vi.fn(() => "M  file.txt\nA  staged.txt\n");
+    await loadModule(mockExecSync);
+    const result = getGitStatus();
+    // "M ": index=M (staged), workTree=space → 1 staged
+    // "A ": index=A (staged), workTree=space → 1 staged
+    expect(result.staged).toBe(2);
+    expect(result.unstaged).toBe(0);
+  });
+
+  it("parse untracked lines", async () => {
+    const mockExecSync = vi.fn(() => "?  untracked1.txt\n?  untracked2.txt\n");
+    await loadModule(mockExecSync);
+    const result = getGitStatus();
+    expect(result.untracked).toBe(2);
+  });
+
+  it("parse branch summary (ahead/behind)", async () => {
+    const mockExecSync = vi.fn(() => "## main...origin/main 3 2\n");
+    await loadModule(mockExecSync);
+    const result = getGitStatus();
+    expect(result.ahead).toBe(3);
+    expect(result.behind).toBe(2);
+  });
+
+  it("malformed lines ignored gracefully", async () => {
+    const mockExecSync = vi.fn(() => "this is not valid\n\n  \n1 AM valid.txt\n");
+    await loadModule(mockExecSync);
+    const result = getGitStatus();
+    // Only the valid scored line should be parsed
+    expect(result.staged).toBe(1);
+    expect(result.unstaged).toBe(1);
+  });
+
+  it("getWorktreeBranch returns null when not in worktree", async () => {
+    const mockExecSync = vi.fn(() => "head ref/heads/main\nworktree /path/to/repo\n");
+    await loadModule(mockExecSync);
+    const result = getWorktreeBranch();
+    expect(result).toBeNull();
+  });
+
+  it("property: getGitStatus never throws (catches execSync errors gracefully)", async () => {
+    const mockExecSync = vi.fn(() => { throw new Error("git not found"); });
+    await loadModule(mockExecSync);
+    expect(() => getGitStatus()).not.toThrow();
+    const result = getGitStatus();
+    expect(result).toEqual({ staged: 0, unstaged: 0, untracked: 0, ahead: 0, behind: 0 });
+  });
+
+  it("property: parseGitOutput handles arbitrary git porcelain output without throwing", async () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 500 }), (output) => {
+        const mockExecSync = vi.fn(() => output);
+        loadModule(mockExecSync).then(() => {
+          expect(() => getGitStatus()).not.toThrow();
+        });
+      }),
+      { verbose: false },
+    );
+  });
+});

--- a/packages/footer/src/utils/git.test.ts
+++ b/packages/footer/src/utils/git.test.ts
@@ -109,11 +109,10 @@ describe("getGitStatus", () => {
 
   it("property: parseGitOutput handles arbitrary git porcelain output without throwing", async () => {
     fc.assert(
-      fc.property(fc.string({ maxLength: 500 }), (output) => {
+      fc.asyncProperty(fc.string({ maxLength: 500 }), async (output) => {
         const mockExecSync = vi.fn(() => output);
-        loadModule(mockExecSync).then(() => {
-          expect(() => getGitStatus()).not.toThrow();
-        });
+        await loadModule(mockExecSync);
+        expect(() => getGitStatus()).not.toThrow();
       }),
       { verbose: false },
     );

--- a/packages/footer/src/utils/git.test.ts
+++ b/packages/footer/src/utils/git.test.ts
@@ -111,7 +111,7 @@ describe("getGitStatus", () => {
   });
 
   it("property: parseGitOutput handles arbitrary git porcelain output without throwing", async () => {
-    fc.assert(
+    await fc.assert(
       fc.asyncProperty(fc.string({ maxLength: 500 }), async (output) => {
         const mockExecSync = vi.fn(() => output);
         await loadModule(mockExecSync);

--- a/packages/footer/src/utils/git.test.ts
+++ b/packages/footer/src/utils/git.test.ts
@@ -55,10 +55,13 @@ describe("getGitStatus", () => {
   });
 
   it("parse unscored format lines (note: trim() strips leading space)", async () => {
-    // NOTE: parseGitOutput calls output.trim() which strips leading whitespace.
-    // So " M file.txt" becomes "M file.txt" after trim, and the regex
-    // /^(..) / matches "M " → indexField='M' (staged), workTreeField='f'.
-    // This is a known quirk of the implementation. We test the actual behavior.
+    // TODO: parseGitOutput calls output.trim() which strips leading whitespace.
+    // This means unscored lines like " M file.txt" (index=space, workTree=M,
+    // meaning unstaged modification) become "M file.txt" after trim, and are
+    // incorrectly parsed as index=M (staged), workTree=space.
+    // This test codifies the current (buggy) behavior so future fixes to
+    // remove trim() won't break silently — update both the implementation
+    // and this test together when fixing.
     const mockExecSync = vi.fn(() => "M  file.txt\nA  staged.txt\n");
     await loadModule(mockExecSync);
     const result = getGitStatus();

--- a/packages/footer/src/utils/stats.test.ts
+++ b/packages/footer/src/utils/stats.test.ts
@@ -160,28 +160,24 @@ describe("getTokenUsageStats", () => {
           }),
         ),
         (usages) => {
-          // Reset module for fresh state
-          vi.resetModules();
-          import("./stats.js").then(async (mod) => {
-            const entries: SessionEntry[] = [];
-            let prev = { totalInput: 0, totalOutput: 0, totalCacheRead: 0, totalCacheWrite: 0, totalCost: 0 };
-            for (const u of usages) {
-              entries.push(makeAssistantEntry({ input: u.input, output: u.output, cacheRead: u.cacheRead, cacheWrite: u.cacheWrite, cost: { total: u.cost } }));
-              const ctx = makeCtx(entries);
-              const curr = mod.getTokenUsageStats(ctx);
-              // Monotonic: each total >= previous
-              if (
-                curr.totalInput < prev.totalInput ||
-                curr.totalOutput < prev.totalOutput ||
-                curr.totalCacheRead < prev.totalCacheRead ||
-                curr.totalCacheWrite < prev.totalCacheWrite ||
-                curr.totalCost < prev.totalCost
-              ) {
-                throw new Error(`Monotonicity violated: ${JSON.stringify(prev)} -> ${JSON.stringify(curr)}`);
-              }
-              prev = curr;
+          const entries: SessionEntry[] = [];
+          let prev = { totalInput: 0, totalOutput: 0, totalCacheRead: 0, totalCacheWrite: 0, totalCost: 0 };
+          for (const u of usages) {
+            entries.push(makeAssistantEntry({ input: u.input, output: u.output, cacheRead: u.cacheRead, cacheWrite: u.cacheWrite, cost: { total: u.cost } }));
+            const ctx = makeCtx(entries);
+            const curr = getTokenUsageStats(ctx);
+            // Monotonic: each total >= previous
+            if (
+              curr.totalInput < prev.totalInput ||
+              curr.totalOutput < prev.totalOutput ||
+              curr.totalCacheRead < prev.totalCacheRead ||
+              curr.totalCacheWrite < prev.totalCacheWrite ||
+              curr.totalCost < prev.totalCost
+            ) {
+              throw new Error(`Monotonicity violated: ${JSON.stringify(prev)} -> ${JSON.stringify(curr)}`);
             }
-          });
+            prev = curr;
+          }
         },
       ),
       { verbose: false },

--- a/packages/footer/src/utils/stats.test.ts
+++ b/packages/footer/src/utils/stats.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fc from "fast-check";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+interface MessageUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: { total: number };
+}
+
+interface AssistantMessage {
+  role: "assistant";
+  usage: MessageUsage;
+}
+
+interface UserMessage {
+  role: "user";
+  content: string;
+}
+
+interface SessionEntry {
+  type: "message";
+  message: AssistantMessage | UserMessage;
+}
+
+interface MockContext {
+  sessionManager: {
+    getEntries: () => SessionEntry[];
+  };
+  getContextUsage: () => { contextWindow?: number; percent?: number } | undefined;
+  model?: { contextWindow?: number };
+}
+
+function makeAssistantEntry(usage: MessageUsage): SessionEntry {
+  return {
+    type: "message",
+    message: { role: "assistant", usage },
+  };
+}
+
+function makeUserEntry(): SessionEntry {
+  return {
+    type: "message",
+    message: { role: "user", content: "hello" },
+  };
+}
+
+function makeCtx(entries: SessionEntry[], contextUsage?: { contextWindow?: number; percent?: number }, modelContextWindow?: number): any {
+  return {
+    sessionManager: { getEntries: () => entries },
+    getContextUsage: () => contextUsage,
+    model: modelContextWindow ? { contextWindow: modelContextWindow } : undefined,
+  };
+}
+
+// ── Tests (vi.resetModules + dynamic import to isolate module state) ────────
+
+describe("getTokenUsageStats", () => {
+  let getTokenUsageStats: typeof import("./stats.js").getTokenUsageStats;
+  let invalidateStatsCache: typeof import("./stats.js").invalidateStatsCache;
+
+  async function loadModule() {
+    vi.resetModules();
+    const mod = await import("./stats.js");
+    getTokenUsageStats = mod.getTokenUsageStats;
+    invalidateStatsCache = mod.invalidateStatsCache;
+  }
+
+  it("empty entries returns zero stats", async () => {
+    await loadModule();
+    const ctx = makeCtx([]);
+    const result = getTokenUsageStats(ctx);
+    expect(result).toEqual({
+      totalInput: 0,
+      totalOutput: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      totalCost: 0,
+    });
+  });
+
+  it("single assistant message accumulates correctly", async () => {
+    await loadModule();
+    const usage = { input: 100, output: 50, cacheRead: 200, cacheWrite: 100, cost: { total: 0.05 } };
+    const ctx = makeCtx([makeAssistantEntry(usage)]);
+    const result = getTokenUsageStats(ctx);
+    expect(result).toEqual({
+      totalInput: 100,
+      totalOutput: 50,
+      totalCacheRead: 200,
+      totalCacheWrite: 100,
+      totalCost: 0.05,
+    });
+  });
+
+  it("multiple messages sum correctly", async () => {
+    await loadModule();
+    const ctx = makeCtx([
+      makeAssistantEntry({ input: 100, output: 50, cacheRead: 10, cacheWrite: 5, cost: { total: 0.01 } }),
+      makeAssistantEntry({ input: 200, output: 100, cacheRead: 20, cacheWrite: 10, cost: { total: 0.02 } }),
+    ]);
+    const result = getTokenUsageStats(ctx);
+    expect(result).toEqual({
+      totalInput: 300,
+      totalOutput: 150,
+      totalCacheRead: 30,
+      totalCacheWrite: 15,
+      totalCost: 0.03,
+    });
+  });
+
+  it("non-assistant messages ignored", async () => {
+    await loadModule();
+    const ctx = makeCtx([
+      makeUserEntry(),
+      makeAssistantEntry({ input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } }),
+      makeUserEntry(),
+    ]);
+    const result = getTokenUsageStats(ctx);
+    expect(result.totalInput).toBe(100);
+    expect(result.totalOutput).toBe(50);
+  });
+
+  it("cache returns same result within TTL", async () => {
+    await loadModule();
+    const ctx = makeCtx([
+      makeAssistantEntry({ input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } }),
+    ]);
+    const first = getTokenUsageStats(ctx);
+    const second = getTokenUsageStats(ctx);
+    expect(first).toBe(second); // same reference (cached)
+  });
+
+  it("invalidateStatsCache clears cache", async () => {
+    await loadModule();
+    const ctx = makeCtx([
+      makeAssistantEntry({ input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } }),
+    ]);
+    const first = getTokenUsageStats(ctx);
+    invalidateStatsCache();
+    const second = getTokenUsageStats(ctx);
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second); // different reference (cache cleared)
+  });
+
+  it("property: stats are monotonic (adding entries never decreases totals)", async () => {
+    await loadModule();
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            input: fc.nat({ max: 1000 }),
+            output: fc.nat({ max: 1000 }),
+            cacheRead: fc.nat({ max: 1000 }),
+            cacheWrite: fc.nat({ max: 1000 }),
+            cost: fc.double({ min: 0, max: 1 }),
+          }),
+        ),
+        (usages) => {
+          // Reset module for fresh state
+          vi.resetModules();
+          import("./stats.js").then(async (mod) => {
+            const entries: SessionEntry[] = [];
+            let prev = { totalInput: 0, totalOutput: 0, totalCacheRead: 0, totalCacheWrite: 0, totalCost: 0 };
+            for (const u of usages) {
+              entries.push(makeAssistantEntry({ input: u.input, output: u.output, cacheRead: u.cacheRead, cacheWrite: u.cacheWrite, cost: { total: u.cost } }));
+              const ctx = makeCtx(entries);
+              const curr = mod.getTokenUsageStats(ctx);
+              // Monotonic: each total >= previous
+              if (
+                curr.totalInput < prev.totalInput ||
+                curr.totalOutput < prev.totalOutput ||
+                curr.totalCacheRead < prev.totalCacheRead ||
+                curr.totalCacheWrite < prev.totalCacheWrite ||
+                curr.totalCost < prev.totalCost
+              ) {
+                throw new Error(`Monotonicity violated: ${JSON.stringify(prev)} -> ${JSON.stringify(curr)}`);
+              }
+              prev = curr;
+            }
+          });
+        },
+      ),
+      { verbose: false },
+    );
+  });
+});
+
+describe("getContextWindowInfo", () => {
+  let getContextWindowInfo: typeof import("./stats.js").getContextWindowInfo;
+
+  async function loadModule() {
+    vi.resetModules();
+    const mod = await import("./stats.js");
+    getContextWindowInfo = mod.getContextWindowInfo;
+  }
+
+  it("computes percentage correctly", async () => {
+    await loadModule();
+    const ctx = makeCtx(
+      [makeAssistantEntry({ input: 500, output: 500, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } })],
+      { contextWindow: 10000, percent: 10 },
+    );
+    const result = getContextWindowInfo(ctx);
+    expect(result.percent).toBe("10.0");
+    expect(result.percentValue).toBe(10);
+    expect(result.windowSize).toBe(10000);
+  });
+
+  it("handles missing context window", async () => {
+    await loadModule();
+    const ctx = makeCtx([], undefined);
+    const result = getContextWindowInfo(ctx);
+    expect(result.percent).toBe("?");
+    expect(result.percentValue).toBe(0);
+    expect(result.windowSize).toBe(0);
+  });
+
+  it("computes percentage from tokens when contextUsage.percent missing", async () => {
+    await loadModule();
+    const ctx = makeCtx(
+      [makeAssistantEntry({ input: 500, output: 500, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } })],
+      { contextWindow: 10000 },
+    );
+    const result = getContextWindowInfo(ctx);
+    expect(result.percent).toBe("?");
+    expect(result.percentValue).toBe(10);
+    expect(result.windowSize).toBe(10000);
+  });
+});

--- a/packages/subagent/src/compact.test.ts
+++ b/packages/subagent/src/compact.test.ts
@@ -379,8 +379,8 @@ describe("buildActivityLine property tests", () => {
   it("truncated argsPreview never exceeds truncLine limit of 60 chars", () => {
     fc.assert(
       fc.property(
-        fc.string({ minLength: 1, maxLength: 20 }).filter((s) => !s.includes(": ") && !s.includes("\n")),
-        fc.string({ minLength: 1, maxLength: 500 }).filter((s) => !s.includes(": ") && !s.includes("\n")),
+        fc.string({ minLength: 1, maxLength: 20 }).filter((s) => !s.includes(": ") && !s.includes("\n") && !s.includes("|")),
+        fc.string({ minLength: 1, maxLength: 500 }).filter((s) => !s.includes(": ") && !s.includes("\n") && !s.includes("|")),
         (currentTool, currentToolArgs) => {
           const { theme } = makeMockTheme();
           const result = buildActivityLine(
@@ -390,10 +390,8 @@ describe("buildActivityLine property tests", () => {
           // Extract the args portion after ": "
           const argsMatch = result.match(/: (.+?)(?:\s\|.*|\[\/dim\].*)?$/);
           expect(argsMatch).not.toBeNull();
-          if (argsMatch && argsMatch[1]) {
-            const argsText = argsMatch[1].replace(/\[\/dim\]$/, "").replace(/\[dim\]/, "");
-            expect(argsText.length).toBeLessThanOrEqual(60);
-          }
+          const argsText = argsMatch![1]!.replace(/\[\/dim\]$/, "").replace(/\[dim\]/, "");
+          expect(argsText.length).toBeLessThanOrEqual(60);
         },
       ),
     );

--- a/packages/subagent/src/compact.test.ts
+++ b/packages/subagent/src/compact.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect, vi } from "vitest";
+import * as fc from "fast-check";
+import { buildActivityLine, renderCompactSingle, renderCompactParallel } from "./compact.js";
+import type { SubagentResult, SubagentProgress, SubagentDetails, SubagentToolCall } from "./types.js";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("@earendil-works/pi-tui", () => {
+  class MockTextInner {
+    private _content = "";
+
+    setText(content: string): void {
+      this._content = content;
+    }
+
+    getContent(): string {
+      return this._content;
+    }
+  }
+  return {
+    Text: MockTextInner,
+  };
+});
+
+// Re-import MockText for use in tests (same class as the mock)
+import { Text as MockText } from "@earendil-works/pi-tui";
+
+// Type-safe helper: ActivityData with all optional fields for test convenience
+// ActivityData is defined in compact.ts — reconstruct the shape here
+type ActivityData = {
+  currentTool: string | undefined;
+  currentToolArgs: string | undefined;
+  currentToolStartedAt: number | undefined;
+  finalOutput: string | undefined;
+  status: "running" | "completed" | "failed" | undefined;
+  error: string | undefined;
+  toolCalls?: (SubagentToolCall | string)[] | undefined;
+};
+
+function activityData(p: Partial<ActivityData>): ActivityData {
+  return {
+    currentTool: undefined,
+    currentToolArgs: undefined,
+    currentToolStartedAt: undefined,
+    finalOutput: undefined,
+    status: undefined,
+    error: undefined,
+    toolCalls: undefined,
+    ...p,
+  };
+}
+
+// Mock theme that tracks calls for verification
+function makeMockTheme() {
+  const calls: Array<{ fn: string; args: unknown[] }> = [];
+
+  const theme = {
+    fg: (token: string, text: string) => {
+      calls.push({ fn: "fg", args: [token, text] });
+      return `[${token}]${text}[/${token}]`;
+    },
+    bold: (text: string) => {
+      calls.push({ fn: "bold", args: [text] });
+      return `**${text}**`;
+    },
+  };
+
+  return { theme, calls };
+}
+
+// ── buildActivityLine ──────────────────────────────────────────────────────
+
+describe("buildActivityLine", () => {
+  it("shows error prefix with truncated error when error is present", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({ error: "Something went wrong", status: "running" }),
+      theme,
+    );
+    expect(result).toContain("✗ Something went wrong");
+  });
+
+  it("shows '✓ Done' when status is completed", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({ status: "completed" }),
+      theme,
+    );
+    expect(result).toContain("✓ Done");
+  });
+
+  it("shows '✗ Failed' when status is failed", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({ status: "failed" }),
+      theme,
+    );
+    expect(result).toContain("✗ Failed");
+  });
+
+  it("shows tool name + args when running with current tool", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({
+        status: "running",
+        currentTool: "read",
+        currentToolArgs: '{"path": "foo.ts"}',
+      }),
+      theme,
+    );
+    expect(result).toContain("read");
+    expect(result).toContain("foo.ts");
+  });
+
+  it("shows last tool call when running with no current tool but toolCalls present", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({
+        status: "running",
+        toolCalls: [
+          { name: "bash", argsPreview: "ls -la", error: false },
+        ],
+      }),
+      theme,
+    );
+    expect(result).toContain("bash");
+  });
+
+  it("shows '↳ Starting...' when running with no info", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({ status: "running" }),
+      theme,
+    );
+    expect(result).toContain("↳ Starting...");
+  });
+
+  it("shows first line of final output when available", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({
+        status: "running",
+        finalOutput: "first line of output\nsecond line\nthird line",
+      }),
+      theme,
+    );
+    expect(result).toContain("first line of output");
+    expect(result).not.toContain("second line");
+  });
+
+  it("returns empty string when status is undefined and no data", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(activityData({}), theme);
+    expect(result).toBe("");
+  });
+
+  it("error takes priority over completed status", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({ error: "oops", status: "completed" }),
+      theme,
+    );
+    expect(result).toContain("✗ oops");
+    expect(result).not.toContain("✓ Done");
+  });
+
+  it("completed status takes priority over currentTool", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({ status: "completed", currentTool: "read" }),
+      theme,
+    );
+    expect(result).toContain("✓ Done");
+    expect(result).not.toContain("read");
+  });
+
+  it("shows string toolCall in toolCalls array", () => {
+    const { theme } = makeMockTheme();
+    const result = buildActivityLine(
+      activityData({
+        status: "running",
+        toolCalls: ["some-string-call"],
+      }),
+      theme,
+    );
+    expect(result).toContain("some-string-call");
+  });
+
+  it("colors last tool call name with error color when error flag set", () => {
+    const { theme, calls } = makeMockTheme();
+    buildActivityLine(
+      activityData({
+        status: "running",
+        toolCalls: [{ name: "bash", argsPreview: "rm -rf /", error: true }],
+      }),
+      theme,
+    );
+    // The tool name "bash" should be colored with "error" token
+    const fgCalls = calls.filter(c => c.fn === "fg");
+    const errorCall = fgCalls.find(c => c.args[0] === "error" && c.args[1] === "bash");
+    expect(errorCall).toBeDefined();
+  });
+
+  it("colors last tool call name with success color when no error", () => {
+    const { theme, calls } = makeMockTheme();
+    buildActivityLine(
+      activityData({
+        status: "running",
+        toolCalls: [{ name: "read", argsPreview: "file.ts", error: false }],
+      }),
+      theme,
+    );
+    const fgCalls = calls.filter(c => c.fn === "fg");
+    const successCall = fgCalls.find(c => c.args[0] === "success" && c.args[1] === "read");
+    expect(successCall).toBeDefined();
+  });
+});
+
+// ── renderCompactSingle ────────────────────────────────────────────────────
+
+describe("renderCompactSingle", () => {
+  function makeResult(overrides: Partial<SubagentResult> = {}): SubagentResult {
+    return {
+      agent: "test-agent",
+      task: "do something",
+      exitCode: 0,
+      usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.01, turns: 3 },
+      model: "gpt-4",
+      finalOutput: undefined,
+      error: undefined,
+      progress: undefined,
+      progressSummary: { toolCount: 5, tokens: 150, durationMs: 3000 },
+      ...overrides,
+    };
+  }
+
+  it("calls setText with expected output structure for completed agent", () => {
+    const { theme } = makeMockTheme();
+    const text = new MockText();
+    const result = makeResult({ exitCode: 0 });
+    const context = { state: {}, invalidate: vi.fn() };
+
+    renderCompactSingle(text, result, undefined, theme, context);
+
+    const output = (text as unknown as { getContent(): string }).getContent();
+    expect(output).toContain("test-agent");
+    expect(output).toContain("do something");
+    expect(output).toContain("✓ Done");
+  });
+
+  it("calls setText with expected output structure for running agent", () => {
+    const { theme } = makeMockTheme();
+    const text = new MockText();
+    const result = makeResult({ exitCode: 1 });
+    const progress: SubagentProgress = {
+      agent: "test-agent",
+      status: "running",
+      task: "do something",
+      currentTool: "read",
+      currentToolArgs: undefined,
+      currentToolStartedAt: undefined,
+      toolCount: 2,
+      inputTokens: 50,
+      outputTokens: 30,
+      tokens: 80,
+      cost: 0.005,
+      durationMs: 1000,
+      error: undefined,
+      model: "gpt-4",
+      output: undefined,
+      recentOutput: undefined,
+      toolCalls: undefined,
+    };
+    const context = { state: {}, invalidate: vi.fn() };
+
+    renderCompactSingle(text, result, progress, theme, context);
+
+    const output = (text as unknown as { getContent(): string }).getContent();
+    expect(output).toContain("test-agent");
+    expect(output).toContain("read");
+  });
+
+  it("returns the text instance", () => {
+    const { theme } = makeMockTheme();
+    const text = new MockText();
+    const result = makeResult();
+    const context = { state: {}, invalidate: vi.fn() };
+
+    const returned = renderCompactSingle(text, result, undefined, theme, context);
+    expect(returned).toBe(text);
+  });
+});
+
+// ── renderCompactParallel ──────────────────────────────────────────────────
+
+describe("renderCompactParallel", () => {
+  function makeDetails(overrides: Partial<SubagentDetails> = {}): SubagentDetails {
+    return {
+      mode: "parallel",
+      results: [
+        {
+          agent: "agent-a",
+          task: "task a",
+          exitCode: 0,
+          usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+          model: undefined,
+          finalOutput: undefined,
+          error: undefined,
+          progress: undefined,
+          progressSummary: { toolCount: 0, tokens: 0, durationMs: 0 },
+        },
+        {
+          agent: "agent-b",
+          task: "task b",
+          exitCode: 1,
+          usage: { input: 200, output: 100, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+          model: undefined,
+          finalOutput: undefined,
+          error: "failed",
+          progress: undefined,
+          progressSummary: { toolCount: 0, tokens: 0, durationMs: 0 },
+        },
+      ],
+      progress: undefined,
+      ...overrides,
+    };
+  }
+
+  it("calls setText with one line per result", () => {
+    const { theme } = makeMockTheme();
+    const text = new MockText();
+    const details = makeDetails();
+    const context = { state: {}, invalidate: vi.fn() };
+
+    renderCompactParallel(text, details, theme, context);
+
+    const output = (text as unknown as { getContent(): string }).getContent();
+    expect(output).toContain("agent-a");
+    expect(output).toContain("agent-b");
+    // Two results joined by newline
+    const lines = output.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns the text instance", () => {
+    const { theme } = makeMockTheme();
+    const text = new MockText();
+    const details = makeDetails();
+    const context = { state: {}, invalidate: vi.fn() };
+
+    const returned = renderCompactParallel(text, details, theme, context);
+    expect(returned).toBe(text);
+  });
+});
+
+// ── Property tests (fast-check) ────────────────────────────────────────────
+
+describe("buildActivityLine property tests", () => {
+  it("truncated error never exceeds truncLine limit of 80 chars", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 500 }),
+        (error) => {
+          const { theme } = makeMockTheme();
+          const result = buildActivityLine(
+            activityData({ error, status: "running" }),
+            theme,
+          );
+          // Strip the "✗ " prefix and ANSI tags to get the actual truncated text
+          const withoutPrefix = result.replace(/^\[error\]✗ /, "");
+          // The visible text (without closing ANSI tag) should be <= 80
+          const visibleText = withoutPrefix.replace(/\[\/error\]$/, "");
+          expect(visibleText.length).toBeLessThanOrEqual(80);
+        },
+      ),
+    );
+  });
+
+  it("truncated argsPreview never exceeds truncLine limit of 60 chars", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 20 }),
+        fc.string({ minLength: 1, maxLength: 500 }),
+        (currentTool, currentToolArgs) => {
+          const { theme } = makeMockTheme();
+          const result = buildActivityLine(
+            activityData({ status: "running", currentTool, currentToolArgs }),
+            theme,
+          );
+          // Extract the args portion after ": "
+          const argsMatch = result.match(/: (.+?)(?:\s\|.*|\[\/dim\].*)?$/);
+          if (argsMatch && argsMatch[1]) {
+            const argsText = argsMatch[1].replace(/\[\/dim\]$/, "").replace(/\[dim\]/, "");
+            expect(argsText.length).toBeLessThanOrEqual(60);
+          }
+        },
+      ),
+    );
+  });
+
+  it("truncated finalOutput first line never exceeds truncLine limit of 80 chars", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 500 }),
+        (finalOutput) => {
+          const { theme } = makeMockTheme();
+          const result = buildActivityLine(
+            activityData({ status: "running", finalOutput }),
+            theme,
+          );
+          // Strip ANSI tags to get visible text
+          const visible = result.replace(/\[muted\]/g, "").replace(/\[\/muted\]/g, "");
+          // The visible text after "↳ " should be <= 80
+          const afterArrow = visible.replace(/^↳ /, "");
+          expect(afterArrow.length).toBeLessThanOrEqual(80);
+        },
+      ),
+    );
+  });
+
+  it("truncated string toolCall never exceeds truncLine limit of 60 chars", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 500 }),
+        (toolCallStr) => {
+          const { theme } = makeMockTheme();
+          const result = buildActivityLine(
+            activityData({ status: "running", toolCalls: [toolCallStr] }),
+            theme,
+          );
+          const visible = result.replace(/\[dim\]/g, "").replace(/\[\/dim\]/g, "");
+          const afterArrow = visible.replace(/^↳ /, "");
+          expect(afterArrow.length).toBeLessThanOrEqual(60);
+        },
+      ),
+    );
+  });
+});

--- a/packages/subagent/src/compact.test.ts
+++ b/packages/subagent/src/compact.test.ts
@@ -379,8 +379,8 @@ describe("buildActivityLine property tests", () => {
   it("truncated argsPreview never exceeds truncLine limit of 60 chars", () => {
     fc.assert(
       fc.property(
-        fc.string({ minLength: 1, maxLength: 20 }),
-        fc.string({ minLength: 1, maxLength: 500 }),
+        fc.string({ minLength: 1, maxLength: 20 }).filter((s) => !s.includes(": ") && !s.includes("\n")),
+        fc.string({ minLength: 1, maxLength: 500 }).filter((s) => !s.includes(": ") && !s.includes("\n")),
         (currentTool, currentToolArgs) => {
           const { theme } = makeMockTheme();
           const result = buildActivityLine(
@@ -389,6 +389,7 @@ describe("buildActivityLine property tests", () => {
           );
           // Extract the args portion after ": "
           const argsMatch = result.match(/: (.+?)(?:\s\|.*|\[\/dim\].*)?$/);
+          expect(argsMatch).not.toBeNull();
           if (argsMatch && argsMatch[1]) {
             const argsText = argsMatch[1].replace(/\[\/dim\]$/, "").replace(/\[dim\]/, "");
             expect(argsText.length).toBeLessThanOrEqual(60);

--- a/packages/subagent/src/cost.test.ts
+++ b/packages/subagent/src/cost.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Events } from "@pi-archimedes/core/bus";
+
+// ── globalThis cleanup ──────────────────────────────────────────────────────
+
+const BUS_KEY = Symbol.for("archimedes:bus");
+const QUEUE_KEY = Symbol.for("archimedes:busQueue");
+
+afterEach(() => {
+  delete (globalThis as Record<symbol, unknown>)[BUS_KEY];
+  delete (globalThis as Record<symbol, unknown>)[QUEUE_KEY];
+});
+
+// ── mock bus ────────────────────────────────────────────────────────────────
+
+let mockEmit: ReturnType<typeof vi.fn>;
+
+vi.mock("@pi-archimedes/core/bus", () => ({
+  getBus: () => ({
+    emit: mockEmit,
+  }),
+  Events: {
+    COST_UPDATE: "archimedes:cost_update",
+    TODOS_UPDATE: "archimedes:todos_update",
+    TODOS_CLEAR: "archimedes:todos_clear",
+    ASK_REQUEST: "archimedes:ask_request",
+    ASK_RESPONSE: "archimedes:ask_response",
+  },
+}));
+
+const { emitCostUpdate } = await import("./cost.js");
+
+describe("emitCostUpdate", () => {
+  beforeEach(() => {
+    mockEmit = vi.fn();
+  });
+
+  it("emits COST_UPDATE event with correct source prefix", () => {
+    emitCostUpdate("my-agent", { inputTokens: 100, outputTokens: 50 });
+
+    expect(mockEmit).toHaveBeenCalledWith(Events.COST_UPDATE, {
+      source: "subagent:my-agent",
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+  });
+
+  it("passes through all usage fields", () => {
+    emitCostUpdate("test-agent", {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 100,
+      cost: 0.05,
+    });
+
+    expect(mockEmit).toHaveBeenCalledWith(Events.COST_UPDATE, {
+      source: "subagent:test-agent",
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 200,
+      cacheWriteTokens: 100,
+      cost: 0.05,
+    });
+  });
+
+  it("works with partial usage fields", () => {
+    emitCostUpdate("minimal", { cost: 0.01 });
+
+    expect(mockEmit).toHaveBeenCalledWith(Events.COST_UPDATE, {
+      source: "subagent:minimal",
+      cost: 0.01,
+    });
+  });
+});

--- a/packages/subagent/src/cost.test.ts
+++ b/packages/subagent/src/cost.test.ts
@@ -1,32 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Events } from "@pi-archimedes/core/bus";
-
-// ── globalThis cleanup ──────────────────────────────────────────────────────
-
-const BUS_KEY = Symbol.for("archimedes:bus");
-const QUEUE_KEY = Symbol.for("archimedes:busQueue");
-
-afterEach(() => {
-  delete (globalThis as Record<symbol, unknown>)[BUS_KEY];
-  delete (globalThis as Record<symbol, unknown>)[QUEUE_KEY];
-});
 
 // ── mock bus ────────────────────────────────────────────────────────────────
 
 let mockEmit: ReturnType<typeof vi.fn>;
 
-vi.mock("@pi-archimedes/core/bus", () => ({
-  getBus: () => ({
-    emit: mockEmit,
-  }),
-  Events: {
-    COST_UPDATE: "archimedes:cost_update",
-    TODOS_UPDATE: "archimedes:todos_update",
-    TODOS_CLEAR: "archimedes:todos_clear",
-    ASK_REQUEST: "archimedes:ask_request",
-    ASK_RESPONSE: "archimedes:ask_response",
-  },
-}));
+vi.mock("@pi-archimedes/core/bus", async (importOriginal) => {
+  const actual = await importOriginal() as typeof import("@pi-archimedes/core/bus");
+  return {
+    ...actual,
+    getBus: () => ({
+      emit: mockEmit,
+    }),
+  };
+});
 
 const { emitCostUpdate } = await import("./cost.js");
 

--- a/packages/subagent/src/frontmatter-io.test.ts
+++ b/packages/subagent/src/frontmatter-io.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { validateAgentName, serializeAgent, AGENT_NAME_REGEX } from "./frontmatter-io.js";
+import type { AgentConfig } from "./agents.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    name: "test-agent",
+    description: "A test agent",
+    systemPrompt: "You are a helpful test agent.",
+    source: "user",
+    filePath: "/tmp/test-agent.md",
+    ...overrides,
+  };
+}
+
+// ── validateAgentName ───────────────────────────────────────────────────────
+
+describe("validateAgentName", () => {
+  it("accepts valid names (3-50 chars, lowercase alnum + hyphens)", () => {
+    expect(validateAgentName("abc")).toBeNull();
+    expect(validateAgentName("test-agent")).toBeNull();
+    expect(validateAgentName("a1b2c3")).toBeNull();
+    expect(validateAgentName("my-long-agent-name-with-many-hyphens")).toBeNull();
+  });
+
+  it("accepts single char names", () => {
+    expect(validateAgentName("a")).toBeNull();
+    expect(validateAgentName("z")).toBeNull();
+    expect(validateAgentName("0")).toBeNull();
+    expect(validateAgentName("9")).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(validateAgentName("")).toBe("Name is required");
+  });
+
+  it("rejects uppercase", () => {
+    expect(validateAgentName("Abc")).not.toBeNull();
+    expect(validateAgentName("ABC")).not.toBeNull();
+  });
+
+  it("rejects special chars", () => {
+    expect(validateAgentName("test_agent")).not.toBeNull();
+    expect(validateAgentName("test.agent")).not.toBeNull();
+    expect(validateAgentName("test agent")).not.toBeNull();
+  });
+
+  it("rejects names starting/ending with hyphens", () => {
+    expect(validateAgentName("-test")).not.toBeNull();
+    expect(validateAgentName("test-")).not.toBeNull();
+  });
+
+  it("rejects two-char names (not single char, not 3+)", () => {
+    expect(validateAgentName("ab")).not.toBeNull();
+  });
+});
+
+// ── serializeAgent ──────────────────────────────────────────────────────────
+
+describe("serializeAgent", () => {
+  it("produces valid YAML frontmatter", () => {
+    const agent = makeAgent();
+    const output = serializeAgent(agent);
+    expect(output).toMatch(/^---\n/);
+    expect(output).toContain("name: test-agent");
+    expect(output).toContain("description: A test agent");
+    expect(output).toContain("You are a helpful test agent.");
+  });
+
+  it("quotes values that need quoting", () => {
+    const agent = makeAgent({ description: "value with: colon" });
+    const output = serializeAgent(agent);
+    expect(output).toContain('description: "value with: colon"');
+  });
+
+  it("includes optional fields when present", () => {
+    const agent = makeAgent({
+      tools: ["read", "write"],
+      model: "gpt-4o",
+      thinking: "high",
+    });
+    const output = serializeAgent(agent);
+    expect(output).toContain("tools: read, write");
+    expect(output).toContain("model: gpt-4o");
+    expect(output).toContain("thinking: high");
+  });
+
+  it("omits optional fields when absent", () => {
+    const agent = makeAgent();
+    const output = serializeAgent(agent);
+    expect(output).not.toContain("tools:");
+    expect(output).not.toContain("model:");
+    expect(output).not.toContain("thinking:");
+  });
+
+  it("property: output starts with '---\\n' and contains closing '\\n---\\n' delimiter", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 50 }),
+        fc.string({ minLength: 1, maxLength: 100 }),
+        fc.string({ minLength: 1, maxLength: 200 }),
+        (name, desc, prompt) => {
+          const agent = makeAgent({ name, description: desc, systemPrompt: prompt });
+          const output = serializeAgent(agent);
+          if (!output.startsWith("---\n")) {
+            throw new Error(`Output does not start with '---\\n': ${JSON.stringify(output.slice(0, 20))}`);
+          }
+          if (!output.includes("\n---\n")) {
+            throw new Error(`Output does not contain closing '\\n---\\n' delimiter`);
+          }
+        },
+      ),
+      { verbose: false },
+    );
+  });
+});

--- a/packages/todo/src/state-manager.test.ts
+++ b/packages/todo/src/state-manager.test.ts
@@ -20,7 +20,7 @@ describe("TodoStateManager", () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   describe("read", () => {
@@ -48,7 +48,6 @@ describe("TodoStateManager", () => {
     });
 
     it("with all completed schedules auto-clear", () => {
-      let cleared = false;
       manager.write([makeTodo(1, "Done", "desc", "completed")]);
       expect(manager.read()).toHaveLength(1);
       vi.advanceTimersByTime(2000);

--- a/packages/todo/src/state-manager.test.ts
+++ b/packages/todo/src/state-manager.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fc from "fast-check";
+import { TodoStateManager } from "./state-manager.js";
+import type { TodoItem } from "./types.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTodo(id: number, title: string, description: string, status: TodoItem["status"]): TodoItem {
+  return { id, title, description, status };
+}
+
+// ── TodoStateManager ────────────────────────────────────────────────────────
+
+describe("TodoStateManager", () => {
+  let manager: TodoStateManager;
+
+  beforeEach(() => {
+    manager = new TodoStateManager();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("read", () => {
+    it("returns empty array initially", () => {
+      expect(manager.read()).toEqual([]);
+    });
+
+    it("returns copy (mutations don't affect internal state)", () => {
+      manager.write([makeTodo(1, "Test", "desc", "not-started")]);
+      const copy = manager.read();
+      copy.push(makeTodo(2, "Injected", "desc", "not-started"));
+      expect(manager.read()).toHaveLength(1);
+    });
+  });
+
+  describe("write", () => {
+    it("stores todos correctly", () => {
+      manager.write([
+        makeTodo(1, "Task 1", "desc 1", "not-started"),
+        makeTodo(2, "Task 2", "desc 2", "in-progress"),
+      ]);
+      expect(manager.read()).toHaveLength(2);
+      expect(manager.read()[0]?.title).toBe("Task 1");
+      expect(manager.read()[1]?.status).toBe("in-progress");
+    });
+
+    it("with all completed schedules auto-clear", () => {
+      let cleared = false;
+      manager.write([makeTodo(1, "Done", "desc", "completed")]);
+      expect(manager.read()).toHaveLength(1);
+      vi.advanceTimersByTime(2000);
+      expect(manager.read()).toHaveLength(0);
+    });
+
+    it("does not schedule auto-clear when not all completed", () => {
+      manager.write([
+        makeTodo(1, "Done", "desc", "completed"),
+        makeTodo(2, "Pending", "desc", "not-started"),
+      ]);
+      vi.advanceTimersByTime(2000);
+      expect(manager.read()).toHaveLength(2);
+    });
+  });
+
+  describe("clear", () => {
+    it("empties todos", () => {
+      manager.write([makeTodo(1, "Task", "desc", "not-started")]);
+      manager.clear();
+      expect(manager.read()).toEqual([]);
+    });
+  });
+
+  describe("getStats", () => {
+    it("computes correct counts", () => {
+      manager.write([
+        makeTodo(1, "A", "desc", "not-started"),
+        makeTodo(2, "B", "desc", "in-progress"),
+        makeTodo(3, "C", "desc", "completed"),
+        makeTodo(4, "D", "desc", "completed"),
+      ]);
+      expect(manager.getStats()).toEqual({
+        total: 4,
+        completed: 2,
+        inProgress: 1,
+        notStarted: 1,
+      });
+    });
+
+    it("returns zero stats for empty list", () => {
+      expect(manager.getStats()).toEqual({
+        total: 0,
+        completed: 0,
+        inProgress: 0,
+        notStarted: 0,
+      });
+    });
+  });
+
+  describe("validate", () => {
+    it("catches missing fields", () => {
+      const result = manager.validate([{ id: 1, title: "", description: "", status: "" } as any]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it("catches invalid status values", () => {
+      const result = manager.validate([{ id: 1, title: "Test", description: "desc", status: "invalid" } as any]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("status");
+    });
+
+    it("catches non-array input", () => {
+      const result = manager.validate("not an array" as any);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toBe("todoList must be an array");
+    });
+
+    it("accepts valid input", () => {
+      const result = manager.validate([
+        makeTodo(1, "Task", "desc", "not-started"),
+        makeTodo(2, "Task 2", "desc", "in-progress"),
+        makeTodo(3, "Task 3", "desc", "completed"),
+      ]);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("property: validate(write(x)).valid === true after write (round-trip)", () => {
+      fc.assert(
+        fc.property(
+          fc.array(
+            fc.record({
+              id: fc.nat({ max: 1000 }),
+              title: fc.string({ minLength: 1, maxLength: 50 }),
+              description: fc.string({ minLength: 1, maxLength: 100 }),
+              status: fc.oneof(fc.constant("not-started"), fc.constant("in-progress"), fc.constant("completed")),
+            }),
+          ),
+          (todos) => {
+            const mgr = new TodoStateManager();
+            mgr.write(todos as TodoItem[]);
+            const readTodos = mgr.read();
+            const result = mgr.validate(readTodos);
+            if (!result.valid) {
+              throw new Error(`Round-trip validation failed: ${JSON.stringify(result.errors)}`);
+            }
+          },
+        ),
+        { verbose: false },
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      fast-check:
+        specifier: ^4.0.0
+        version: 4.9.0
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^3.0.0
         version: 3.2.6(@types/node@22.19.19)(jiti@2.7.0)(yaml@2.9.0)
@@ -830,6 +836,126 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
@@ -978,6 +1104,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -1212,6 +1342,9 @@ packages:
     resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
     engines: {node: '>=12.0.0'}
 
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -1314,6 +1447,11 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@6.21.0:
@@ -2137,6 +2275,66 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@ungap/structured-clone@1.3.1': {}
 
   '@vitest/expect@3.2.6':
@@ -2289,6 +2487,10 @@ snapshots:
   expect-type@1.4.0: {}
 
   extend@3.0.2: {}
+
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -2550,6 +2752,8 @@ snapshots:
       '@types/node': 22.19.19
       long: 5.3.2
 
+  pure-rand@8.4.2: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -2661,6 +2865,29 @@ snapshots:
   typebox@1.1.38: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary
Add unit tests + property-based tests for 21 previously untested pure-logic files across 6 packages, growing from 223 to 572 tests (+349 new).

### Test files added (21 new `.test.ts` files)
- **core** (9): `transform.test.ts`, `unindent.test.ts`, `settings-io.test.ts`, `config.test.ts`, `sections.test.ts`, `logo.test.ts`, `version.test.ts`, `patch.test.ts`, `theme.test.ts`
- **diff** (4): `codes.test.ts`, `colors.test.ts`, `diff.test.ts`, `shiki.test.ts`
- **footer** (2): `stats.test.ts`, `git.test.ts`
- **subagent** (3): `cost.test.ts`, `compact.test.ts`, `frontmatter-io.test.ts`
- **ask** (2): `cursor.test.ts`, `wrap.test.ts`
- **todo** (1): `state-manager.test.ts`

### Property-based tests (fast-check)
~24 property tests covering: idempotence, reflexivity, antisymmetry, transitivity, bounds checking, structural invariants, truncation limits, CRLF normalization.

### Dependencies
- Added `fast-check@^4.0.0` (property-based testing)
- Added `typescript@^7.0.2` (needed for `tsc --noEmit` verification)

### Review notes
- All tests follow existing patterns (co-located `*.test.ts`, vitest imports, section dividers)
- Mock isolation via `vi.resetModules()` + dynamic imports for modules with global state
- `importOriginal()` used in partial mocks to prevent silent breakage on future imports
- Zero source code changes — pure test additions

## Test plan
- [ ] `pnpm test` — 572 tests pass across 36 test files
- [ ] `npx tsc --noEmit` — clean in all 6 affected packages
- [ ] Spot-check property tests exercise meaningful input space