### PR TITLE
feat(image-paste): make paste shortcuts configurable

### DIFF
--- a/docs/plans/2026-08-16-image-paste-shortcuts.md
+++ b/docs/plans/2026-08-16-image-paste-shortcuts.md
@@ -1,0 +1,34 @@
+# Configurable Image-Paste Shortcuts Plan
+
+**Goal:** Let users override or disable the keyboard shortcuts used to attach clipboard images.
+**Architecture:** Keep configuration and shortcut validation in a small, pure module within `packages/image-paste`; resolve shortcuts once while registering the extension.
+**Tech Stack:** TypeScript, Vitest, `@pi-archimedes/core/settings-io`, `@earendil-works/pi-tui`
+
+---
+
+## Implementation
+
+**Files:**
+- Create: `packages/image-paste/src/config.ts`
+- Create: `packages/image-paste/src/config.test.ts`
+- Modify: `packages/image-paste/src/index.ts`
+- Modify: `packages/image-paste/package.json`
+- Modify: `packages/image-paste/README.md`
+- Modify: `pnpm-lock.yaml`
+
+**Steps:**
+- [x] Add `archimedes.imagePaste` configuration loading through the core `settings-io` subpath export.
+- [x] Resolve configured shortcut IDs only when every entry is a supported Pi TUI `KeyId`.
+- [x] Preserve existing platform defaults when the setting is omitted or invalid.
+- [x] Treat an empty shortcut array as an explicit opt-out.
+- [x] Register resolved shortcuts in the existing image-paste extension flow.
+- [x] Declare the workspace core dependency and document the setting.
+- [x] Add focused tests for defaults, overrides, opt-out, invalid values, and namespace loading.
+- [x] Run `npx tsc --noEmit` in `packages/image-paste`.
+- [x] Run `npx --no-install vitest run packages/image-paste`.
+
+**Acceptance criteria:**
+- [x] Existing shortcuts remain the default on each platform.
+- [x] Users can provide a replacement shortcut list or an empty list.
+- [x] Invalid persisted values cannot register unsupported shortcut IDs.
+- [x] The package type-check and focused test suite pass.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,5 +1,10 @@
 # Plans
 
+## In Progress
+
+| # | Plan | Status | Created |
+| 24 | [Configurable image-paste shortcuts](2026-08-16-image-paste-shortcuts.md) | 🔄 IN PROGRESS (PR #30) | 2026-08-16 |
+
 ## Done
 
 | # | Plan | Status | Created |
@@ -33,6 +38,6 @@
 
 ## Quick Stats
 
-- Total Plans: 23
+- Total Plans: 24
 - Completed: 23
-- In Progress: 0
+- In Progress: 1

--- a/packages/image-paste/README.md
+++ b/packages/image-paste/README.md
@@ -37,7 +37,19 @@ A `[Image #N]` placeholder is inserted into your draft. When you submit, any ima
 
 ## Settings
 
-Uses Pi's core `terminal.showImages` setting to control inline previews. No package-specific settings.
+Uses Pi's core `terminal.showImages` setting to control inline previews.
+
+Image-paste shortcuts can be overridden in `~/.pi/agent/settings.json` under the existing Archimedes namespace. When omitted, the platform defaults above remain unchanged. An empty array disables image-paste shortcuts.
+
+```json
+{
+  "archimedes.imagePaste": {
+    "shortcuts": ["ctrl+shift+v", "ctrl+alt+v"]
+  }
+}
+```
+
+Invalid values fall back to the platform defaults.
 
 ## Troubleshooting
 

--- a/packages/image-paste/package.json
+++ b/packages/image-paste/package.json
@@ -10,6 +10,9 @@
     "src"
   ],
   "main": "./src/index.ts",
+  "dependencies": {
+    "@pi-archimedes/core": "workspace:*"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.1.0",
     "@earendil-works/pi-tui": ">=0.1.0"

--- a/packages/image-paste/src/config.test.ts
+++ b/packages/image-paste/src/config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@pi-archimedes/core/settings-io", () => ({
+  loadConfig: vi.fn(),
+}));
+
+const {
+  DEFAULT_IMAGE_PASTE_CONFIG,
+  loadImagePasteConfig,
+  resolveImagePasteShortcuts,
+} = await import("./config.js");
+const { loadConfig } = await import("@pi-archimedes/core/settings-io");
+
+describe("resolveImagePasteShortcuts", () => {
+  it("uses the established Linux defaults", () => {
+    expect(resolveImagePasteShortcuts("linux", undefined)).toEqual([
+      "ctrl+v",
+      "alt+v",
+      "ctrl+alt+v",
+    ]);
+  });
+
+  it("uses the established Windows defaults", () => {
+    expect(resolveImagePasteShortcuts("win32", undefined)).toEqual([
+      "alt+v",
+      "ctrl+alt+v",
+    ]);
+  });
+
+  it("uses configured shortcuts exactly", () => {
+    expect(resolveImagePasteShortcuts("linux", ["ctrl+shift+v", "ctrl+alt+v"])).toEqual([
+      "ctrl+shift+v",
+      "ctrl+alt+v",
+    ]);
+  });
+
+  it("allows an empty array to disable shortcuts", () => {
+    expect(resolveImagePasteShortcuts("linux", [])).toEqual([]);
+  });
+
+  it("falls back to platform defaults for invalid configuration", () => {
+    expect(resolveImagePasteShortcuts("linux", ["ctrl+shift+v", 42])).toEqual([
+      "ctrl+v",
+      "alt+v",
+      "ctrl+alt+v",
+    ]);
+  });
+});
+
+describe("loadImagePasteConfig", () => {
+  it("uses the established image-paste namespace", () => {
+    vi.mocked(loadConfig).mockReturnValue(DEFAULT_IMAGE_PASTE_CONFIG);
+
+    expect(loadImagePasteConfig()).toEqual(DEFAULT_IMAGE_PASTE_CONFIG);
+    expect(loadConfig).toHaveBeenCalledWith(
+      "archimedes.imagePaste",
+      DEFAULT_IMAGE_PASTE_CONFIG,
+    );
+  });
+});

--- a/packages/image-paste/src/config.test.ts
+++ b/packages/image-paste/src/config.test.ts
@@ -38,8 +38,24 @@ describe("resolveImagePasteShortcuts", () => {
     expect(resolveImagePasteShortcuts("linux", [])).toEqual([]);
   });
 
-  it("falls back to platform defaults for invalid configuration", () => {
+  it("falls back to platform defaults for non-string configuration entries", () => {
     expect(resolveImagePasteShortcuts("linux", ["ctrl+shift+v", 42])).toEqual([
+      "ctrl+v",
+      "alt+v",
+      "ctrl+alt+v",
+    ]);
+  });
+
+  it("falls back to platform defaults for unsupported shortcut identifiers", () => {
+    expect(resolveImagePasteShortcuts("linux", ["ctrl+zzz"])).toEqual([
+      "ctrl+v",
+      "alt+v",
+      "ctrl+alt+v",
+    ]);
+  });
+
+  it("falls back to platform defaults when valid and invalid shortcuts are mixed", () => {
+    expect(resolveImagePasteShortcuts("linux", ["ctrl+shift+v", "ctrl+zzz"])).toEqual([
       "ctrl+v",
       "alt+v",
       "ctrl+alt+v",

--- a/packages/image-paste/src/config.ts
+++ b/packages/image-paste/src/config.ts
@@ -1,4 +1,4 @@
-import type { KeyId } from "@earendil-works/pi-tui";
+import { Key, type KeyId } from "@earendil-works/pi-tui";
 import { loadConfig } from "@pi-archimedes/core/settings-io";
 
 export interface ImagePasteConfig {
@@ -8,6 +8,32 @@ export interface ImagePasteConfig {
 export const DEFAULT_IMAGE_PASTE_CONFIG: ImagePasteConfig = {};
 
 const NAMESPACE = "archimedes.imagePaste";
+const MODIFIERS = ["ctrl", "shift", "alt", "super"] as const;
+
+const VALID_KEY_IDS = new Set<KeyId>();
+const namedBaseKeys = Object.values(Key).filter(
+  (key): key is Extract<typeof key, string> => typeof key === "string",
+);
+const baseKeys: string[] = [..."abcdefghijklmnopqrstuvwxyz0123456789", ...namedBaseKeys];
+
+function addKeyIds(baseKey: string, modifiers: string[] = [], remaining: readonly string[] = MODIFIERS): void {
+  VALID_KEY_IDS.add(`${modifiers.join("+")}${modifiers.length ? "+" : ""}${baseKey}` as KeyId);
+
+  for (let index = 0; index < remaining.length; index++) {
+    const modifier = remaining[index];
+    if (modifier) {
+      addKeyIds(baseKey, [...modifiers, modifier], remaining.filter((_, i) => i !== index));
+    }
+  }
+}
+
+for (const baseKey of baseKeys) {
+  addKeyIds(baseKey);
+}
+
+function isKeyId(shortcut: unknown): shortcut is KeyId {
+  return typeof shortcut === "string" && VALID_KEY_IDS.has(shortcut as KeyId);
+}
 
 export function loadImagePasteConfig(): ImagePasteConfig {
   return loadConfig(NAMESPACE, DEFAULT_IMAGE_PASTE_CONFIG);
@@ -15,10 +41,10 @@ export function loadImagePasteConfig(): ImagePasteConfig {
 
 function getDefaultShortcuts(platform: string): KeyId[] {
   if (platform === "win32") {
-    return ["alt+v", "ctrl+alt+v"] as KeyId[];
+    return ["alt+v", "ctrl+alt+v"];
   }
 
-  return ["ctrl+v", "alt+v", "ctrl+alt+v"] as KeyId[];
+  return ["ctrl+v", "alt+v", "ctrl+alt+v"];
 }
 
 /**
@@ -29,9 +55,9 @@ function getDefaultShortcuts(platform: string): KeyId[] {
 export function resolveImagePasteShortcuts(platform: string, configured: unknown): KeyId[] {
   if (
     Array.isArray(configured) &&
-    configured.every((shortcut) => typeof shortcut === "string" && shortcut.trim().length > 0)
+    configured.every(isKeyId)
   ) {
-    return configured as KeyId[];
+    return configured;
   }
 
   return getDefaultShortcuts(platform);

--- a/packages/image-paste/src/config.ts
+++ b/packages/image-paste/src/config.ts
@@ -1,0 +1,38 @@
+import type { KeyId } from "@earendil-works/pi-tui";
+import { loadConfig } from "@pi-archimedes/core/settings-io";
+
+export interface ImagePasteConfig {
+  shortcuts?: KeyId[];
+}
+
+export const DEFAULT_IMAGE_PASTE_CONFIG: ImagePasteConfig = {};
+
+const NAMESPACE = "archimedes.imagePaste";
+
+export function loadImagePasteConfig(): ImagePasteConfig {
+  return loadConfig(NAMESPACE, DEFAULT_IMAGE_PASTE_CONFIG);
+}
+
+function getDefaultShortcuts(platform: string): KeyId[] {
+  if (platform === "win32") {
+    return ["alt+v", "ctrl+alt+v"] as KeyId[];
+  }
+
+  return ["ctrl+v", "alt+v", "ctrl+alt+v"] as KeyId[];
+}
+
+/**
+ * Resolve configured shortcuts, falling back to the established platform defaults
+ * when the persisted value is absent or malformed. An empty array intentionally
+ * disables image-paste shortcuts.
+ */
+export function resolveImagePasteShortcuts(platform: string, configured: unknown): KeyId[] {
+  if (
+    Array.isArray(configured) &&
+    configured.every((shortcut) => typeof shortcut === "string" && shortcut.trim().length > 0)
+  ) {
+    return configured as KeyId[];
+  }
+
+  return getDefaultShortcuts(platform);
+}

--- a/packages/image-paste/src/index.ts
+++ b/packages/image-paste/src/index.ts
@@ -2,8 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-import type { KeyId } from "@earendil-works/pi-tui";
-
+import { loadImagePasteConfig, resolveImagePasteShortcuts } from "./config.js";
 import { readClipboardImage } from "./clipboard.js";
 import { registerImagePreview, sendPreviewMessage } from "./preview.js";
 import type { ClipboardImage, PendingImage, ImageMarker } from "./types.js";
@@ -58,11 +57,11 @@ function queueImage(
 
 // ── Registration ────────────────────────────────────────────────
 
-function getImagePasteShortcuts(): KeyId[] {
-  if (process.platform === "win32") {
-    return ["alt+v", "ctrl+alt+v"] as KeyId[];
-  }
-  return ["ctrl+v", "alt+v", "ctrl+alt+v"] as KeyId[];
+function getImagePasteShortcuts() {
+  return resolveImagePasteShortcuts(
+    process.platform,
+    loadImagePasteConfig().shortcuts,
+  );
 }
 
 // Module-level state — registered once, queue reset per session

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: '>=0.1.0'
         version: 0.78.0
+      '@pi-archimedes/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       typescript:
         specifier: ^6.0.0


### PR DESCRIPTION
Adds configurable keyboard shortcuts for `@pi-archimedes/image-paste`.

This introduces `archimedes.imagePaste.shortcuts` in Pi settings while keeping the existing platform defaults unchanged when no override is configured. An empty array disables image-paste shortcuts, and malformed values fall back to the defaults.

The change includes:
- config loading via the existing Archimedes settings mechanism
- shortcut resolution for default/custom/disabled cases
- focused tests
- README documentation

My use case is avoiding a terminal-level `Ctrl+V` conflict by using `Ctrl+Shift+V` / `Ctrl+Alt+V` for image paste instead.

The implementation may be a little more structured than necessary for such a small setting, so I’m happy to simplify it if there’s a preferred lighter-weight pattern in the project.