### PR TITLE
fix(image-paste): bind theme.fg to prevent uncaught crash on image fallback render

### DIFF
--- a/packages/image-paste/src/preview.ts
+++ b/packages/image-paste/src/preview.ts
@@ -13,7 +13,7 @@ export function registerImagePreview(pi: ExtensionAPI): void {
   pi.registerMessageRenderer<PreviewDetails>(CUSTOM_TYPE, (message, _options, theme) => {
     try {
       // Theme.fg is runtime-available but not exposed in the Theme type definition
-      const fg = (theme as any).fg as ((color: string, text: string) => string) | undefined;
+      const fg = (theme as any).fg?.bind(theme) as ((color: string, text: string) => string) | undefined;
       if (!fg) return undefined;
 
       // Extract image data from content array


### PR DESCRIPTION
## Bug trigger
Pi exits with an uncaught `TypeError: Cannot read properties of undefined (reading 'fgColors')` when a pasted image cannot be rendered inline and the `Image` component falls back to colored text.

It triggered on my setup (WezTerm + tmux) because `pi-tui`'s `detectCapabilities()` forces `images: null` whenever `$TMUX` is set (image escape sequences are unreliable through tmux).

## Repro
1. Paste a clipboard image so `image-paste` sends a `hephaestus-image-preview` message.
2. Run pi in a terminal without inline image support (or any session where `getCapabilities().images` is falsy / `renderImage` returns null).
3. On the next render tick, `Image.render` calls `this.theme.fallbackColor(fallback)`, invoking the closure `(text) => fg("toolOutput", text)`.

```
TypeError: Cannot read properties of undefined (reading 'fgColors')
    at fg (.../theme.js:273:27)                  // const ansi = this.fgColors.get(color)
    at Object.fallbackColor (.../image-paste/src/preview.ts:31)
    at Image.render (.../pi-tui/dist/components/image.js:83)
    at Container.render / Timeout._onTimeout (.../tui.js:547)
```

## Root cause
`preview.ts` extracts `Theme.fg` as an unbound reference:

```ts
const fg = (theme as any).fg as ((color: string, text: string) => string) | undefined;
```

The closure stores `fg` and later calls it as a free function `fg("toolOutput", text)` from inside `Image.render`, which runs asynchronously on a `Timeout` — outside the renderer's own `try/catch`. A free call to an unbound method sets `this = undefined` (strict mode), so `this.fgColors` throws; running outside any try/catch, it kills the process.

The renderer's wrapping `try { ... } catch { return undefined; }` cannot catch this: registration succeeds and returns the container; the throw happens later in the TUI render loop.

## Fix
Bind the extracted method to the theme so `this` is preserved when `Image.render` invokes the stored `fallbackColor`:

```ts
const fg = (theme as any).fg?.bind(theme) as ((color: string, text: string) => string) | undefined;
```

Optional chaining keeps the existing `if (!fg) return undefined;` guard working when `theme.fg` is absent. One-line change; `tsc --noEmit` passes and the full vitest suite (615 tests) is green.
