### PR TITLE
Todo schema alignment + subagent-visibility fix (plan 029)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Rules for AI agents working on this monorepo.
 - `packages/footer` — status bar (depends on core)
 - `packages/diff` — Shiki-powered diff rendering (standalone)
 - `packages/image-paste` — clipboard image paste (standalone)
-- `packages/subagent` — subagent dispatch with live TUI streaming and cost tracking (depends on core)
+- `packages/subagent` — subagent dispatch with live TUI streaming and cost tracking (depends on core, todo)
 - `packages/todo` — todo list tool with auto-clear and subagent visibility (depends on core)
 - `packages/notify` — delayed desktop notifications with circuit breaker (depends on core)
 - `packages/session-name` — auto session naming (depends on core)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ When a new package is added under `packages/<name>/`, update **all** of these or
 - Always commit per logical unit — don't batch unrelated changes
 
 ### Plans
-- Plans live in `docs/plans/YYYY-MM-DD-<feature>.md`
+- Plans live in `docs/plans/plan-NNN-<feature>.md` (sequential number, e.g. `plan-029-todo-schema-alignment.md`)
 - Use the `create-plan` skill to generate plans, then dispatch the `reviewer` subagent to review them
 - **Always commit the plan file to git** — it is an untracked file by default and will be lost if not added
 - Update `docs/plans/README.md` to track plan status (IN PROGRESS → COMPLETED)

--- a/docs/adr/0009-todo-schema-cc-alignment.md
+++ b/docs/adr/0009-todo-schema-cc-alignment.md
@@ -1,0 +1,12 @@
+# Todo schema follows the Claude Code training prior
+
+The `manage_todo_list` tool used a strict 4-field item shape (`id: number`, `title`, `description`, `status: not-started|in-progress|completed`). Frozen open-weight models (Qwen3.x, trained on Claude-Code-style agentic environments) consistently fight this shape: they omit or null the invented `id`, use `content`/`step` instead of `title`, and emit `pending`/`in_progress`. Research of mainstream harnesses (2026-08): Claude Code `TodoWrite` = `{content, status, activeForm?}`, Codex `update_plan` = `{step, status}`, Gemini CLI `write_todos` = `{description, status}` — none ask the model to generate an id.
+
+We decided to align the item shape exactly with the Claude Code prior: `{content, status: pending|in_progress|completed, description?}`, no `id`, index-based display numbering. `description` stays (optional, for subagent-dispatch planning); `activeForm` is not adopted (no spinner integration). The `prepare-args` repair layer is demoted from primary surface to a backstop (it still absorbs Codex `step`, bare strings, stringified arrays, legacy field names, and status aliases). Legacy persisted state (`title`, `not-started`) is normalized in `loadFromSession`.
+
+Considered and rejected:
+
+- **Robustness only (strict schema stays)** — would not fix main-agent hard failures on keys the model defaults to.
+- **Keep our shape, relax constraints (id/description optional)** — permanently depends on the repair layer for the model's primary text field, and keeps the invented-`id` field in the schema, which no model's training data includes.
+
+Consequences: models that already conformed (Anthropic) see a smaller, different schema and re-adapt in-session; anything pre-migration becomes unreadable-without-normalization by design, so `loadFromSession` must keep the legacy alias map alive as long as old session files exist.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -30,7 +30,7 @@
 | 26 | [MCP OAuth (port phase 2)](done/plan-026-mcp-oauth.md) | ✅ COMPLETED (squash `2861660`) | 2026-08-18 |
 | 27 | [MCP commands + panels (port phase 3)](done/plan-027-mcp-commands-panels.md) | ✅ COMPLETED (squash `09dd105`) | 2026-08-17 |
 | 28 | [Codebase improvement — dead API, DRY, config patterns, file splits](plan-028-codebase-improvement.md) | ✅ COMPLETED (PR #35) | 2026-08-25 |
-| 29 | [Todo schema alignment + subagent-visibility fix](plan-029-todo-schema-alignment.md) | ✅ COMPLETED | 2026-08-27 |
+| 29 | [Todo schema alignment + subagent-visibility fix](plan-029-todo-schema-alignment.md) | ✅ COMPLETED (PR #37) | 2026-08-27 |
 
 > **Notes:****
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -40,13 +40,13 @@
 
 | # | Plan | Status | Created |
 |---|------|--------|---------|
-| — | _none — backlog is empty_ | | |
+| 29 | [Todo schema alignment + subagent-visibility fix](plan-029-todo-schema-alignment.md) | 🔧 IN PROGRESS | 2026-08-27 | |
 
 ## Quick Stats
 
-- Total Plans: 28
+- Total Plans: 29
 - Completed: 28
-- In Progress: 0
-- Backlog: 0
+- In Progress: 1
+- Backlog: 1
 
 > **MCP port (plans 025–027):** A three-phase port of `pi-mcp-adapter` into `@pi-archimedes/mcp`. Phase 1 = core reliability (cache, lifecycle, connection hardening); Phase 2 = OAuth (`/mcp-auth`, keyring, callback server); Phase 3 = `/mcp` command + panels. Design decisions in ADRs 0001–0003. Execute in order (026 needs 025; 027 needs both).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -30,6 +30,7 @@
 | 26 | [MCP OAuth (port phase 2)](done/plan-026-mcp-oauth.md) | ✅ COMPLETED (squash `2861660`) | 2026-08-18 |
 | 27 | [MCP commands + panels (port phase 3)](done/plan-027-mcp-commands-panels.md) | ✅ COMPLETED (squash `09dd105`) | 2026-08-17 |
 | 28 | [Codebase improvement — dead API, DRY, config patterns, file splits](plan-028-codebase-improvement.md) | ✅ COMPLETED (PR #35) | 2026-08-25 |
+| 29 | [Todo schema alignment + subagent-visibility fix](plan-029-todo-schema-alignment.md) | ✅ COMPLETED | 2026-08-27 |
 
 > **Notes:****
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.
@@ -40,13 +41,12 @@
 
 | # | Plan | Status | Created |
 |---|------|--------|---------|
-| 29 | [Todo schema alignment + subagent-visibility fix](plan-029-todo-schema-alignment.md) | 🔧 IN PROGRESS | 2026-08-27 | |
 
 ## Quick Stats
 
 - Total Plans: 29
-- Completed: 28
-- In Progress: 1
-- Backlog: 1
+- Completed: 29
+- In Progress: 0
+- Backlog: 0
 
 > **MCP port (plans 025–027):** A three-phase port of `pi-mcp-adapter` into `@pi-archimedes/mcp`. Phase 1 = core reliability (cache, lifecycle, connection hardening); Phase 2 = OAuth (`/mcp-auth`, keyring, callback server); Phase 3 = `/mcp` command + panels. Design decisions in ADRs 0001–0003. Execute in order (026 needs 025; 027 needs both).

--- a/docs/plans/plan-029-todo-schema-alignment.md
+++ b/docs/plans/plan-029-todo-schema-alignment.md
@@ -1,0 +1,431 @@
+# Todo schema alignment + subagent-visibility fix Plan
+
+**Goal:** Make the `manage_todo_list` item shape match what agentic models were actually trained to emit (Claude Code prior: `{content, status: pending|in_progress|completed, description?}`, no `id`), and make the parent todo widget mirror only *accepted* subagent todo state (fixing the `undefined`-title column and phantom lists).
+
+**Architecture:** The repair layer in `packages/todo/src/prepare-args.ts` (wired via the tool's `prepareArguments`) becomes the single authority for normalizing whatever shape a model emits — canonical form is Claude Code's. The subagent package (`packages/subagent/src/stream.ts`) stops mirroring raw `tool_execution_start` args (which pi emits *before* repair/validation) and instead mirrors the child's accepted state from `tool_execution_end` (`result.details.todos`, `isError`-checked). The todo package's bus consumer additionally normalizes all incoming `TODOS_UPDATE` payloads. Rendering is index-based (no model-invented ids) with `?? ""` guards.
+
+**Tech Stack:** TypeScript, pi extension API (`TypeBox` via `@earendil-works/pi-ai`, `ExtensionAPI`), pi pub/sub bus (`@pi-archimedes/core/bus`), vitest, pnpm workspace. No new runtime deps; one new workspace dep edge (`subagent → todo`).
+
+**Decisions on record:** `docs/adr/0009-todo-schema-cc-alignment.md` (schema choice + why). Out of scope (explicit): parent-enforced todo validation with an ask-style socket error relay; renaming the tool or `operation`; adopting `activeForm` into the schema; `cancelled`/`blocked` statuses.
+
+**Verification commands (used throughout):**
+- `npx tsc --noEmit` in the package directory (AGENTS.md: run independently, wait for each)
+- `npx vitest run` in `packages/todo` and `packages/subagent` (both have `vitest.config.ts`)
+
+---
+
+### Task 1: New item schema — types, repair layer, state, tool, widget (todo + core)
+
+**Context:**
+Frozen open-weight models (Qwen3.x — RL-trained on Claude-Code-style agentic environments) systematically deviate from our old strict 4-field schema `{id: number, title, description, status: not-started|in-progress|completed}`: they omit/null the invented `id`, put text under `content`/`step` instead of `title`, and emit `pending`/`in_progress` statuses. Research (2026-08, on file in ADR 0009) shows every mainstream harness avoids asking the model for an id (Claude Code `TodoWrite` = `{content, status, activeForm?}`; Codex `update_plan` = `{step, status}`; Gemini CLI `write_todos` = `{description, status}`). This task rewrites the todo package's core layer to the new canonical shape `{content: string, status: "pending"|"in_progress"|"completed", description?: string}` in ONE commit so `tsc --noEmit` stays green across `packages/todo` and `packages/core`. The repair module (`prepare-args.ts`) stays, but `content` becomes canonical and it gains a `normalizeTodoItems()` export used by Tasks 2 and 3.
+
+**Files:**
+- Modify: `packages/todo/src/types.ts`
+- Modify: `packages/todo/src/prepare-args.ts`
+- Modify: `packages/todo/src/state-manager.ts`
+- Modify: `packages/todo/src/tool.ts`
+- Modify: `packages/todo/src/ui/todo-widget.ts`
+- Modify: `packages/core/src/bus.ts`
+- Test: `packages/todo/src/prepare-args.test.ts` (rewrite cases)
+- Test: `packages/todo/src/state-manager.test.ts` (rewrite cases)
+- Test: `packages/todo/src/tool.test.ts` (update existing cases to new shape; read it first)
+
+**What to implement:**
+
+`packages/todo/src/types.ts` — replace with:
+```ts
+/** Status of a single todo item (Claude Code aligned). */
+export type TodoStatus = "pending" | "in_progress" | "completed";
+
+/** A single todo item. No `id` — display numbering is array position. */
+export interface TodoItem {
+  /** Short imperative label of the task (3-10 words). Displayed in UI. */
+  content: string;
+  /** Optional detailed context: file paths, methods, acceptance criteria. */
+  description?: string;
+  /** Current status. */
+  status: TodoStatus;
+}
+
+/** Stored in tool result details for session persistence. */
+export interface TodoDetails {
+  operation: "read" | "write";
+  todos: TodoItem[];
+  error?: string;
+}
+
+/** Stats about the current todo list. */
+export interface TodoStats {
+  total: number;
+  completed: number;
+  inProgress: number;
+  pending: number;
+}
+
+/** Validation result. */
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/** Status icons for each todo state. */
+export const STATUS_ICONS: Record<TodoStatus, string> = {
+  completed: "✓",
+  in_progress: "◉ ",
+  pending: "○",
+};
+```
+
+`packages/todo/src/prepare-args.ts` — rewrite the module (keep its exports `prepareTodoArguments`, `deriveTitleFromDescription`, `normalizeTodoItem`; ADD export `normalizeTodoItems`). Keep the file's purpose comment but update the scenario list (canonical is now `content`; `id` is stripped, not repaired). Concretely:
+
+- `VALID_STATUSES: ReadonlySet<string> = new Set(["pending", "in_progress", "completed"])`.
+- `STATUS_ALIASES: ReadonlyMap<string, TodoStatus>` keyed by the *collapsed* form (lowercase, all `[\s_-]+` separators removed), mapping:
+  - → `"completed"`: `done`, `complete`, `finished`, `closed`, `success`, `passed`
+  - → `"in_progress"`: `doing`, `started`, `working`, `active`, `wip`, `ongoing`, `inprogress`
+  - → `"pending"`: `pending`, `todo`, `planned`, `untouched`, `notstarted`, `unstarted`, `open`
+  (The canonical values themselves match `VALID_STATUSES` directly before alias lookup.)
+- `normalizeStatus(raw: unknown): TodoStatus` (export it so future bus consumers can reuse it — but do NOT import it in `state-manager.ts`; `validate()` uses a local `validStatuses` set and `loadFromSession` only needs `normalizeTodoItems`): non-string → `"pending"`; else `s = raw.trim().toLowerCase()`; if `VALID_STATUSES.has(s)` return `s as TodoStatus`; else `collapsed = s.replace(/[\s_-]+/g, "")`; return `STATUS_ALIASES.get(collapsed) ?? "pending"`. Note: `validate()` in `state-manager.ts` must stay canonical-strict — it rejects `"in-progress"` (dashed); only `normalizeStatus` accepts dashed/aliased forms. Test 1.2 in `state-manager.test.ts` depends on exactly that split.
+- `CONTENT_FALLBACK_KEYS = ["title", "step", "task", "text", "name", "label", "activeForm"] as const` (checked only when `content` itself is missing/empty).
+- `DESCRIPTION_FALLBACK_KEYS = ["details", "notes", "summary", "context"] as const` (unchanged).
+- `deriveTitleFromDescription(text: string): string` — unchanged (60-char word-boundary cut with trailing `…`); still used to derive a short `content` from long source text.
+- `normalizeTodoItem(raw: unknown, index: number): unknown` — returns a FRESH object with only canonical keys `{content, description?, status}`:
+  - `typeof raw === "string"`: trim; empty → return `raw` (schema error stands); else return `{ content: deriveTitleFromDescription(text), status: "pending" }`.
+  - `!isRecord(raw)` (null/number/nested array) → return `raw` (schema error stands).
+  - `description = (typeof raw.description === "string" ? raw.description.trim() : "") || firstStringOf(raw, DESCRIPTION_FALLBACK_KEYS)`.
+  - `content = (typeof raw.content === "string" ? raw.content.trim() : "") || firstStringOf(raw, CONTENT_FALLBACK_KEYS)`.
+  - if `content === "" && description !== ""` → `content = deriveTitleFromDescription(description)`.
+  - if still `content === ""` → last-resort scan: first entry of `Object.entries(raw)` where the key is NOT in `["content", ...CONTENT_FALLBACK_KEYS, "description", ...DESCRIPTION_FALLBACK_KEYS, "status", "id"]` AND the value is a non-empty string → use the full value (untrimmed-of-length, as-is). This is the only catch-all; it must NOT match `status`/`id` values.
+  - Return `{ content, ...(description !== "" ? { description } : {}), status: normalizeStatus(raw.status) }`. When both are empty this is `{ content: "", status: <normalized> }` — deliberately keeps an empty (valid-string) field so `state-manager.validate()` reports the missing `content` rather than the schema masking it.
+  - `id` is ALWAYS dropped from the output (input key simply never read for output).
+- `looksLikeTodoItem(value)` — a record containing any of `"content" | "title" | "step" | "description" | "status"`.
+- `parseStringifiedList` / `ID_QUOTE_FIX` (`"id": 1"` mangled-quote repair) — keep unchanged.
+- `normalizeTodoList(raw: unknown): { value: unknown; kept: boolean }` — same control flow as today: string → `parseStringifiedList`; `null` → `{value: undefined, kept: true}`; `undefined` → `{value: undefined, kept: false}`; array → map `normalizeTodoItem`; single `looksLikeTodoItem` object → wrap `[normalizeTodoItem(value, 0)]`; else pass through.
+- `normalizeOperation(raw, listPresent)` — unchanged.
+- `prepareTodoArguments(args: unknown): ManageTodoListInput` — unchanged structure/semantics (returns `args` as-is when not a record; always emits `operation`; emits `todoList` only when present), delegating to the updated normalizers.
+- NEW export:
+```ts
+/**
+ * Normalize a raw todo list (e.g. from bus payloads) into canonical TodoItems.
+ * Returns [] for an empty input array, undefined for anything unrecoverable.
+ * Used by the bus consumer (index.ts) and the subagent stream — where
+ * prepareArguments is NOT in the call path.
+ */
+export function normalizeTodoItems(raw: unknown): TodoItem[] | undefined
+```
+  Behavior: `raw == null` → `undefined`. Input array → map `normalizeTodoItem` then keep only canonical items (`isRecord(item) && typeof item.content === "string" && item.content.trim() !== "" && typeof item.status === "string" && VALID_STATUSES.has(item.status)`); return the surviving list when non-empty, `[]` when the input array was empty, `undefined` when the input had items but none survived. Single `looksLikeTodoItem` object → same logic over `[raw]`. Anything else → `undefined`.
+
+`packages/todo/src/state-manager.ts`:
+- Import `{ normalizeTodoItems }` from `./prepare-args.js` (runtime-safe: `prepare-args.ts` has no runtime imports, no cycle; do NOT import `normalizeStatus` — `validate()` uses a local `validStatuses` set and `loadFromSession` only needs `normalizeTodoItems`).
+- `validate(todos)`: per item — `!item` → `"Item N: undefined item"`; `(typeof item.content !== "string" || item.content.trim() === "")` → `"Item N: missing or invalid 'content'"`; `typeof item.status !== "string" || !validStatuses.has(...)` → `"Item N: 'status' must be one of: pending, in_progress, completed"` (with `validStatuses = new Set(["pending","in_progress","completed"])`); `item.description !== undefined && typeof item.description !== "string"` → `"Item N: 'description' must be a string"`. No `id`/`title` checks.
+- `getStats()`: `pending` replaces `notStarted`.
+- `loadFromSession(ctx)`: per `toolResult` entry for `manage_todo_list`, `const items = normalizeTodoItems(details?.todos); if (items) this.todos = items.map(t => ({ ...t }));` — this IS the legacy-pass: old persisted items (`title`, `not-started`, `id`) are normalized by the same normalizer; unrecoverable entries are dropped; `normalizeTodoItems` returning `undefined` (e.g. old entry was a string) leaves state untouched for that entry.
+- `write()`/`clear()`/auto-clear — unchanged.
+
+`packages/todo/src/tool.ts`:
+- `TodoItemSchema`:
+```ts
+const TodoItemSchema = Type.Object({
+  content: Type.String({
+    description: "Short imperative label for the task (3-10 words). Displayed in UI. Example: \"Fix the auth middleware\".",
+  }),
+  status: StringEnum(["pending", "in_progress", "completed"] as const, {
+    description: "pending: Not begun | in_progress: Currently working (multiple allowed for parallel work/subagents) | completed: Fully finished with no blockers",
+  }),
+  description: Type.Optional(Type.String({
+    description: "Optional detailed context: file paths, specific methods, or acceptance criteria.",
+  })),
+});
+```
+  No `id` field. `ManageTodoListParams` otherwise unchanged (keep its `todoList` description wording).
+- `TOOL_DESCRIPTION`: REWRITE the model-facing status vocabulary to the canonical tokens — find every dashed form in the current text (the `Todo states:` list: `not-started`/`in-progress`, and the prose lines `mark todo(s) as in-progress` / `mark as in-progress` / `mark todo IN PROGRESS` if present) and replace with `pending`/`in_progress`/`completed` (e.g. `in_progress: Currently working (multiple allowed for parallel work/subagents)`, `Mark todo(s) as in_progress before starting work`). After this task, `packages/todo/src/tool.ts` must contain ZERO occurrences of the dashed strings `not-started` or `in-progress` (Task 4 greps for this). In addition: add a short "Todo item shape" section after the CRITICAL workflow section showing the exact expected JSON item (`{"content": "Fix the auth middleware", "status": "pending", "description": "optional: file paths, acceptance criteria"}`). Keep all other bullets and the "mark IMMEDIATELY / don't batch" wording.
+- `execute()`: logic unchanged (`state.validate` → `state.write` → bus emit with `source: "main"`). No status-string literals change.
+- `renderResult` expanded loop: iterate with index (`for (let i = 0; i < todos.length; i++)`); number = `i + 1` (replaces `todo.id`); text = `todo.content ?? ""` (completed → `theme.fg("dim", theme.strikethrough(...))`; in_progress → `theme.fg("warning", ...)`; else → `theme.fg("muted", ...)`); icon still from `STATUS_ICONS[todo.status] ?? "?"` with the existing per-status colors. Keep everything else (header label logic, error/empty branches).
+- `renderCall` — unchanged.
+
+`packages/todo/src/ui/todo-widget.ts`:
+- `getStatusIcon` / `formatTodoTitle`: switch on new statuses — `completed`/`in_progress`/`pending` (same glyphs/colors as today: success dim-strikethrough for completed, warning for in_progress, muted for pending).
+- Row rendering in `render(width)`: replace `${todo.id}.` with `${todoIndex + 1}.` (`todoIndex = row - headerRows` is already computed); title rendered via `formatTodoTitle` reading `todo.content ?? ""`.
+- Everything else (column layout, headers, truncation) unchanged.
+
+`packages/core/src/bus.ts`:
+- `TodoUpdatePayload.todos` type → `Array<{ content: string; description?: string; status: "pending" | "in_progress" | "completed" }>`. Nothing else in `bus.ts` changes (the bus `emit`/`on` signatures are untyped payloads).
+
+**Tests (write failing tests FIRST):**
+- `packages/todo/src/prepare-args.test.ts` — rewrite/move to cover at least:
+  1. canonical `{content:"Fix auth", status:"pending"}` → unchanged `{content:"Fix auth", status:"pending"}` (output has NO `id`, NO `title`, NO `description` keys).
+  2. legacy `{id:1, title:"X", description:"Y", status:"not-started"}` → `{content:"X", description:"Y", status:"pending"}`.
+  3. Codex `{step:"X", status:"in_progress"}` → `{content:"X", status:"in_progress"}`.
+  4. `{id:null, content:"X", status:"in progress"}` → `{content:"X", status:"in_progress"}` (id stripped, space folded).
+  5. `{activeForm:"Adding tests"}` alone → `{content:"Adding tests", status:"pending"}`.
+  6. bare string `"write tests"` item → `{content:"write tests", status:"pending"}`.
+  7. stringified list `"[{\"id\": 1\\\", \"title\": \"X\", \"status\": \"pending\"}]"` (the `"id": 1"` mangled-quote shape) → parses and normalizes.
+  8. last-resort scan: `{instruction:"do X", status:"pending"}` → `{content:"do X", status:"pending"}`; but `{id: 42, status:"bad"} ` does NOT pick up the number 42.
+  9. `description` fallback: `{title:"X", notes:"n"}` → `{content:"X", description:"n"}`.
+  10. `prepareTodoArguments({operation:"write", todoList:[...]})` end-to-end; missing `operation` with a list present → `"write"`; missing `operation` without a list → `"read"`.
+  11. `normalizeTodoItems`: canonical array → as-is (`{content,status}`); legacy array → normalized; `[]` → `[]`; `null` → `undefined`; `[{content:"", status:"pending"}]` → `undefined` (no surviving items).
+- `packages/todo/src/state-manager.test.ts`:
+  1. `validate` accepts `{content, status}` (description optional); rejects empty `content`; rejects `"in-progress"` (hyphen) as status; rejects non-string `description`.
+  2. `loadFromSession` with fake `ctx = { sessionManager: { getBranch: () => [{ type: "message", message: { role: "toolResult", toolName: "manage_todo_list", details: { todos: [{ id: 1, title: "Old", status: "not-started" }] } } }] } }` → `read()` = `[{ content: "Old", status: "pending" }]` (no `id`).
+  3. `getStats()` counts `pending`.
+- `packages/todo/src/tool.test.ts` — read the existing file first; update fixtures to the new shape; assert `parameters` no longer declares `id`, declares `content` + required `status` with the new enum, and `description` optional; update any `execute()` fixture lists.
+
+**Steps:**
+- [ ] Verify plan provenance is recorded (done in the spec session — commit `docs(plans): track plan-029 (todo schema alignment) + record ADR 0009`): `git log --oneline --diff-filter=A -- docs/plans/plan-029-todo-schema-alignment.md` should show that commit, and `docs/plans/README.md` should already contain the plan-029 row (IN PROGRESS) with Quick Stats Total 29 / In Progress 1. If ANY of that is missing (file untracked, row absent, stale stats), fix it now and commit `docs(plans): track plan-029 (todo schema alignment) + record ADR 0009` (per repo precedent plan/ADR tracking commits use the `docs:` prefix) before proceeding.
+- [ ] Read `packages/todo/src/prepare-args.test.ts`, `state-manager.test.ts`, `tool.test.ts` to learn existing test style/helpers before rewriting.
+- [ ] Write the new/updated failing tests listed above.
+- [ ] Run `cd packages/todo && npx vitest run`
+  - Did it FAIL (old behavior, e.g. `id` present / `title` keys / old statuses)? If anything passed unexpectedly, investigate before continuing.
+- [ ] Implement `types.ts`, `prepare-args.ts`, `state-manager.ts`, `tool.ts`, `ui/todo-widget.ts`, and the `packages/core/src/bus.ts` payload type.
+- [ ] Run `cd packages/todo && npx vitest run`
+  - Did all tests pass? If not, fix and re-run before continuing.
+- [ ] Run `cd packages/todo && npx tsc --noEmit`
+  - Did it succeed? If not, read the error, fix, re-run.
+- [ ] Run `cd packages/core && npx tsc --noEmit`
+  - Did it succeed? If not, fix and re-run.
+- [ ] Commit with message: `feat(todo): align item schema to Claude Code prior — content/status, drop id (ADR 0009)`
+
+**Acceptance criteria:**
+- [ ] `npx vitest run` in `packages/todo` green, including the new canonical/legacy/Codex/last-resort/mangled-JSON cases.
+- [ ] `npx tsc --noEmit` green in `packages/todo` AND `packages/core`.
+- [ ] No `id` or `title` field exists in `TodoItem`, the tool schema, or the bus payload type.
+- [ ] `normalizeTodoItems` is exported from `prepare-args.ts` and behaves as specified (including `[]` and `undefined` cases).
+- [ ] Widget renders `${index+1}.` numbering and `content` text (old `todo.id` references gone from the file).
+- [ ] Single commit touching only the files listed above.
+
+**Do NOT change:** `prepareArguments` wiring in `tool.ts` (keep the `prepareArguments: prepareTodoArguments` field); `ManageTodoListParams.operation`; the tool name `manage_todo_list`; `packages/subagent/*` (Task 3); `packages/todo/src/index.ts` (Task 2); auto-clear timing; the `"id": 1"` quote-repair regex behavior.
+
+---
+
+### Task 2: Normalize subagent todos at the bus consumer + rendering guards
+
+**Context:**
+The parent todo widget receives subagent todo state ONLY via the bus event `TODOS_UPDATE` (`events.TODOS_UPDATE` from `@pi-archimedes/core/bus`). Until Task 3, the *producer* still emits raw model args (and after Task 3 it emits accepted-but-possibly-legacy state, e.g. when a child session was recorded with an older schema). The consumer therefore must normalize every incoming payload itself. `packages/todo/src/index.ts` currently does `subagentTodos.set(data.source, data.todos)` verbatim — this is where `undefined` titles could still reach the widget. This task makes the consumer the guarantee: stored subagent todos are always canonical, and the widget can never print the string "undefined".
+
+**Files:**
+- Modify: `packages/todo/src/index.ts`
+- Create: `packages/todo/src/index.test.ts`
+
+**What to implement:**
+
+`packages/todo/src/index.ts`:
+- Import `{ normalizeTodoItems }` from `./prepare-args.js`.
+- In the `TODOS_UPDATE` subscription (the `data.source === "main" return` branch stays first):
+```ts
+const normalized = normalizeTodoItems(data.todos);
+if (normalized && normalized.length > 0) {
+  subagentTodos.set(data.source, normalized);
+  refreshWidget();
+}
+```
+  (Unrecoverable payloads — `normalizeTodoItems` returns `undefined` — and empty lists are simply not mirrored; the widget hides empty subagent columns, and `TODOS_CLEAR`/child-exit remain the lifecycle ends.)
+- No other changes in `index.ts`.
+
+`packages/todo/src/index.test.ts` (new file):
+- Minimal mocks:
+  - `captured: Record<string, unknown>` for `setWidget(id, component)`.
+  - `handlers: Record<string, Function>` filled by `pi.on(evt, fn)`.
+  - `registered: { tool?: any; commands: Record<string, unknown> }` filled by `pi.registerTool`/`pi.registerCommand`.
+  - `pi` = `{ on, registerTool, registerCommand }` cast `as unknown as ExtensionAPI`; `ctx` = `{ ui: { setWidget }, sessionManager: { getBranch: () => [] } }` cast `as any`.
+  - Call `registerTodo(pi as any)` from `./index.js`.
+- Real bus: use the actual `getBus()`/`Events` from `@pi-archimedes/core/bus` (it's a global singleton; the other todo test files don't touch the bus).
+- Widget access: the widget is stored under the key `"todo-list"` (`WIDGET_ID` in `ui/todo-widget.ts`); capture `ctx.ui.setWidget(id, component)` into `captured: Record<string, unknown>` and read `captured["todo-list"]` fresh on EVERY render step (the factory can be replaced, or self-cleared to `undefined`, between steps). The widget factory is `(_tui, theme) => ({ render(width), invalidate() })`.
+- Theme stub for invoking the captured widget factory: `const theme: any = { fg: (_c: unknown, s: unknown) => String(s), strikethrough: (s: unknown) => String(s) };` (the widget only calls `theme.fg` and `theme.strikethrough` — no other members are needed). Call `factory(null, theme)`, then `lines = comp.render(200)`.
+- **Test ordering rule (critical)**: `session_start` → `reconstructState(ctx)` → `state.loadFromSession(ctx)`, which **resets the list** from `ctx.sessionManager.getBranch()` (the mock returns `[]`, i.e. empty). So `session_start` MUST fire BEFORE any `registered.tool.execute(...)` seed — in the reverse order the seed is wiped and no main column ever exists: `const anyP = handlers.session_start(undefined, ctx as any); await anyP;` (the handler is async; awaiting its promise is sufficient since the body is synchronous).
+- Tests:
+  1. **Legacy subagent payload is normalized, never "undefined"**: `await handlers.session_start(undefined, ctx as any)` FIRST; then seed main state by calling `registered.tool.execute("c1", { operation: "write", todoList: [{ content: "Main task", status: "pending" }] }, undefined, undefined, ctx as any)` (widget main column now exists); then `getBus().emit(Events.TODOS_UPDATE, { source: "subagent:fake1", todos: [{ id: 1, title: "Old shape task", status: "not-started" }] })`; render; assert joined lines contain `"Old shape task"` AND `"Main task"` and do NOT contain the substring `"undefined"`.
+  2. **Unrecoverable payload is ignored without crashing**: (state from test 1 persists) emit `{ source: "subagent:fake2", todos: "garbage" }` and `{ source: "subagent:fake2", todos: [{ status: "pending" }] }`; no throw; render again → main column still intact (still contains `"Main task"`), no `subagent (fake2)` header.
+  3. **TODOS_CLEAR removes the subagent column**: `getBus().emit(Events.TODOS_CLEAR, { source: "subagent:fake1" })`, render → no `subagent (fake1)` header line, `"Main task"` still present.
+- Cleanup: call `handlers.session_shutdown?.(undefined, ctx as any)` in `afterAll` and unsubscribe any bus listeners you added directly (the registerTodo subscriptions unsubscribe on `session_shutdown`). Avoid emitting/creating lists where every item is `completed` in the tool `execute` fixture (that schedules a 2s auto-clear timer); the fixtures above use a pending item.
+
+**Steps:**
+- [ ] Read `packages/todo/src/index.ts` and `packages/todo/src/ui/todo-widget.ts` (the latter to confirm the widget factory shape used by the tests).
+- [ ] Create `packages/todo/src/index.test.ts` with the tests above.
+- [ ] Run `cd packages/todo && npx vitest run`
+  - Expected pre-implementation: tests 1–2 FAIL (under the current unguarded consumer the legacy `title`-only payload renders `undefined`/`undefined.` in the subagent column, and the phantom `subagent (fake2)` header appears); test 3 (TODOS_CLEAR) already passes — regression guard. If tests 1–2 unexpectedly pass, stop and investigate why.
+- [ ] Implement the `index.ts` change.
+- [ ] Run `cd packages/todo && npx vitest run`
+  - Did all tests pass? If not, fix and re-run before continuing.
+- [ ] Run `cd packages/todo && npx tsc --noEmit`
+  - Did it succeed? If not, fix and re-run.
+- [ ] Commit with message: `fix(todo): normalize subagent todos at the bus consumer; guard rendering`
+
+**Acceptance criteria:**
+- [ ] `subagentTodos` only ever receives canonical, non-empty lists from the bus.
+- [ ] The new index test proves a legacy payload renders as real text and the string "undefined" never appears.
+- [ ] `npx vitest run` + `npx tsc --noEmit` green in `packages/todo`; single commit touching only `index.ts` + `index.test.ts`.
+
+**Do NOT change:** the main-agent write flow (`source: "main"` returns early, state handled locally); `TODOS_CLEAR` handler; `reconstructState`/session lifecycle; the widget file (finished in Task 1); `stream.ts` (Task 3).
+
+---
+
+### Task 3: Subagent mirrors only accepted todo state
+
+**Context:**
+`packages/subagent/src/stream.ts` currently forwards `args.todoList` from the child's `tool_execution_start` event onto `TODOS_UPDATE` immediately. Pi emits that event with the **raw** `toolCall.arguments` — `prepareToolCall(...)` (which runs `prepareArguments` + schema validation) executes only AFTER the emit (verified in pi's agent loop: `executeToolCallsSequential` emits `tool_execution_start` before calling `prepareToolCall`). Result: the parent widget shows un-repaired items (the `undefined` titles) and shows lists the child then rejects (phantom lists). The fix: correlate by `toolCallId`, and on `tool_execution_end` mirror the child's *accepted* state: prefer `event.result.details.todos` (the child ran its own repair+validate — a child is a full pi process that self-holds the entire extension, so todo errors already reach the subagent's model); fall back to the stowed raw start args passed through `normalizeTodoItems`. On `isError !== false`, mirror nothing. This needs a new workspace dep edge `subagent → todo` (publish order already places `todo` before `subagent` in `.github/workflows/release.yml` — no workflow change), an `exports` field on the todo package (it currently has none; `@pi-archimedes/core` sets the pattern), and nothing else.
+
+**Files:**
+- Modify: `packages/subagent/src/stream.ts`
+- Test: `packages/subagent/src/stream.test.ts`
+- Modify: `packages/todo/package.json` (add `exports`)
+- Modify: `packages/subagent/package.json` (add dep)
+
+**What to implement:**
+
+`packages/todo/package.json` — add (alongside the existing `"main": "./src/index.ts"`), mirroring the `core` package pattern with `.ts` targets:
+```json
+"exports": {
+  ".": "./src/index.ts",
+  "./prepare-args": "./src/prepare-args.ts"
+}
+```
+
+`packages/subagent/package.json` — `dependencies` becomes:
+```json
+"dependencies": {
+  "@pi-archimedes/core": "workspace:*",
+  "@pi-archimedes/todo": "workspace:*"
+}
+```
+Then run `pnpm install` at the repo root to link the workspace edge.
+
+`packages/subagent/src/stream.ts`:
+- `import { normalizeTodoItems } from "@pi-archimedes/todo/prepare-args";`
+- Inside `streamEvents`, before the `rl.on("line", ...)` handler: `const pendingTodoArgs = new Map<string, unknown[]>();` and `const subagentSource = \`subagent:${callbacks.agent ?? "general"}\`;`
+- `tool_execution_start` case — replace the existing inline `TODOS_UPDATE` block with stow-only:
+```ts
+case "tool_execution_start": {
+  handleToolStart(state, event);
+  emitProgress();
+  if (event.toolName === "manage_todo_list" && typeof event.toolCallId === "string") {
+    const args = event.args as Record<string, unknown> | undefined;
+    const todoList = args?.todoList;
+    if (Array.isArray(todoList)) {
+      pendingTodoArgs.set(event.toolCallId, todoList);
+    }
+  }
+  break;
+}
+```
+- `tool_execution_end` case — add the mirror BEFORE the existing `handleToolEnd`/`emitProgress`/`handleToolResult` lines (which stay unchanged — note the existing code calls `handleToolEnd(state)` with ONE argument):
+```ts
+case "tool_execution_end": {
+  if (event.toolName === "manage_todo_list") {
+    const id = typeof event.toolCallId === "string" ? event.toolCallId : undefined;
+    const stowed = id ? pendingTodoArgs.get(id) : undefined;
+    if (id) pendingTodoArgs.delete(id);
+    const result = event.result as Record<string, unknown> | undefined;
+    // Tool-level failure (todo's execute() RETURNS {isError:true} on validation
+    // rejection — it does not throw) arrives as event.isError=false with
+    // result.isError=true. Harness failures (abort, not-found, block, throw)
+    // arrive as event.isError=true. Check BOTH — the same convention
+    // handleToolResult in handlers.ts already uses.
+    const failed = event.isError === true || result?.isError === true;
+    if (!failed) {
+      const detailsTodos = (result?.details as Record<string, unknown> | undefined)?.todos;
+      const todos = normalizeTodoItems(Array.isArray(detailsTodos) ? detailsTodos : stowed);
+      if (todos) {
+        getBus().emit(Events.TODOS_UPDATE, { source: subagentSource, todos });
+      }
+    }
+  }
+  handleToolEnd(state);
+  emitProgress();
+  handleToolResult(state, event);
+  emitProgress();
+  break;
+}
+```
+  Notes: `event` is `JsonEvent` (`[key: string]: unknown`) — keep the casts as written. An accepted-but-empty list (`todos = []`) IS emitted and is consumed-but-ignored by the Task 2 consumer (it stores nothing and clears nothing — the guard is `normalized.length > 0`, with no else branch); the subagent column drops ONLY via `TODOS_CLEAR` at child exit (or via the child's next non-empty list). A child's auto-clear itself emits no tool event, so no other path drops the column. Rejected writes — in EITHER error encoding — emit nothing. `detailsTodos` is normalized too — it is defense-in-depth for child sessions recorded by an older extension version (legacy `title`/`not-started` shapes normalize cleanly).
+- `close` handler: replace the inline `subagent:` source string with `subagentSource`.
+- Do not touch `handleToolStart`/`handleToolEnd`/`handleToolResult` in `handlers.ts`, the heartbeat, the startup watchdog, or the ask-socket code in `spawn.ts`.
+
+**Tests — `packages/subagent/src/stream.test.ts`:**
+- Follow the existing `fakeChild()`/`finishWith(events)` harness (read the file first) and EXTEND it: `async function finishWith(events: Array<Record<string, unknown>>, callbacks: StreamCallbacks = {})` — pass `callbacks` through to `streamEvents(child, callbacks)`. The current harness calls `streamEvents(child)` with no callbacks, which would make every source `subagent:general` and break the per-test source assertions below. All other harness behavior (synchronous per-line processing before `close`, 1s heartbeat, startup watchdog cleared on first JSON event) is unchanged and sufficient. Bus capture pattern per test block:
+  ```ts
+  const updates: Array<{ source: string; todos: unknown[] }> = [];
+  const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) => updates.push(p as (typeof updates)[number]));
+  // ... run streamEvents with callbacks { agent: "<unique-per-test>" } ...
+  off();
+  ```
+  Use a DIFFERENT `callbacks.agent` per test (e.g. `"t-acc"`, `"t-rej"`, `"t-nodetails"`) so sources don't collide across tests. Remember `finishWith` ends with `child.emit("close", 0)` which fires `TODOS_CLEAR` — assert on `updates` AFTER the `await finishWith(...)`; the `TODOS_UPDATE` entries are what we assert (ignore clears).
+1. **Accepted write mirrors child-accepted state**: events `[{ type:"tool_execution_start", toolCallId:"t1", toolName:"manage_todo_list", args:{ operation:"write", todoList:[{ id:1, title:"Fix auth", status:"not-started" }] } }, { type:"tool_execution_end", toolCallId:"t1", toolName:"manage_todo_list", isError:false, result:{ content:[{type:"text",text:"ok"}], details:{ operation:"write", todos:[{ content:"Fix auth", status:"pending" }] } } }]` → exactly one `TODOS_UPDATE`, `source === "subagent:t-acc"`, `todos` deep-equals `[{ content: "Fix auth", status: "pending" }]` (NOT the raw stowed list).
+2. **Rejected write mirrors nothing — REAL shape**: same start event; end event with event-level `isError: false` and `result: { content: [{type:"text",text:"Validation failed"}], details: { operation: "write", todos: [{ content: "Old item", status: "completed" }], error: "Item 1: missing or invalid 'content'" }, isError: true }` (this is how todo's `execute()` returns a validation rejection — `result.isError: true`, NOT an event-level error) → zero `TODOS_UPDATE`. Add a second fixture for the harness/abort shape: same start, end event-level `isError: true` with `result: { content: [{type:"text",text:"Aborted"}], details: {} }` → zero `TODOS_UPDATE`.
+3. **Accepted without details falls back to normalized raw args**: same start event; end `isError: false`, `result: { content: [{type:"text",text:"ok"}] }` (no `details`) → one update, `todos` deep-equals `[{ content: "Fix auth", status: "pending" }]` (normalized from raw).
+4. **End without a matching start does not crash and does not emit**: only the end event (build it with `result: { content: [{type:"text",text:"ok"}] }` — NO `details`, mirroring test 3's no-details shape; do NOT reuse test 1's end fixture, which carries `details.todos` and would mirror) → zero updates, promise resolves.
+5. **Non-todo tools do not emit**: start+end for `toolName:"bash"` with a `todoList`-shaped args → zero updates.
+
+**Steps:**
+- [ ] Read `packages/subagent/src/stream.ts`, `stream.test.ts`, and `handlers.ts` (the `JsonEvent` shape) first.
+- [ ] Apply the two `package.json` changes; run `pnpm install` at the repo root.
+- [ ] Extend the `finishWith` harness (callbacks parameter) and write the five test fixtures in `stream.test.ts` (test 2 has two fixtures — real rejection shape + abort shape — for six scenarios total).
+- [ ] Run `cd packages/subagent && npx vitest run`
+  - Expected pre-implementation: tests 1–3 FAIL (old code emits on `tool_execution_start`: test 1 gets one update carrying the RAW stowed list, so the deep-equal against canonical state fails; tests 2–3 get a non-zero update count / raw-payload mismatch). Tests 4 and 5 (the no-emit cases) are regression guards that PASS under the old code as well — do not treat their passing as a bug to investigate. If tests 1–3 unexpectedly pass, stop and investigate why.
+- [ ] Implement the `stream.ts` change.
+- [ ] Run `cd packages/subagent && npx vitest run`
+  - Did all tests pass? If not, fix and re-run before continuing.
+- [ ] Run `cd packages/subagent && npx tsc --noEmit`
+  - Did it succeed? If not, fix and re-run. (A tsc failure about the `@pi-archimedes/todo/prepare-args` subpath means the `exports` entry or the `pnpm install` link is wrong — check both.)
+- [ ] Commit with message: `fix(subagent): mirror only accepted todo state from child tool results` — the commit must include `stream.ts`, `stream.test.ts`, the two `package.json` files, AND `pnpm-lock.yaml` (regenerated by the `pnpm install` step).
+
+**Acceptance criteria:**
+- [ ] `TODOS_UPDATE` is emitted from `stream.ts` in EXACTLY ONE place (the `tool_execution_end` case); `tool_execution_start` only stows.
+- [ ] All five stream tests pass; `npx tsc --noEmit` green in `packages/subagent`.
+- [ ] `pnpm --filter @pi-archimedes/subagent exec tsc --noEmit` also resolves the new import (i.e. the exports map works under pnpm filtering, not just workspace linking).
+- [ ] No changes to `.github/workflows/release.yml` (todo already publishes before subagent).
+- [ ] Single commit covering `stream.ts`, `stream.test.ts`, the two `package.json` files, and `pnpm-lock.yaml`.
+
+**Do NOT change:** the ask-socket bridge in `spawn.ts`; `handleToolResult`'s recentOutput behavior; `SubagentResult` shape; the startup timeout or heartbeat; `Events` in `core/bus.ts`.
+
+---
+
+### Task 4: Docs, stale references, full-gate verification
+
+**Context:**
+After Tasks 1–3 the code is consistent, but prose (README) and possibly stray code comments/docs may still reference the old field names (`id`, `title`, `not-started`, `in-progress`). This task sweeps and fixes every live reference (historical plan files under `docs/plans/done/` are NOT touched — they record what was done at the time), then runs the full repo gate (every package type-checks, all test suites run) to prove nothing else regressed. This is the task that makes the change releasable.
+
+**Files:**
+- Modify: `README.md` (the todo feature section — read it first; update any mention of item fields/statuses)
+- Modify: `docs/plans/README.md` (flip the plan-029 row to `✅ COMPLETED`; Quick Stats: Completed 29, In Progress 0)
+- Modify: any other file flagged by the grep below (expected candidates: none in `packages/*/src` after Task 1–3, but check `packages/todo/README*`, `meta/` docs, `packages/core/src/bus.ts` comments)
+- Do NOT modify: `docs/plans/done/**`, any file whose only old reference is inside a historical plan
+
+**What to do:**
+1. Sweep: `grep -rn "not-started\|in-progress\|TodoItem\|todoList\|title:" packages meta README.md --include="*.ts" --include="*.md" | grep -v node_modules | grep -v "\.test\.ts"` — review each hit; fix any that describe the CURRENT schema (i.e. everything except test files, which were rewritten in Task 1).
+   - Re-run the same grep scoped to `packages/todo/src/prepare-args.ts` and expect **zero** `not-started`/`in-progress` hits after Task 1: legacy shapes are absorbed by the `/[\s_-]+/g` (separator collapse — strip whitespace/hyphen/underscore to `""`) before alias lookup, so the alias table is keyed by collapsed forms (`notstarted`, `inprogress`, …) and no dashed literals remain. Do NOT "fix" this by re-adding dashed alias keys — they would be dead code (never matched after the collapse). (The sweep pattern `TodoItem` also substring-matches the new `normalizeTodoItems` import in `packages/subagent/src/stream.ts` — expected; skip that hit.)
+2. README: update the todo section's item-shape wording (if it documents the shape at all) to `content` + `status` (`pending`/`in_progress`/`completed`), no `id`.
+3. Full gate — run each independently and wait (AGENTS.md verification order):
+   - `npx tsc --noEmit` in EVERY directory under `packages/` (core, ask, footer, diff, image-paste, notify, subagent, todo, session-name, mcp) AND in `meta/`.
+   - `npx vitest run` in every package that has `vitest.config.ts` (at minimum `packages/todo` and `packages/subagent`; if others have configs, run them too).
+4. Update `docs/plans/README.md`: the plan-029 row MOVES from the Backlog table to the `## Done` table with status `✅ COMPLETED` (link it `plan-029-todo-schema-alignment.md`, relative path — same precedent as plan-028's row, no `done/` prefix since the file lives at the plans root), and set Quick Stats (Completed 29, In Progress 0, Backlog 0).
+5. Confirm `git status` shows only the doc edits for this commit (no code drift from the sweep).
+
+**Steps:**
+- [ ] Run both greps; fix live references (code comments, README, any package README).
+- [ ] Run the full tsc loop over all 11 directories listed above.
+  - Did every one succeed? If any fails, read the error, fix, re-run.
+- [ ] Run `npx vitest run` in each package with `vitest.config.ts`, starting with `packages/todo` and `packages/subagent`.
+  - Did all suites pass? If not, fix and re-run before continuing.
+- [ ] Commit with message: `docs(todo): schema-alignment docs and stale reference cleanup`
+
+**Acceptance criteria:**
+- [ ] Zero non-historical occurrences of `not-started`/`in-progress`/`title:`-as-todo-field in live code or docs (the alias table legitimately contains only collapsed keys like `notstarted`).
+- [ ] All 11 type-checks green; all test suites green.
+- [ ] Commit touches documentation/comments only, plus the `docs/plans/README.md` status flip.
+
+**Do NOT change:** the alias tables in `prepare-args.ts` (they keep legacy keys on purpose); `docs/plans/done/**`; `docs/adr/0009-todo-schema-cc-alignment.md` (already correct); any version numbers (bumped at release time per AGENTS.md, not here).
+
+---
+
+## Out of scope (carried from the approved spec — do NOT build)
+
+- Parent-enforced todo validation with an ask-style socket error relay from parent to child.
+- Renaming the `manage_todo_list` tool or its `operation` parameter.
+- Adopting `activeForm` into the schema / spinner integration; `cancelled`/`blocked` statuses.
+- Version bumps or release workflow changes (todo already publishes before subagent).
+
+## Cross-task notes for the executing agent
+
+- The monorepo has NO build step — verification is `tsc --noEmit` + vitest only (AGENTS.md).
+- Cross-package imports use package subpath exports (`@pi-archimedes/todo/prepare-args`), relative imports stay package-internal.
+- Each task MUST end with a green `tsc --noEmit` in every package it touched (plus `core` for Task 1) and vitest green where tests exist — intermediate commits must not leave the repo red.
+- If a check fails twice in a row without edits between runs, stop and report BLOCKED (AGENTS.md loop-break rule).

--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -108,7 +108,7 @@ export const Events = {
 
 interface TodoUpdatePayload {
   source: string;       // "main" or "subagent:<agent-name>"
-  todos: Array<{ id: number; title: string; description: string; status: "not-started" | "in-progress" | "completed" }>;
+  todos: Array<{ content: string; description?: string; status: "pending" | "in_progress" | "completed" }>;
 }
 
 interface TodoClearPayload {

--- a/packages/image-paste/vitest.config.ts
+++ b/packages/image-paste/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-    exclude: ["**/node_modules/**"],
-  },
-});

--- a/packages/notify/vitest.config.ts
+++ b/packages/notify/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-    exclude: ["**/node_modules/**"],
-  },
-});

--- a/packages/subagent/package.json
+++ b/packages/subagent/package.json
@@ -11,7 +11,8 @@
   ],
   "main": "./src/index.ts",
   "dependencies": {
-    "@pi-archimedes/core": "workspace:*"
+    "@pi-archimedes/core": "workspace:*",
+    "@pi-archimedes/todo": "workspace:*"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.1.0",

--- a/packages/subagent/src/stream.test.ts
+++ b/packages/subagent/src/stream.test.ts
@@ -2,7 +2,8 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import type { ChildProcess } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { streamEvents } from "./stream.js";
+import { getBus, Events } from "@pi-archimedes/core/bus";
+import { streamEvents, type StreamCallbacks } from "./stream.js";
 
 type FakeChild = ChildProcess & { stdout: PassThrough; stderr: PassThrough };
 
@@ -16,15 +17,19 @@ function fakeChild(): FakeChild {
   return child;
 }
 
-async function finishWith(events: Array<Record<string, unknown>>) {
+async function finishWith(
+  events: Array<Record<string, unknown>>,
+  callbacks: StreamCallbacks = {},
+) {
   const child = fakeChild();
-  const result = streamEvents(child);
+  const result = streamEvents(child, callbacks);
   for (const event of events) {
     child.stdout.write(`${JSON.stringify(event)}\n`);
   }
   child.emit("close", 0);
   return result;
 }
+
 
 describe("streamEvents session identity", () => {
   it("returns the logical child Pi session ID", async () => {
@@ -45,3 +50,199 @@ describe("streamEvents session identity", () => {
     expect(result.childSessionId).toBeUndefined();
   });
 });
+
+describe("streamEvents todo mirroring", () => {
+  const start = {
+    type: "tool_execution_start",
+    toolCallId: "t1",
+    toolName: "manage_todo_list",
+    args: {
+      operation: "write",
+      todoList: [{ id: 1, title: "Fix auth", status: "not-started" }],
+    },
+  } as unknown as Record<string, unknown>;
+
+  it("mirrors the child-accepted state from result.details.todos", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+
+    await finishWith(
+      [
+        start,
+        {
+          type: "tool_execution_end",
+          toolCallId: "t1",
+          toolName: "manage_todo_list",
+          isError: false,
+          result: {
+            content: [{ type: "text", text: "ok" }],
+            details: {
+              operation: "write",
+              todos: [{ content: "Fix auth", status: "pending" }],
+            },
+          },
+        },
+      ],
+      { agent: "t-acc" },
+    );
+    off();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.source).toBe("subagent:t-acc");
+    expect(updates[0]!.todos).toEqual([
+      { content: "Fix auth", status: "pending" },
+    ]);
+  });
+
+  it("mirrors nothing when the tool returned a validation rejection (result.isError)", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+
+    await finishWith(
+      [
+        start,
+        {
+          type: "tool_execution_end",
+          toolCallId: "t1",
+          toolName: "manage_todo_list",
+          isError: false,
+          result: {
+            content: [{ type: "text", text: "Validation failed" }],
+            details: {
+              operation: "write",
+              todos: [{ content: "Old item", status: "completed" }],
+              error: "Item 1: missing or invalid 'content'",
+            },
+            isError: true,
+          },
+        },
+      ],
+      { agent: "t-rej" },
+    );
+    off();
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it("mirrors nothing when the harness reported an error (event.isError)", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+
+    await finishWith(
+      [
+        start,
+        {
+          type: "tool_execution_end",
+          toolCallId: "t1",
+          toolName: "manage_todo_list",
+          isError: true,
+          result: {
+            content: [{ type: "text", text: "Aborted" }],
+            details: {},
+          },
+        },
+      ],
+      { agent: "t-rej2" },
+    );
+    off();
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it("falls back to normalized raw args when the accepted result has no details", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+
+    await finishWith(
+      [
+        start,
+        {
+          type: "tool_execution_end",
+          toolCallId: "t1",
+          toolName: "manage_todo_list",
+          isError: false,
+          result: { content: [{ type: "text", text: "ok" }] },
+        },
+      ],
+      { agent: "t-nodetails" },
+    );
+    off();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.source).toBe("subagent:t-nodetails");
+    expect(updates[0]!.todos).toEqual([
+      { content: "Fix auth", status: "pending" },
+    ]);
+  });
+
+  it("does not crash or emit when the end event has no matching start", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+
+    const result = await finishWith(
+      [
+        {
+          type: "tool_execution_end",
+          toolCallId: "orphan",
+          toolName: "manage_todo_list",
+          isError: false,
+          result: { content: [{ type: "text", text: "ok" }] },
+        },
+      ],
+      { agent: "t-orphan" },
+    );
+    off();
+
+    expect(result.exitCode).toBe(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("does not emit for non-todo tools with todoList-shaped args", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+
+    await finishWith(
+      [
+        {
+          type: "tool_execution_start",
+          toolCallId: "b1",
+          toolName: "bash",
+          args: {
+            operation: "write",
+            todoList: [{ content: "Fix auth", status: "pending" }],
+          },
+        },
+        {
+          type: "tool_execution_end",
+          toolCallId: "b1",
+          toolName: "bash",
+          isError: false,
+          result: {
+            content: [{ type: "text", text: "ok" }],
+            details: {
+              operation: "write",
+              todos: [{ content: "Fix auth", status: "pending" }],
+            },
+          },
+        },
+      ],
+      { agent: "t-bash" },
+    );
+    off();
+
+    expect(updates).toHaveLength(0);
+  });
+});
+

--- a/packages/subagent/src/stream.test.ts
+++ b/packages/subagent/src/stream.test.ts
@@ -253,5 +253,59 @@ describe("streamEvents todo mirroring", () => {
 
     expect(updates).toHaveLength(0);
   });
+
+  it("uses a unique per-child source when the child provides a session id", async () => {
+    const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const clears: Array<{ source: string }> = [];
+    const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
+      updates.push(p as (typeof updates)[number]),
+    );
+    const offClear = getBus().on(Events.TODOS_CLEAR, (p: unknown) =>
+      clears.push(p as { source: string }),
+    );
+
+    const agent = "t-unique";
+    const idA = "11111111-1111-7111-8111-111111111111";
+    const idB = "22222222-2222-7222-8222-222222222222";
+
+    const accepted = {
+      type: "tool_execution_end",
+      toolCallId: "t1",
+      toolName: "manage_todo_list",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "ok" }],
+        details: {
+          operation: "write",
+          todos: [{ content: "Fix auth", status: "pending" }],
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    // Two concurrent children, same agent, distinct session ids.
+    await finishWith(
+      [{ type: "session", id: idA }, start, accepted],
+      { agent },
+    );
+    await finishWith(
+      [{ type: "session", id: idB }, start, accepted],
+      { agent },
+    );
+    off();
+    offClear();
+
+    const sources = updates.map((u) => u.source);
+    // Each child gets its own suffixed source equal to subagent:<agent>:<uuid>.
+    expect(sources).toContain(`subagent:${agent}:${idA}`);
+    expect(sources).toContain(`subagent:${agent}:${idB}`);
+    // The two concurrent children must NOT share a single source.
+    expect(sources.filter((s) => s.startsWith(`subagent:${agent}:`))).toEqual([
+      `subagent:${agent}:${idA}`,
+      `subagent:${agent}:${idB}`,
+    ]);
+    // The clear on close carries the same suffixed source for each child.
+    expect(clears.filter((c) => c.source === `subagent:${agent}:${idA}`)).toHaveLength(1);
+    expect(clears.filter((c) => c.source === `subagent:${agent}:${idB}`)).toHaveLength(1);
+  });
 });
 

--- a/packages/subagent/src/stream.test.ts
+++ b/packages/subagent/src/stream.test.ts
@@ -64,8 +64,12 @@ describe("streamEvents todo mirroring", () => {
 
   it("mirrors the child-accepted state from result.details.todos", async () => {
     const updates: Array<{ source: string; todos: unknown[] }> = [];
+    const clears: Array<{ source: string }> = [];
     const off = getBus().on(Events.TODOS_UPDATE, (p: unknown) =>
       updates.push(p as (typeof updates)[number]),
+    );
+    const offClear = getBus().on(Events.TODOS_CLEAR, (p: unknown) =>
+      clears.push(p as { source: string }),
     );
 
     await finishWith(
@@ -88,12 +92,17 @@ describe("streamEvents todo mirroring", () => {
       { agent: "t-acc" },
     );
     off();
+    offClear();
 
     expect(updates).toHaveLength(1);
     expect(updates[0]!.source).toBe("subagent:t-acc");
     expect(updates[0]!.todos).toEqual([
       { content: "Fix auth", status: "pending" },
     ]);
+    // Bus re-drains queued events (emitted while unsubscribed) to the next
+    // subscriber, so stale "subagent:general" clears from earlier tests may
+    // be present — assert on the per-agent source instead of the raw count.
+    expect(clears.filter((c) => c.source === "subagent:t-acc")).toHaveLength(1);
   });
 
   it("mirrors nothing when the tool returned a validation rejection (result.isError)", async () => {

--- a/packages/subagent/src/stream.ts
+++ b/packages/subagent/src/stream.ts
@@ -116,7 +116,7 @@ export function streamEvents(
     // matching tool_execution_end. pi emits tool_execution_start with the
     // raw (pre-prepareToolCall) arguments, so these may be unrepaired.
     const pendingTodoArgs = new Map<string, unknown[]>();
-    const subagentSource = `subagent:${callbacks.agent ?? "general"}`;
+    let subagentSource = `subagent:${callbacks.agent ?? "general"}`;
 
     rl.on("line", (line) => {
       const trimmed = line.trim();
@@ -137,6 +137,11 @@ export function streamEvents(
         case "session": {
           if (typeof event.id === "string" && event.id) {
             state.childSessionId = event.id;
+            // A child with a session id gets a unique per-child todo source so
+            // concurrent children sharing an agent name don't clobber each
+            // other's accepted state when one clears on exit. Children without
+            // a session id (e.g. tests) keep the legacy subagent:<agent> form.
+            subagentSource = `subagent:${callbacks.agent ?? "general"}:${event.id}`;
           }
           break;
         }

--- a/packages/subagent/src/stream.ts
+++ b/packages/subagent/src/stream.ts
@@ -2,6 +2,7 @@ import { createInterface } from "node:readline";
 import type { ChildProcess } from "node:child_process";
 import type { StreamState, SubagentProgress, SubagentResult } from "./types.js";
 import { getBus, Events } from "@pi-archimedes/core/bus";
+import { normalizeTodoItems } from "@pi-archimedes/todo/prepare-args";
 import {
   type JsonEvent,
   handleToolStart,
@@ -111,6 +112,12 @@ export function streamEvents(
 
     const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
 
+    // toolCallId → raw todoList from tool_execution_start, consumed by the
+    // matching tool_execution_end. pi emits tool_execution_start with the
+    // raw (pre-prepareToolCall) arguments, so these may be unrepaired.
+    const pendingTodoArgs = new Map<string, unknown[]>();
+    const subagentSource = `subagent:${callbacks.agent ?? "general"}`;
+
     rl.on("line", (line) => {
       const trimmed = line.trim();
       if (!trimmed) return;
@@ -136,20 +143,35 @@ export function streamEvents(
         case "tool_execution_start": {
           handleToolStart(state, event);
           emitProgress();
-          // Forward manage_todo_list writes to the parent's todo widget
-          if (event.toolName === "manage_todo_list") {
+          if (event.toolName === "manage_todo_list" && typeof event.toolCallId === "string") {
             const args = event.args as Record<string, unknown> | undefined;
-            const todoList = args?.todoList as Array<unknown> | undefined;
+            const todoList = args?.todoList;
             if (Array.isArray(todoList)) {
-              getBus().emit(Events.TODOS_UPDATE, {
-                source: `subagent:${callbacks.agent ?? "general"}`,
-                todos: todoList,
-              });
+              pendingTodoArgs.set(event.toolCallId, todoList);
             }
           }
           break;
         }
         case "tool_execution_end": {
+          if (event.toolName === "manage_todo_list") {
+            const id = typeof event.toolCallId === "string" ? event.toolCallId : undefined;
+            const stowed = id ? pendingTodoArgs.get(id) : undefined;
+            if (id) pendingTodoArgs.delete(id);
+            const result = event.result as Record<string, unknown> | undefined;
+            // Tool-level failure (todo's execute() RETURNS {isError:true} on validation
+            // rejection — it does not throw) arrives as event.isError=false with
+            // result.isError=true. Harness failures (abort, not-found, block, throw)
+            // arrive as event.isError=true. Check BOTH — the same convention
+            // handleToolResult in handlers.ts already uses.
+            const failed = event.isError === true || result?.isError === true;
+            if (!failed) {
+              const detailsTodos = (result?.details as Record<string, unknown> | undefined)?.todos;
+              const todos = normalizeTodoItems(Array.isArray(detailsTodos) ? detailsTodos : stowed);
+              if (todos) {
+                getBus().emit(Events.TODOS_UPDATE, { source: subagentSource, todos });
+              }
+            }
+          }
           handleToolEnd(state);
           emitProgress();
           handleToolResult(state, event);
@@ -218,7 +240,7 @@ export function streamEvents(
 
       // Clear subagent todos from the bus on exit
       getBus().emit(Events.TODOS_CLEAR, {
-        source: `subagent:${callbacks.agent ?? "general"}`,
+        source: subagentSource,
       });
 
       resolve(result);

--- a/packages/todo/README.md
+++ b/packages/todo/README.md
@@ -17,7 +17,7 @@ Track complex multi-step tasks structured in a todo list with automatic clearing
 
 ### Multiple todos with progress tracking
 
-Widget showing three todos with completion status — completed items dimmed with strikethrough, in-progress highlighted:
+Widget showing three todos with completion status — completed items dimmed with strikethrough, the item currently being worked on highlighted:
 
 ![todos multiple todos](../../docs/images/todos-multiple-todos.png)
 
@@ -59,9 +59,9 @@ The `manage_todo_list` tool accepts two operations:
 {
   "operation": "write",
   "todoList": [
-    { "id": 1, "title": "Parse config files", "description": "Read and validate all config files", "status": "in-progress" },
-    { "id": 2, "title": "Build state manager", "description": "Implement TodoStateManager class", "status": "not-started" },
-    { "id": 3, "title": "Wire up widget", "description": "Connect widget to bus events", "status": "not-started" }
+    { "content": "Parse config files", "description": "Read and validate all config files", "status": "in_progress" },
+    { "content": "Build state manager", "description": "Implement TodoStateManager class", "status": "pending" },
+    { "content": "Wire up widget", "description": "Connect widget to bus events", "status": "pending" }
   ]
 }
 ```
@@ -75,8 +75,8 @@ The `manage_todo_list` tool accepts two operations:
 
 | Status | Icon | Description |
 |--------|------|-------------|
-| `not-started` | ○ | Not yet begun |
-| `in-progress` | ◉ | Currently being worked on |
+| `pending` | ○ | Not yet begun |
+| `in_progress` | ◉ | Currently being worked on |
 | `completed` | ✓ | Fully finished |
 
 ## Auto-clear

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -10,6 +10,10 @@
     "src"
   ],
   "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./prepare-args": "./src/prepare-args.ts"
+  },
   "dependencies": {
     "@pi-archimedes/core": "workspace:*"
   },

--- a/packages/todo/src/index.test.ts
+++ b/packages/todo/src/index.test.ts
@@ -118,6 +118,39 @@ describe("todo index — bus consumer normalization", () => {
     expect(joined).toContain("Main task");
   });
 
+  it("renders the plain agent name for a unique per-child (suffixed) source", async () => {
+    // Fresh setup mirroring test 1: session_start first (resets main), then
+    // seed main through the real tool, then a suffixed subagent bus emit.
+    const start = handlers.session_start;
+    if (typeof start !== "function") throw new Error("session_start handler not registered");
+    let anyP: unknown;
+    anyP = start(undefined, ctx as any);
+    await anyP;
+
+    const result = await registered.tool.execute(
+      "c1",
+      { operation: "write", todoList: [{ content: "Main task", status: "pending" }] },
+      undefined,
+      undefined,
+      ctx as any,
+    );
+    expect(result.isError).toBeFalsy();
+
+    // Per-child source now carries a suffix; the header must still render
+    // just the agent name, not the uuid.
+    getBus().emit(Events.TODOS_UPDATE, {
+      source: "subagent:fake1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      todos: [{ id: 1, title: "Old shape task", status: "not-started" }],
+    });
+
+    const lines = renderLines();
+    const joined = lines.join("\n");
+    expect(lines.some((l) => l.includes("subagent (fake1)"))).toBe(true);
+    expect(joined).toContain("Old shape task");
+    expect(joined).toContain("Main task");
+    expect(joined).not.toContain("undefined");
+  });
+
   afterAll(() => {
     // Unsubscribes the bus listeners registered by registerTodo and
     // clears state (fixture uses a pending item, so no auto-clear timer

--- a/packages/todo/src/index.test.ts
+++ b/packages/todo/src/index.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Index-level test: the bus consumer guarantee.
+ *
+ * The parent todo widget receives subagent todo state ONLY via the
+ * TODOS_UPDATE bus event. These tests prove that whatever the producer
+ * emits (legacy shapes, garbage) the consumer stored in `subagentTodos`
+ * is always canonical — the widget can render real text and can never
+ * print the string "undefined".
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getBus, Events } from "@pi-archimedes/core/bus";
+import { registerTodo } from "./index.js";
+
+describe("todo index — bus consumer normalization", () => {
+  const captured: Record<string, unknown> = {};
+  const handlers: Record<string, Function> = {};
+  const registered: { tool?: any; commands: Record<string, unknown> } = { commands: {} };
+
+  const pi = {
+    on(evt: string, fn: Function) {
+      handlers[evt] = fn;
+    },
+    registerTool(tool: any) {
+      registered.tool = tool;
+    },
+    registerCommand(name: string, def: unknown) {
+      registered.commands[name] = def;
+    },
+  } as unknown as ExtensionAPI;
+
+  const ctx = {
+    ui: {
+      setWidget(id: string, component: unknown) {
+        captured[id] = component;
+      },
+    },
+    sessionManager: { getBranch: () => [] },
+  } as any;
+
+  // The widget calls theme.fg / theme.strikethrough; same behavior these
+  // tests rely on (identity-ish, no ANSI) is enough to inspect the text.
+  const theme: any = {
+    fg: (_c: unknown, s: unknown) => String(s),
+    strikethrough: (s: unknown) => String(s),
+  };
+
+  function renderLines(): string[] {
+    // Read fresh on every render step — the factory can be replaced, or
+    // self-cleared to undefined, between steps.
+    const factory = captured["todo-list"] as
+      | ((_tui: unknown, t: unknown) => { render(width: number): string[]; invalidate(): void })
+      | undefined;
+    expect(typeof factory).toBe("function");
+    const comp = factory!(null, theme);
+    return comp.render(200);
+  }
+
+  beforeAll(() => {
+    registerTodo(pi as any);
+  });
+
+  it("normalizes a legacy subagent payload — renders real text, never 'undefined'", async () => {
+    // CRITICAL ordering: session_start must fire BEFORE seeding, because
+    // reconstructState → state.loadFromSession(ctx) resets the list from
+    // getBranch() (mock returns []), which would wipe the seed.
+    const start = handlers.session_start;
+    if (typeof start !== "function") throw new Error("session_start handler not registered");
+    let anyP: unknown;
+    anyP = start(undefined, ctx as any);
+    await anyP;
+
+    // Seed main state through the real tool.
+    const result = await registered.tool.execute(
+      "c1",
+      { operation: "write", todoList: [{ content: "Main task", status: "pending" }] },
+      undefined,
+      undefined,
+      ctx as any,
+    );
+    expect(result.isError).toBeFalsy();
+
+    // Legacy (old-schema) subagent payload: id/title/not-started.
+    getBus().emit(Events.TODOS_UPDATE, {
+      source: "subagent:fake1",
+      todos: [{ id: 1, title: "Old shape task", status: "not-started" }],
+    });
+
+    const lines = renderLines();
+    const joined = lines.join("\n");
+    expect(joined).toContain("Old shape task");
+    expect(joined).toContain("Main task");
+    expect(joined).not.toContain("undefined");
+  });
+
+  it("ignores unrecoverable payloads without crashing (no phantom column)", () => {
+    // State from the previous test persists (same registered instance).
+    expect(() => {
+      getBus().emit(Events.TODOS_UPDATE, { source: "subagent:fake2", todos: "garbage" });
+      getBus().emit(Events.TODOS_UPDATE, {
+        source: "subagent:fake2",
+        todos: [{ status: "pending" }],
+      });
+    }).not.toThrow();
+
+    const lines = renderLines();
+    const joined = lines.join("\n");
+    expect(joined).toContain("Main task");
+    expect(lines.some((l) => l.includes("subagent (fake2)"))).toBe(false);
+  });
+
+  it("TODOS_CLEAR removes the subagent column", () => {
+    getBus().emit(Events.TODOS_CLEAR, { source: "subagent:fake1" });
+
+    const lines = renderLines();
+    const joined = lines.join("\n");
+    expect(lines.some((l) => l.includes("subagent (fake1)"))).toBe(false);
+    expect(joined).toContain("Main task");
+  });
+
+  afterAll(() => {
+    // Unsubscribes the bus listeners registered by registerTodo and
+    // clears state (fixture uses a pending item, so no auto-clear timer
+    // is pending, but cancel defensively).
+    handlers.session_shutdown?.(undefined, ctx as any);
+  });
+});

--- a/packages/todo/src/index.ts
+++ b/packages/todo/src/index.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionContext, ExtensionCommandContext } from "@e
 import { getBus, Events } from "@pi-archimedes/core/bus";
 import { TodoStateManager } from "./state-manager.js";
 import { createManageTodoListTool } from "./tool.js";
+import { normalizeTodoItems } from "./prepare-args.js";
 import { updateWidget, clearWidget } from "./ui/todo-widget.js";
 import type { TodoItem } from "./types.js";
 
@@ -25,8 +26,17 @@ export function registerTodo(pi: ExtensionAPI): void {
   const unsubTodosUpdate = getBus().on(Events.TODOS_UPDATE, (payload: unknown) => {
     const data = payload as { source: string; todos: TodoItem[] };
     if (data.source === "main") return; // main handled locally
-    subagentTodos.set(data.source, data.todos);
-    refreshWidget();
+    // The consumer is the guarantee: producers (subagent stream, older
+    // child sessions) may emit raw or legacy shapes, so every incoming
+    // payload is normalized before it is stored. Unrecoverable payloads
+    // (normalizeTodoItems → undefined) and empty lists are not mirrored —
+    // the widget hides empty subagent columns, and TODOS_CLEAR/child-exit
+    // remain the lifecycle ends.
+    const normalized = normalizeTodoItems(data.todos);
+    if (normalized && normalized.length > 0) {
+      subagentTodos.set(data.source, normalized);
+      refreshWidget();
+    }
   });
   unsubscribes.push(unsubTodosUpdate);
 

--- a/packages/todo/src/prepare-args.test.ts
+++ b/packages/todo/src/prepare-args.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   deriveTitleFromDescription,
   normalizeTodoItem,
+  normalizeTodoItems,
   prepareTodoArguments,
 } from "./prepare-args.js";
 
@@ -14,32 +15,25 @@ const REAL_STRINGIFIED_LIST =
   '"description": "Document all container-level env vars", ' +
   '"status": "in-progress"}]';
 
-const REAL_MISSING_TITLE = {
-  operation: "write",
-  todoList: [
-    { description: "Understand what c12d4a0 fixed and how the current base interacts with it", id: 1, status: "in-progress" },
-    { description: "Trace user_api_key_auth() catch-all behaviour", id: 2, status: "not-started" },
-  ],
-};
-
-const REAL_MISSING_STATUS = {
-  operation: "write",
-  todoList: [
-    { id: 1, title: "Fix shell command interpolation", description: "fetchNewToken() builds cmd as string" },
-    { id: 2, title: "Update tests", description: "add regression test" },
-  ],
-};
+// Legacy 4-field shape (id/title/description + dashed statuses) that older
+// sessions persisted — must normalize to the canonical {content, status}.
+const LEGACY_ITEM = { id: 1, title: "Fix auth", description: "Y", status: "not-started" };
 
 describe("prepareTodoArguments", () => {
-  it("passes through already-valid arguments unchanged", () => {
+  it("passes through already-valid canonical arguments unchanged", () => {
     const input = {
       operation: "write",
       todoList: [
-        { id: 1, title: "Task", description: "Desc", status: "in-progress" },
-        { id: 2, title: "Other", description: "More", status: "completed" },
+        { content: "Fix auth", status: "pending" as const },
+        { content: "Ship it", status: "completed" as const },
       ],
-    } as const;
-    expect(prepareTodoArguments(input)).toEqual(input);
+    };
+    const out = prepareTodoArguments(input);
+    expect(out).toEqual(input);
+    for (const item of out.todoList!) {
+      expect(Object.keys(item as Record<string, unknown>)).not.toContain("id");
+      expect(Object.keys(item as Record<string, unknown>)).not.toContain("title");
+    }
   });
 
   it("passes non-object arguments through untouched", () => {
@@ -48,14 +42,52 @@ describe("prepareTodoArguments", () => {
     }
   });
 
+  it("normalizes a legacy item (id/title/not-started) to canonical, dropping id", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: [LEGACY_ITEM] });
+    expect(out.todoList).toEqual([{ content: "Fix auth", description: "Y", status: "pending" }]);
+  });
+
+  it("reads Codex-shaped items ({step, status}) into content", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: [{ step: "X", status: "in_progress" }] });
+    expect(out.todoList).toEqual([{ content: "X", status: "in_progress" }]);
+  });
+
+  it("strips id (even null) and folds spaced statuses", () => {
+    const out = prepareTodoArguments({
+      operation: "write",
+      todoList: [{ id: null, content: "X", status: "in progress" }],
+    });
+    expect(out.todoList).toEqual([{ content: "X", status: "in_progress" }]);
+  });
+
+  it("recovers content from activeForm alone", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: [{ activeForm: "Adding tests" }] });
+    expect(out.todoList).toEqual([{ content: "Adding tests", status: "pending" }]);
+  });
+
+  it("wraps bare-string items into canonical items", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: ["write tests", "deploy it"] });
+    expect(out.todoList).toEqual([
+      { content: "write tests", status: "pending" },
+      { content: "deploy it", status: "pending" },
+    ]);
+  });
+
   it("parses a stringified todoList (real-world case, incl. mangled quotes)", () => {
     const out = prepareTodoArguments({ operation: "write", todoList: REAL_STRINGIFIED_LIST });
     expect(out.operation).toBe("write");
-    const list = out.todoList as Array<Record<string, unknown>>;
-    expect(Array.isArray(list)).toBe(true);
-    expect(list).toHaveLength(2);
-    expect(list[0]).toEqual({ id: 1, title: "Catalog all undocumented env vars", description: "Compare env vars from all K8s manifests against what is in AI-SETUP.md", status: "completed" });
-    expect(list[1]).toEqual({ id: 2, title: "Add K8s env vars section", description: "Document all container-level env vars", status: "in-progress" });
+    expect(out.todoList).toEqual([
+      {
+        content: "Catalog all undocumented env vars",
+        description: "Compare env vars from all K8s manifests against what is in AI-SETUP.md",
+        status: "completed",
+      },
+      {
+        content: "Add K8s env vars section",
+        description: "Document all container-level env vars",
+        status: "in_progress",
+      },
+    ]);
   });
 
   it("returns a stringified list it cannot parse, so the schema error still fires", () => {
@@ -63,69 +95,71 @@ describe("prepareTodoArguments", () => {
     expect(out.todoList).toBe("[{ def 《");
   });
 
-  it("derives a title when the model only sent description", () => {
-    const out = prepareTodoArguments(parseJSON(JSON.stringify(REAL_MISSING_TITLE)));
-    const list = out.todoList as Array<Record<string, unknown>>;
-    expect(list[0]?.title).not.toBe("");
-    expect(list[0]?.description).toBe("Understand what c12d4a0 fixed and how the current base interacts with it");
-    expect(list[1]).toEqual({ id: 2, title: expect.any(String), description: "Trace user_api_key_auth() catch-all behaviour", status: "not-started" });
+  it("last-resort scan picks the first unreserved string field", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: [{ instruction: "do X", status: "pending" }] });
+    expect(out.todoList).toEqual([{ content: "do X", status: "pending" }]);
   });
 
-  it("defaults missing status to not-started", () => {
-    const out = prepareTodoArguments(parseJSON(JSON.stringify(REAL_MISSING_STATUS)));
-    const list = out.todoList as Array<Record<string, unknown>>;
-    expect(list.every((item) => item?.status === "not-started")).toBe(true);
+  it("last-resort scan does NOT pick up status or id values", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: [{ id: 42, status: "bad" }] });
+    expect(out.todoList).toEqual([{ content: "", status: "pending" }]);
   });
 
-  it("normalizes status synonyms and spacing", () => {
+  it("copies description from fallback keys (notes)", () => {
+    const out = prepareTodoArguments({ operation: "write", todoList: [{ title: "X", notes: "n" }] });
+    expect(out.todoList).toEqual([{ content: "X", description: "n", status: "pending" }]);
+  });
+
+  it("normalizes status synonyms, spacing and dashes", () => {
     const out = prepareTodoArguments({
       operation: "write",
       todoList: [
-        { id: 1, title: "a", description: "a", status: "In_Progress" },
-        { id: 2, title: "b", description: "b", status: "Done" },
-        { id: 3, title: "c", description: "c", status: "doing" },
-        { id: 4, title: "d", description: "d", status: "Pending" },
-        { id: 5, title: "e", description: "e", status: "CLOSED" },
-        { id: 6, title: "f", description: "f", status: "in-progress" },
+        { content: "a", status: "In_Progress" },
+        { content: "b", status: "Done" },
+        { content: "c", status: "doing" },
+        { content: "d", status: "Pending" },
+        { content: "e", status: "CLOSED" },
+        { content: "f", status: "in-progress" },
+        { content: "g", status: "wip" },
+        { content: "h", status: "open" },
+        { content: "i" },
       ],
     });
-    const list = out.todoList as Array<Record<string, unknown>>;
-    const statuses = list.map((item) => item?.status);
-    expect(statuses).toEqual(["in-progress", "completed", "in-progress", "not-started", "completed", "in-progress"]);
-  });
-
-  it("repairs missing ids (string, null, missing) to sequential numbers", () => {
-    const out = prepareTodoArguments({
-      operation: "write",
-      todoList: [
-        { title: "a", description: "a", status: "not-started" },
-        { id: "4", title: "b", description: "b", status: "not-started" },
-        { id: null, title: "c", description: "c", status: "not-started" },
-      ],
-    });
-    const list = out.todoList as Array<Record<string, unknown>>;
-    expect(list.map((item) => item?.id)).toEqual([1, 4, 3]);
-  });
-
-  it("wraps bare-string items into full items", () => {
-    const out = prepareTodoArguments({ operation: "write", todoList: ["write tests", "deploy it"] });
-    const list = out.todoList as Array<Record<string, unknown>>;
-    expect(list).toEqual([
-      { id: 1, title: "write tests", description: "write tests", status: "not-started" },
-      { id: 2, title: "deploy it", description: "deploy it", status: "not-started" },
+    const statuses = (out.todoList as Array<Record<string, unknown>>).map((item) => item?.status);
+    expect(statuses).toEqual([
+      "in_progress",
+      "completed",
+      "in_progress",
+      "pending",
+      "completed",
+      "in_progress",
+      "in_progress",
+      "pending",
+      "pending",
     ]);
   });
 
-  it("wraps a single bare object in an array and drops extra keys (item + top level)", () => {
+  it("end-to-end: prepareTodoArguments emits operation and canonical list", () => {
     const out = prepareTodoArguments({
       operation: "write",
-      extraTop: "drop me",
-      todoList: { id: 1, title: "a", description: "a", status: "completed", fluff: true },
+      todoList: [{ content: "a", status: "pending" }, LEGACY_ITEM],
     });
     expect(out).toEqual({
       operation: "write",
-      todoList: [{ id: 1, title: "a", description: "a", status: "completed" }],
+      todoList: [
+        { content: "a", status: "pending" },
+        { content: "Fix auth", description: "Y", status: "pending" },
+      ],
     });
+  });
+
+  it("infers operation from a present list, tolerates casing, and defaults to read", () => {
+    const withList = prepareTodoArguments({ operation: "WRITE-please", todoList: ["x"] });
+    expect(withList.operation).toBe("write");
+    const inferred = prepareTodoArguments({ todoList: ["x"] });
+    expect(inferred.operation).toBe("write");
+    const read = prepareTodoArguments({});
+    expect(read).toEqual({ operation: "read" });
   });
 
   it("drops a null todoList and doesn't fabricate one", () => {
@@ -134,42 +168,94 @@ describe("prepareTodoArguments", () => {
     expect(Object.hasOwn(out, "todoList")).toBe(false);
   });
 
-  it("infers operation from a present list, tolerates casing, and defaults to read", () => {
-    const withList = prepareTodoArguments({ operation: "WRITE-please", todoList: ["x"] });
-    expect(withList.operation).toBe("write");
-    const read = prepareTodoArguments({});
-    expect(read).toEqual({ operation: "read" });
-  });
-
-  it("looks up title/description under the keys models sometimes pick", () => {
+  it("wraps a single bare object in an array and drops extra keys (item + top level)", () => {
     const out = prepareTodoArguments({
       operation: "write",
-      todoList: [{ id: 1, content: "Write the thing", details: "Long context here", status: "not-started" }],
+      extraTop: "drop me",
+      todoList: { content: "a", fluff: true, status: "completed" },
     });
-    const item = (out.todoList as Array<Record<string, unknown>>)[0];
-    expect(item).toEqual({ id: 1, title: "Write the thing", description: "Long context here", status: "not-started" });
+    expect(out).toEqual({ operation: "write", todoList: [{ content: "a", status: "completed" }] });
   });
 
   it("keeps null items null so the schema error stays meaningful", () => {
     const out = prepareTodoArguments({ operation: "write", todoList: [null, "x"] });
-    expect(out.todoList).toEqual([null, { id: 2, title: "x", description: "x", status: "not-started" }]);
+    expect(out.todoList).toEqual([null, { content: "x", status: "pending" }]);
   });
 
   it("is idempotent on repaired output", () => {
-    const parsed = parseJSON(
-      JSON.stringify({ ...REAL_MISSING_TITLE, extra: "gap", todoListX: [null] }),
-    ) as Record<string, unknown>;
-    const once = prepareTodoArguments(parsed);
-    const twice = prepareTodoArguments(once);
-    expect(twice).toEqual(once);
-  });
-
-  it("is idempotent on the real-world string + missing-title failures", () => {
     const once = prepareTodoArguments({ operation: "write", todoList: REAL_STRINGIFIED_LIST });
     expect(prepareTodoArguments(once)).toEqual(once);
-    expect(prepareTodoArguments(prepareTodoArguments(REAL_MISSING_TITLE))).toEqual(
-      prepareTodoArguments(REAL_MISSING_TITLE),
-    );
+    const legacy = prepareTodoArguments({ operation: "write", todoList: [LEGACY_ITEM] });
+    expect(prepareTodoArguments(legacy)).toEqual(legacy);
+  });
+});
+
+describe("normalizeTodoItem", () => {
+  it("returns a fresh canonical object (no id/title/description keys)", () => {
+    const out = normalizeTodoItem({ content: "Fix auth", status: "pending" }, 0);
+    expect(out).toEqual({ content: "Fix auth", status: "pending" });
+  });
+
+  it("keeps a textless item as an empty (valid-string) content item", () => {
+    expect(normalizeTodoItem({}, 0)).toEqual({ content: "", status: "pending" });
+  });
+
+  it("returns non-object items unchanged", () => {
+    expect(normalizeTodoItem(3, 0)).toBe(3);
+    expect(normalizeTodoItem("", 0)).toBe("");
+  });
+
+  it("derives content from description when only description was given", () => {
+    const desc = "Understand what c12d4a0 fixed and how the current base interacts with it";
+    const out = normalizeTodoItem({ description: desc, status: "in-progress" }, 0);
+    expect(out).toEqual({
+      content: deriveTitleFromDescription(desc),
+      description: desc,
+      status: "in_progress",
+    });
+  });
+});
+
+describe("normalizeTodoItems", () => {
+  it("returns canonical items as-is", () => {
+    expect(
+      normalizeTodoItems([
+        { content: "a", status: "pending" },
+        { content: "b", status: "in_progress" },
+      ])
+    ).toEqual([
+      { content: "a", status: "pending" },
+      { content: "b", status: "in_progress" },
+    ]);
+  });
+
+  it("normalizes legacy items", () => {
+    expect(normalizeTodoItems([LEGACY_ITEM])).toEqual([{ content: "Fix auth", description: "Y", status: "pending" }]);
+  });
+
+  it("returns [] for an empty input array", () => {
+    expect(normalizeTodoItems([])).toEqual([]);
+  });
+
+  it("returns undefined for null/undefined input", () => {
+    expect(normalizeTodoItems(null)).toBeUndefined();
+    expect(normalizeTodoItems(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when no item survives", () => {
+    expect(normalizeTodoItems([{ content: "", status: "pending" }])).toBeUndefined();
+    expect(normalizeTodoItems(["", null])).toBeUndefined();
+  });
+
+  it("wraps a single looks-like-todo object", () => {
+    expect(normalizeTodoItems({ title: "X", status: "not-started" })).toEqual([
+      { content: "X", status: "pending" },
+    ]);
+  });
+
+  it("returns undefined for unrelated values", () => {
+    expect(normalizeTodoItems(42)).toBeUndefined();
+    expect(normalizeTodoItems("a string")).toBeUndefined();
   });
 });
 
@@ -186,21 +272,3 @@ describe("deriveTitleFromDescription", () => {
     expect(title.endsWith(" ")).toBe(false);
   });
 });
-
-describe("normalizeTodoItem", () => {
-  it("keeps a textless item as an empty item", () => {
-    expect(normalizeTodoItem({}, 0)).toEqual({ id: 1, title: "", description: "", status: "not-started" });
-  });
-
-  it("returns non-object items unchanged", () => {
-    expect(normalizeTodoItem(3, 0)).toBe(3);
-    expect(normalizeTodoItem("", 0)).toBe("");
-  });
-});
-
-// ── helpers ─────────────────────────────────────────────────────────────────
-
-// Deep-clone fixture objects, mirroring how arguments arrive (post-JSON).
-function parseJSON(s: string): unknown {
-  return JSON.parse(s) as unknown;
-}

--- a/packages/todo/src/prepare-args.ts
+++ b/packages/todo/src/prepare-args.ts
@@ -14,8 +14,9 @@
  *   - `id` is invented, omitted, or nulled — the canonical schema has NO
  *     `id`; display numbering is array position, so it is stripped, not
  *     repaired
- *   - statuses come out dashed ("not-started", "in-progress") or as
- *     plain-english synonyms ("doing", "done")
+ *   - statuses come out dashed (a hyphenated variant of a canonical
+ *     value that then collapses to a no-separator form), or as plain
+ *     english synonyms ("doing", "done")
  *   - items are plain strings
  *   - stray top-level / per-item keys outside the schema
  *

--- a/packages/todo/src/prepare-args.ts
+++ b/packages/todo/src/prepare-args.ts
@@ -3,35 +3,44 @@
  *
  * Wires into the tool via `prepareArguments`, which pi runs BEFORE schema
  * validation (and before `execute`). The model occasionally sends
- * malformed-but-recoverable `manage_todo_list` arguments; observed in practice:
+ * malformed-but-recoverable `manage_todo_list` arguments; observed in
+ * practice (frozen open-weight models, ADR 0009):
  *
  *   - `todoList` is a stringified JSON array instead of an array (sometimes
- *     with mangled escaping, e.g. `"id": 1"` — an extra quote after the number)
- *   - items are missing `title` because the model considers it redundant
- *     with `description`
- *   - items are missing `status` (or it is a non-enum phrase like "doing")
+ *     with mangled escaping, e.g. `"id": 1"` — an extra quote after the
+ *     number)
+ *   - items put the task text under `title`/`step` (shapes borrowed from
+ *     other harnesses) instead of the canonical `content`
+ *   - `id` is invented, omitted, or nulled — the canonical schema has NO
+ *     `id`; display numbering is array position, so it is stripped, not
+ *     repaired
+ *   - statuses come out dashed ("not-started", "in-progress") or as
+ *     plain-english synonyms ("doing", "done")
  *   - items are plain strings
- *   - `id` missing or a numeric string
  *   - stray top-level / per-item keys outside the schema
  *
- * Only *recoverable* deviations are repaired. Anything unrecoverable is passed
- * through untouched so the standard validation error still surfaces with the
- * real complaint. The public schema stays strict; this module is purely a
- * repair layer.
+ * Only *recoverable* deviations are repaired. Anything unrecoverable is
+ * passed through untouched so the standard validation error still surfaces
+ * with the real complaint. The public schema stays strict; this module is
+ * purely a repair layer.
  */
 
 import type { ManageTodoListInput } from "./tool.js";
-import type { TodoStatus } from "./types.js";
+import type { TodoItem, TodoStatus } from "./types.js";
 
 type Record_ = Record<string, unknown>;
 
 const VALID_STATUSES: ReadonlySet<string> = new Set<string>([
-  "not-started",
-  "in-progress",
+  "pending",
+  "in_progress",
   "completed",
 ]);
 
-/** LLM synonyms for the three enum values (after case/spacing normalization). */
+/**
+ * LLM synonyms for the three enum values, keyed by the collapsed form
+ * (lowercase, all whitespace/underscore/dash separators removed) so dashed,
+ * spaced, and underscored variants all land on the same key.
+ */
 const STATUS_ALIASES: ReadonlyMap<string, TodoStatus> = new Map<string, TodoStatus>([
   ["done", "completed"],
   ["complete", "completed"],
@@ -39,28 +48,41 @@ const STATUS_ALIASES: ReadonlyMap<string, TodoStatus> = new Map<string, TodoStat
   ["closed", "completed"],
   ["success", "completed"],
   ["passed", "completed"],
-  ["doing", "in-progress"],
-  ["started", "in-progress"],
-  ["working", "in-progress"],
-  ["active", "in-progress"],
-  ["wip", "in-progress"],
-  ["ongoing", "in-progress"],
-  ["pending", "not-started"],
-  ["todo", "not-started"],
-  ["planned", "not-started"],
-  ["untouched", "not-started"],
+  ["doing", "in_progress"],
+  ["started", "in_progress"],
+  ["working", "in_progress"],
+  ["active", "in_progress"],
+  ["wip", "in_progress"],
+  ["ongoing", "in_progress"],
+  ["inprogress", "in_progress"],
+  ["pending", "pending"],
+  ["todo", "pending"],
+  ["planned", "pending"],
+  ["untouched", "pending"],
+  ["notstarted", "pending"],
+  ["unstarted", "pending"],
+  ["open", "pending"],
 ]);
 
 /**
- * Keys the model sometimes uses instead of `title`/`description`. Checked
- * only when the canonical field is itself missing, so a model that DID send
- * `title`/`description` is never overwritten.
+ * Keys the model sometimes uses instead of `content`. Checked only when
+ * `content` itself is missing/empty, so a model that DID send `content` is
+ * never overwritten.
  */
-const TITLE_FALLBACK_KEYS = ["content", "task", "text", "name", "label"] as const;
+const CONTENT_FALLBACK_KEYS = ["title", "step", "task", "text", "name", "label", "activeForm"] as const;
 const DESCRIPTION_FALLBACK_KEYS = ["details", "notes", "summary", "context"] as const;
 
-/** Upper bound for a `title` derived from `description`. */
-const DERIVED_TITLE_MAX = 60;
+/** Reserved keys the last-resort text scan must never pick up. */
+const LAST_RESORT_SKIP_KEYS = new Set<string>([
+  "content",
+  ...(CONTENT_FALLBACK_KEYS as readonly string[]),
+  "description",
+  ...(DESCRIPTION_FALLBACK_KEYS as readonly string[]),
+  "status",
+  "id",
+]);
+
+const DERIVED_CONTENT_MAX = 60;
 
 function isRecord(value: unknown): value is Record_ {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -75,58 +97,48 @@ function firstStringOf(record: Record_, keys: readonly string[]): string {
 }
 
 /**
- * Collapse whitespace and cut at a word boundary so a derived title stays a
- * short, human-readable label in the widget.
+ * Collapse whitespace and cut at a word boundary so a derived `content`
+ * stays a short, human-readable label in the widget.
  */
 export function deriveTitleFromDescription(description: string): string {
   const flat = description.replace(/\s+/g, " ").trim();
-  if (flat.length <= DERIVED_TITLE_MAX) return flat;
-  const cut = flat.slice(0, DERIVED_TITLE_MAX);
+  if (flat.length <= DERIVED_CONTENT_MAX) return flat;
+  const cut = flat.slice(0, DERIVED_CONTENT_MAX);
   const lastSpace = cut.lastIndexOf(" ");
   const head = lastSpace > 0 ? cut.slice(0, lastSpace) : cut;
   return `${head.trimEnd()}…`;
 }
 
-function normalizeId(raw: unknown, index: number): number {
-  let n: number;
-  if (typeof raw === "number") {
-    n = raw;
-  } else if (typeof raw === "string" && raw.trim() !== "") {
-    n = Number(raw);
-  } else {
-    n = Number.NaN;
-  }
-  return Number.isFinite(n) ? Math.trunc(n) : index + 1;
-}
-
-function normalizeStatus(raw: unknown): TodoStatus {
+/**
+ * Normalize a raw status to the canonical enum. Accepts dashed/spaced/
+ * underscored variants and plain-english synonyms; anything unrecognized
+ * (incl. non-strings) falls back to `"pending"`. Kept permissive — this is
+ * the REPAIR layer. `state-manager.validate()` stays canonical-strict.
+ */
+export function normalizeStatus(raw: unknown): TodoStatus {
   if (typeof raw !== "string") {
     // Missing, null, number, … — no signal about intent.
-    return "not-started";
+    return "pending";
   }
-  // "in progress" / "In_Progress" / "IN-PROGRESS" → "in-progress"
-  const normalized = raw.trim().toLowerCase().replace(/[_\s]+/g, "-");
-  if (VALID_STATUSES.has(normalized)) return normalized as TodoStatus;
-  return STATUS_ALIASES.get(normalized) ?? "not-started";
+  const s = raw.trim().toLowerCase();
+  if (VALID_STATUSES.has(s)) return s as TodoStatus;
+  const collapsed = s.replace(/[\s_-]+/g, "");
+  return STATUS_ALIASES.get(collapsed) ?? "pending";
 }
 
 /**
- * Normalize one todo item. Returns a fresh object containing ONLY the four
- * schema keys (extra keys are dropped — the schema rejects them with "must
- * not have additional properties"). Unrecoverable items are returned as-is so
- * the schema error keeps its meaning.
+ * Normalize one todo item. Returns a fresh object containing ONLY the
+ * canonical keys `{content, description?, status}` — `id` is always dropped,
+ * extra keys are dropped (the schema rejects them with "must not have
+ * additional properties"). Unrecoverable items are returned as-is so the
+ * schema error keeps its meaning.
  */
 export function normalizeTodoItem(raw: unknown, index: number): unknown {
   // Laziest form: ["write tests", "deploy"]
   if (typeof raw === "string") {
     const text = raw.trim();
     if (text === "") return raw;
-    return {
-      id: index + 1,
-      title: deriveTitleFromDescription(text),
-      description: text,
-      status: "not-started" as TodoStatus,
-    };
+    return { content: deriveTitleFromDescription(text), status: "pending" as TodoStatus };
   }
 
   if (!isRecord(raw)) return raw; // null / number / nested array → schema error
@@ -134,18 +146,61 @@ export function normalizeTodoItem(raw: unknown, index: number): unknown {
   const description =
     (typeof raw.description === "string" ? raw.description.trim() : "") ||
     firstStringOf(raw, DESCRIPTION_FALLBACK_KEYS);
-  let title = typeof raw.title === "string" ? raw.title.trim() : "";
-  if (title === "") title = firstStringOf(raw, TITLE_FALLBACK_KEYS);
-  if (title === "" && description !== "") title = deriveTitleFromDescription(description);
+  let content =
+    (typeof raw.content === "string" ? raw.content.trim() : "") ||
+    firstStringOf(raw, CONTENT_FALLBACK_KEYS);
+  if (content === "" && description !== "") {
+    content = deriveTitleFromDescription(description);
+  }
+  // Last resort: any remaining non-empty string field that isn't a known
+  // alias/status/id. This alone is the catch-all.
+  if (content === "") {
+    for (const [key, value] of Object.entries(raw)) {
+      if (!LAST_RESORT_SKIP_KEYS.has(key) && typeof value === "string" && value.trim() !== "") {
+        content = value;
+        break;
+      }
+    }
+  }
 
-  // No text at all: keep the (empty) fields so the schema error lists the
-  // missing `title`/`description` instead of masking it with a derivation.
+  // If both are empty this returns { content: "", status } — deliberately
+  // keeps an empty (valid-string) field so state-manager.validate() reports
+  // the missing `content` instead of the schema masking it.
   return {
-    id: normalizeId(raw.id, index),
-    title,
-    description: description || title,
+    content,
+    ...(description !== "" ? { description } : {}),
     status: normalizeStatus(raw.status),
   };
+}
+
+/**
+ * Normalize a raw todo list (e.g. from bus payloads) into canonical
+ * TodoItems. Returns [] for an empty input array, undefined for anything
+ * unrecoverable. Used by the bus consumer (index.ts) and the subagent
+ * stream — where prepareArguments is NOT in the call path.
+ */
+export function normalizeTodoItems(raw: unknown): TodoItem[] | undefined {
+  let list: unknown[] | undefined;
+  if (Array.isArray(raw)) {
+    list = raw;
+  } else if (raw != null && looksLikeTodoItem(raw)) {
+    list = [raw];
+  } else {
+    return undefined;
+  }
+
+  const items = list.map((item, i) => normalizeTodoItem(item, i));
+  const surviving = items.filter(
+    (item): item is TodoItem =>
+      isRecord(item) &&
+      typeof item.content === "string" &&
+      item.content.trim() !== "" &&
+      typeof item.status === "string" &&
+      VALID_STATUSES.has(item.status),
+  );
+  if (items.length === 0) return [];
+  if (surviving.length === 0) return undefined;
+  return surviving;
 }
 
 /**
@@ -171,7 +226,11 @@ function parseStringifiedList(raw: string): unknown {
 function looksLikeTodoItem(value: unknown): boolean {
   return (
     isRecord(value) &&
-    ("id" in value || "title" in value || "description" in value || "status" in value)
+    ("content" in value ||
+      "title" in value ||
+      "step" in value ||
+      "description" in value ||
+      "status" in value)
   );
 }
 

--- a/packages/todo/src/state-manager.test.ts
+++ b/packages/todo/src/state-manager.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fc from "fast-check";
 import { TodoStateManager } from "./state-manager.js";
-import type { TodoItem } from "./types.js";
+import type { TodoItem, TodoStatus } from "./types.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function makeTodo(id: number, title: string, description: string, status: TodoItem["status"]): TodoItem {
-  return { id, title, description, status };
+function makeTodo(content: string, status: TodoStatus, description?: string): TodoItem {
+  return description === undefined ? { content, status } : { content, status, description };
 }
 
 // ── TodoStateManager ────────────────────────────────────────────────────────
@@ -29,9 +29,9 @@ describe("TodoStateManager", () => {
     });
 
     it("returns copy (mutations don't affect internal state)", () => {
-      manager.write([makeTodo(1, "Test", "desc", "not-started")]);
+      manager.write([makeTodo("Task", "pending")]);
       const copy = manager.read();
-      copy.push(makeTodo(2, "Injected", "desc", "not-started"));
+      copy.push(makeTodo("Injected", "pending"));
       expect(manager.read()).toHaveLength(1);
     });
   });
@@ -39,16 +39,16 @@ describe("TodoStateManager", () => {
   describe("write", () => {
     it("stores todos correctly", () => {
       manager.write([
-        makeTodo(1, "Task 1", "desc 1", "not-started"),
-        makeTodo(2, "Task 2", "desc 2", "in-progress"),
+        makeTodo("Task 1", "pending"),
+        makeTodo("Task 2", "in_progress"),
       ]);
       expect(manager.read()).toHaveLength(2);
-      expect(manager.read()[0]?.title).toBe("Task 1");
-      expect(manager.read()[1]?.status).toBe("in-progress");
+      expect(manager.read()[0]?.content).toBe("Task 1");
+      expect(manager.read()[1]?.status).toBe("in_progress");
     });
 
     it("with all completed schedules auto-clear", () => {
-      manager.write([makeTodo(1, "Done", "desc", "completed")]);
+      manager.write([makeTodo("Done", "completed")]);
       expect(manager.read()).toHaveLength(1);
       vi.advanceTimersByTime(2000);
       expect(manager.read()).toHaveLength(0);
@@ -56,8 +56,8 @@ describe("TodoStateManager", () => {
 
     it("does not schedule auto-clear when not all completed", () => {
       manager.write([
-        makeTodo(1, "Done", "desc", "completed"),
-        makeTodo(2, "Pending", "desc", "not-started"),
+        makeTodo("Done", "completed"),
+        makeTodo("Pending", "pending"),
       ]);
       vi.advanceTimersByTime(2000);
       expect(manager.read()).toHaveLength(2);
@@ -66,25 +66,25 @@ describe("TodoStateManager", () => {
 
   describe("clear", () => {
     it("empties todos", () => {
-      manager.write([makeTodo(1, "Task", "desc", "not-started")]);
+      manager.write([makeTodo("Task", "pending")]);
       manager.clear();
       expect(manager.read()).toEqual([]);
     });
   });
 
   describe("getStats", () => {
-    it("computes correct counts", () => {
+    it("computes correct counts incl. pending", () => {
       manager.write([
-        makeTodo(1, "A", "desc", "not-started"),
-        makeTodo(2, "B", "desc", "in-progress"),
-        makeTodo(3, "C", "desc", "completed"),
-        makeTodo(4, "D", "desc", "completed"),
+        makeTodo("A", "pending"),
+        makeTodo("B", "in_progress"),
+        makeTodo("C", "completed"),
+        makeTodo("D", "completed"),
       ]);
       expect(manager.getStats()).toEqual({
         total: 4,
         completed: 2,
         inProgress: 1,
-        notStarted: 1,
+        pending: 1,
       });
     });
 
@@ -93,38 +93,56 @@ describe("TodoStateManager", () => {
         total: 0,
         completed: 0,
         inProgress: 0,
-        notStarted: 0,
+        pending: 0,
       });
     });
   });
 
   describe("validate", () => {
-    it("catches missing fields", () => {
-      const result = manager.validate([{ id: 1, title: "", description: "", status: "" } as any]);
-      expect(result.valid).toBe(false);
-      expect(result.errors.length).toBeGreaterThan(0);
-    });
-
-    it("catches invalid status values", () => {
-      const result = manager.validate([{ id: 1, title: "Test", description: "desc", status: "invalid" } as any]);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain("status");
-    });
-
-    it("catches non-array input", () => {
-      const result = manager.validate("not an array" as any);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toBe("todoList must be an array");
-    });
-
-    it("accepts valid input", () => {
+    it("accepts canonical items with optional description", () => {
       const result = manager.validate([
-        makeTodo(1, "Task", "desc", "not-started"),
-        makeTodo(2, "Task 2", "desc", "in-progress"),
-        makeTodo(3, "Task 3", "desc", "completed"),
+        { content: "Task", status: "pending" },
+        { content: "Task 2", status: "in_progress", description: "desc" },
+        { content: "Task 3", status: "completed" },
       ]);
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual([]);
+    });
+
+    it("rejects empty content", () => {
+      const result = manager.validate([{ content: "  ", status: "pending" }]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("content"))).toBe(true);
+    });
+
+    it("rejects missing content", () => {
+      const result = manager.validate([{ status: "pending" } as unknown as TodoItem]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("content"))).toBe(true);
+    });
+
+    it("rejects dashed legacy statuses (validate stays canonical-strict)", () => {
+      const result = manager.validate([{ content: "Test", status: "in-progress" } as unknown as TodoItem]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("pending, in_progress, completed"))).toBe(true);
+    });
+
+    it("rejects non-string description", () => {
+      const result = manager.validate([{ content: "x", status: "pending", description: 42 } as unknown as TodoItem]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("description"))).toBe(true);
+    });
+
+    it("rejects undefined items", () => {
+      const result = manager.validate([undefined, { content: "x", status: "pending" }] as unknown as TodoItem[]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("undefined item"))).toBe(true);
+    });
+
+    it("catches non-array input", () => {
+      const result = manager.validate("not an array" as unknown as TodoItem[]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toBe("todoList must be an array");
     });
 
     it("property: validate(write(x)).valid === true after write (round-trip)", () => {
@@ -132,15 +150,14 @@ describe("TodoStateManager", () => {
         fc.property(
           fc.array(
             fc.record({
-              id: fc.nat({ max: 1000 }),
-              title: fc.string({ minLength: 1, maxLength: 50 }),
-              description: fc.string({ minLength: 1, maxLength: 100 }),
-              status: fc.oneof(fc.constant("not-started"), fc.constant("in-progress"), fc.constant("completed")),
+              content: fc.string({ minLength: 1, maxLength: 50 }),
+              description: fc.string({ minLength: 0, maxLength: 100 }),
+              status: fc.oneof(fc.constant("pending"), fc.constant("in_progress"), fc.constant("completed")),
             }),
           ),
           (todos) => {
             const mgr = new TodoStateManager();
-            mgr.write(todos as TodoItem[]);
+            mgr.write(todos.filter((t) => t.content.trim() !== "") as TodoItem[]);
             const readTodos = mgr.read();
             const result = mgr.validate(readTodos);
             if (!result.valid) {
@@ -150,6 +167,60 @@ describe("TodoStateManager", () => {
         ),
         { verbose: false },
       );
+    });
+  });
+
+  describe("loadFromSession", () => {
+    function fakeCtx(branch: unknown[]): unknown {
+      return { sessionManager: { getBranch: () => branch } };
+    }
+
+    function toolResultEntry(details: unknown): unknown {
+      return { type: "message", message: { role: "toolResult", toolName: "manage_todo_list", details } };
+    }
+
+    it("normalizes legacy persisted items to canonical shape (id dropped)", () => {
+      const ctx = fakeCtx([
+        toolResultEntry({
+          todos: [{ id: 1, title: "Old", status: "not-started" }],
+        }),
+      ]);
+      manager.loadFromSession(ctx as never);
+      expect(manager.read()).toEqual([{ content: "Old", status: "pending" }]);
+    });
+
+    it("keeps current canonical items verbatim", () => {
+      const ctx = fakeCtx([
+        toolResultEntry({
+          todos: [
+            { content: "A", status: "in_progress" },
+            { content: "B", status: "completed", description: "d" },
+          ],
+        }),
+      ]);
+      manager.loadFromSession(ctx as never);
+      expect(manager.read()).toEqual([
+        { content: "A", status: "in_progress" },
+        { content: "B", status: "completed", description: "d" },
+      ]);
+    });
+
+    it("ignores other tools and non-message entries", () => {
+      const ctx = fakeCtx([
+        { type: "message", message: { role: "toolResult", toolName: "run_read", details: { todos: [] } } },
+        toolResultEntry({ todos: [{ content: "X", status: "pending" }] }),
+      ]);
+      manager.loadFromSession(ctx as never);
+      expect(manager.read()).toEqual([{ content: "X", status: "pending" }]);
+    });
+
+    it("ignores unrecoverable persisted entries (leaves earlier state)", () => {
+      const ctx = fakeCtx([
+        toolResultEntry({ todos: [{ content: "Good", status: "pending" }] }),
+        toolResultEntry({ todos: "a bare string" }),
+      ]);
+      manager.loadFromSession(ctx as never);
+      expect(manager.read()).toEqual([{ content: "Good", status: "pending" }]);
     });
   });
 });

--- a/packages/todo/src/state-manager.ts
+++ b/packages/todo/src/state-manager.ts
@@ -66,8 +66,9 @@ export class TodoStateManager {
       const msg = entry.message;
       if (msg.role !== "toolResult" || msg.toolName !== "manage_todo_list") continue;
       const details = msg.details as { todos?: unknown } | undefined;
-      // Legacy persisted items (id/title/not-started) and newer canonical
-      // items both go through the same normalizer. Unrecoverable entries
+      // Legacy persisted items (id / title / dashed or synonym
+      // statuses) and newer canonical items both go through the same
+      // normalizer. Unrecoverable entries
       // leave state untouched for that entry.
       const items = normalizeTodoItems(details?.todos);
       if (items) {

--- a/packages/todo/src/state-manager.ts
+++ b/packages/todo/src/state-manager.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { normalizeTodoItems } from "./prepare-args.js";
 import type { TodoItem, TodoStats, ValidationResult } from "./types.js";
 
 /** Manages the in-memory todo list state. */
@@ -27,9 +28,9 @@ export class TodoStateManager {
   getStats(): TodoStats {
     const total = this.todos.length;
     const completed = this.todos.filter((t) => t.status === "completed").length;
-    const inProgress = this.todos.filter((t) => t.status === "in-progress").length;
-    const notStarted = this.todos.filter((t) => t.status === "not-started").length;
-    return { total, completed, inProgress, notStarted };
+    const inProgress = this.todos.filter((t) => t.status === "in_progress").length;
+    const pending = this.todos.filter((t) => t.status === "pending").length;
+    return { total, completed, inProgress, pending };
   }
 
   validate(todos: TodoItem[]): ValidationResult {
@@ -37,7 +38,7 @@ export class TodoStateManager {
     if (!Array.isArray(todos)) {
       return { valid: false, errors: ["todoList must be an array"] };
     }
-    const validStatuses = new Set(["not-started", "in-progress", "completed"]);
+    const validStatuses = new Set(["pending", "in_progress", "completed"]);
     for (let i = 0; i < todos.length; i++) {
       const item = todos[i];
       const prefix = `Item ${i + 1}`;
@@ -45,19 +46,14 @@ export class TodoStateManager {
         errors.push(`${prefix}: undefined item`);
         continue;
       }
-      if (item.id == null) {
-        errors.push(`${prefix}: missing 'id'`);
-      } else if (typeof item.id !== "number") {
-        errors.push(`${prefix}: 'id' must be a number`);
+      if (typeof item.content !== "string" || item.content.trim() === "") {
+        errors.push(`${prefix}: missing or invalid 'content'`);
       }
-      if (!item.title || typeof item.title !== "string") {
-        errors.push(`${prefix}: missing or invalid 'title'`);
+      if (typeof item.status !== "string" || !validStatuses.has(item.status)) {
+        errors.push(`${prefix}: 'status' must be one of: pending, in_progress, completed`);
       }
-      if (!item.description || typeof item.description !== "string") {
-        errors.push(`${prefix}: missing or invalid 'description'`);
-      }
-      if (!item.status || !validStatuses.has(item.status)) {
-        errors.push(`${prefix}: 'status' must be one of: not-started, in-progress, completed`);
+      if (item.description !== undefined && typeof item.description !== "string") {
+        errors.push(`${prefix}: 'description' must be a string`);
       }
     }
     return { valid: errors.length === 0, errors };
@@ -69,9 +65,13 @@ export class TodoStateManager {
       if (entry.type !== "message") continue;
       const msg = entry.message;
       if (msg.role !== "toolResult" || msg.toolName !== "manage_todo_list") continue;
-      const details = msg.details as { todos?: TodoItem[] } | undefined;
-      if (details?.todos) {
-        this.todos = details.todos.map((t) => ({ ...t }));
+      const details = msg.details as { todos?: unknown } | undefined;
+      // Legacy persisted items (id/title/not-started) and newer canonical
+      // items both go through the same normalizer. Unrecoverable entries
+      // leave state untouched for that entry.
+      const items = normalizeTodoItems(details?.todos);
+      if (items) {
+        this.todos = items.map((t) => ({ ...t }));
       }
     }
   }

--- a/packages/todo/src/tool.test.ts
+++ b/packages/todo/src/tool.test.ts
@@ -19,6 +19,7 @@ const VALIDATION_ERROR_TEXT = [
 // tell apart the status colour, the glyph, and the label.
 const theme = {
   fg: (token: unknown, text: unknown) => `[${token}]${text}`,
+  strikethrough: (text: unknown) => `[s]${text}`,
 } as unknown as Theme;
 
 const tool = createManageTodoListTool(new TodoStateManager(), () => {});
@@ -72,6 +73,40 @@ describe("renderResult — harness error shapes", () => {
   });
 });
 
+describe("tool schema", () => {
+  const params = tool.parameters as unknown as {
+    properties: Record<string, { type?: string; enum?: string[]; items?: unknown }>;
+    required?: string[];
+  };
+  const itemSchema = params.properties.todoList?.items as unknown as {
+    properties: Record<string, { type?: string; enum?: string[] }>;
+    required?: string[];
+  };
+
+  it("declares content + canonical status enum, with no id/title and optional description", () => {
+    const props = itemSchema.properties;
+    expect(props.id).toBeUndefined();
+    expect(props.title).toBeUndefined();
+    expect(props.content?.type).toBe("string");
+    expect(props.status?.enum).toEqual(["pending", "in_progress", "completed"]);
+    expect(itemSchema.required).toContain("content");
+    expect(itemSchema.required).toContain("status");
+    expect(itemSchema.required).not.toContain("description");
+  });
+
+  it("keeps the manage_todo_list tool name, op and prepareArguments wiring", () => {
+    expect(tool.name).toBe("manage_todo_list");
+    expect(typeof tool.prepareArguments).toBe("function");
+    expect(params.properties.operation?.enum).toEqual(["write", "read"]);
+  });
+
+  it("model-facing description uses canonical status tokens only", () => {
+    expect(tool.description).not.toMatch(/not-started|in-progress/);
+    expect(tool.description).toContain("in_progress");
+    expect(tool.description).toContain("\"content\": \"Fix the auth middleware\"");
+  });
+});
+
 describe("renderResult — successful results unchanged", () => {
   it("renders the completed counter from details.todos", () => {
     const result = {
@@ -79,13 +114,35 @@ describe("renderResult — successful results unchanged", () => {
       details: {
         operation: "write" as const,
         todos: [
-          { id: 1, title: "a", description: "a", status: "completed" as const },
-          { id: 2, title: "b", description: "b", status: "completed" as const },
-          { id: 3, title: "c", description: "c", status: "completed" as const },
+          { content: "a", status: "completed" as const },
+          { content: "b", status: "completed" as const },
+          { content: "c", status: "completed" as const },
         ],
       },
     } as unknown as AgentToolResult<TodoDetails>;
     const [line] = renderLines(result, false).split("\n");
     expect(line).toContain("3/3 completed");
+  });
+
+  it("numbers items by array position and renders content", () => {
+    const result = {
+      content: [{ type: "text" as const, text: "1/3 completed." }],
+      details: {
+        operation: "write" as const,
+        todos: [
+          { content: "First", status: "completed" as const },
+          { content: "Second", status: "in_progress" as const },
+          { content: "Third", status: "pending" as const },
+        ],
+      },
+    } as unknown as AgentToolResult<TodoDetails>;
+    const lines = renderLines(result, true);
+    expect(lines).toContain("[accent]1.");
+    expect(lines).toContain("[accent]2.");
+    expect(lines).toContain("[accent]3.");
+    expect(lines).toContain("[s]First");
+    expect(lines).toContain("[warning]Second");
+    expect(lines).toContain("[muted]Third");
+    expect(lines).not.toContain("undefined");
   });
 });

--- a/packages/todo/src/tool.ts
+++ b/packages/todo/src/tool.ts
@@ -9,14 +9,15 @@ import { STATUS_ICONS } from "./types.js";
 import type { TodoDetails } from "./types.js";
 
 const TodoItemSchema = Type.Object({
-  id: Type.Number({ description: "Unique identifier for the todo. Use sequential numbers starting from 1." }),
-  title: Type.String({ description: "Concise action-oriented todo label (3-7 words). Displayed in UI." }),
-  description: Type.String({
-    description: "Detailed context, requirements, or implementation notes. Include file paths, specific methods, or acceptance criteria.",
+  content: Type.String({
+    description: "Short imperative label for the task (3-10 words). Displayed in UI. Example: \"Fix the auth middleware\".",
   }),
-  status: StringEnum(["not-started", "in-progress", "completed"] as const, {
-    description: "not-started: Not begun | in-progress: Currently working (multiple allowed for parallel work) | completed: Fully finished with no blockers",
+  status: StringEnum(["pending", "in_progress", "completed"] as const, {
+    description: "pending: Not begun | in_progress: Currently working (multiple allowed for parallel work/subagents) | completed: Fully finished with no blockers",
   }),
+  description: Type.Optional(Type.String({
+    description: "Optional detailed context: file paths, specific methods, or acceptance criteria.",
+  })),
 });
 
 export const ManageTodoListParams = Type.Object({
@@ -38,7 +39,7 @@ When to use this tool:
 - Complex multi-step work requiring planning and tracking
 - When user provides multiple tasks or requests (numbered, comma-separated)
 - After receiving new instructions that require multiple steps
-- BEFORE starting work on any todo (mark as in-progress)
+- BEFORE starting work on any todo (mark as in_progress)
 - IMMEDIATELY after completing each todo (mark completed individually)
 - When breaking down larger tasks into smaller actionable steps
 - To give users visibility into your progress and planning
@@ -50,14 +51,19 @@ When NOT to use:
 
 CRITICAL workflow:
 1. Plan tasks by writing todo list with specific, actionable items
-2. Mark todo(s) as in-progress before starting work
+2. Mark todo(s) as in_progress before starting work
 3. Complete the work for that specific todo
 4. Mark that todo as completed IMMEDIATELY
 5. Move to next todo and repeat
 
+Todo item shape:
+{"content": "Fix the auth middleware", "status": "pending", "description": "optional: file paths, acceptance criteria"}
+- content: the short displayed label — do NOT assign ids (numbering is order)
+- status: exactly one of pending | in_progress | completed
+
 Todo states:
-- not-started: Todo not yet begun
-- in-progress: Currently working (multiple allowed for parallel work/subagents)
+- pending: Todo not yet begun
+- in_progress: Currently working (multiple allowed for parallel work/subagents)
 - completed: Finished successfully
 
 IMPORTANT: Mark todos completed as soon as they are done. Do not batch completions.
@@ -188,21 +194,22 @@ export function createManageTodoListTool(state: TodoStateManager, onUpdate: () =
       let text = renderStatusLabel("success", label, theme);
 
       if (expanded) {
-        for (const todo of todos) {
+        for (let i = 0; i < todos.length; i++) {
+          const todo = todos[i]!;
           const iconChar = STATUS_ICONS[todo.status] ?? "?";
           const icon =
             todo.status === "completed"
               ? theme.fg("success", iconChar)
-              : todo.status === "in-progress"
+              : todo.status === "in_progress"
                 ? theme.fg("warning", iconChar)
                 : theme.fg("dim", iconChar);
           const title =
             todo.status === "completed"
-              ? theme.fg("dim", theme.strikethrough(todo.title))
-              : todo.status === "in-progress"
-                ? theme.fg("warning", todo.title)
-                : theme.fg("muted", todo.title);
-          text += `\n  ${icon} ${theme.fg("accent", `${todo.id}.`)} ${title}`;
+              ? theme.fg("dim", theme.strikethrough(todo.content ?? ""))
+              : todo.status === "in_progress"
+                ? theme.fg("warning", todo.content ?? "")
+                : theme.fg("muted", todo.content ?? "");
+          text += `\n  ${icon} ${theme.fg("accent", `${i + 1}.`)} ${title}`;
         }
       }
 

--- a/packages/todo/src/tool.ts
+++ b/packages/todo/src/tool.ts
@@ -196,7 +196,7 @@ export function createManageTodoListTool(state: TodoStateManager, onUpdate: () =
       if (expanded) {
         for (let i = 0; i < todos.length; i++) {
           const todo = todos[i]!;
-          const iconChar = STATUS_ICONS[todo.status] ?? "?";
+          const iconChar = (STATUS_ICONS[todo.status] ?? "?").trim();
           const icon =
             todo.status === "completed"
               ? theme.fg("success", iconChar)

--- a/packages/todo/src/types.ts
+++ b/packages/todo/src/types.ts
@@ -2,17 +2,15 @@
  * Core types for the todo list extension.
  */
 
-/** Status of a single todo item */
-export type TodoStatus = "not-started" | "in-progress" | "completed";
+/** Status of a single todo item (Claude Code aligned). */
+export type TodoStatus = "pending" | "in_progress" | "completed";
 
-/** A single todo item */
+/** A single todo item. No `id` — display numbering is array position. */
 export interface TodoItem {
-  /** Sequential identifier starting from 1 */
-  id: number;
-  /** Concise action-oriented label (3-7 words). Displayed in UI. */
-  title: string;
-  /** Detailed context, requirements, or implementation notes. */
-  description: string;
+  /** Short imperative label of the task (3-10 words). Displayed in UI. */
+  content: string;
+  /** Optional detailed context: file paths, methods, acceptance criteria. */
+  description?: string;
   /** Current status. */
   status: TodoStatus;
 }
@@ -29,7 +27,7 @@ export interface TodoStats {
   total: number;
   completed: number;
   inProgress: number;
-  notStarted: number;
+  pending: number;
 }
 
 /** Validation result */
@@ -40,7 +38,7 @@ export interface ValidationResult {
 
 /** Status icons for each todo state */
 export const STATUS_ICONS: Record<TodoStatus, string> = {
-  "completed": "✓",
-  "in-progress": "◉ ",
-  "not-started": "○",
+  completed: "✓",
+  in_progress: "◉ ",
+  pending: "○",
 };

--- a/packages/todo/src/ui/todo-widget.ts
+++ b/packages/todo/src/ui/todo-widget.ts
@@ -52,7 +52,9 @@ export function updateWidget(
     for (const source of sortedSources) {
       const todos = currentSub.get(source)!;
       if (todos.length > 0) {
-        const agentName = source.replace("subagent:", "");
+        // Per-child sources are subagent:<agent>:<uuid>; render only the agent
+        // name so the header stays `subagent (myagent)` regardless of suffix.
+        const agentName = source.replace("subagent:", "").split(":")[0];
         columns.push({ header: `subagent (${agentName})`, todos });
       }
     }

--- a/packages/todo/src/ui/todo-widget.ts
+++ b/packages/todo/src/ui/todo-widget.ts
@@ -103,7 +103,7 @@ export function updateWidget(
                 const todo = column.todos[todoIndex];
                 if (todo) {
                   const icon = getStatusIcon(todo.status, theme);
-                  const idStr = theme.fg("accent", `${todo.id}.`);
+                  const idStr = theme.fg("accent", `${todoIndex + 1}.`);
                   const title = formatTodoTitle(todo, theme);
                   cellText = ` ${icon} ${idStr} ${title}`;
                 } else {
@@ -142,18 +142,18 @@ export function updateWidget(
 function getStatusIcon(status: TodoItem["status"], theme: Theme): string {
   const icon = STATUS_ICONS[status] ?? "?";
   if (status === "completed") return theme.fg("success", icon);
-  if (status === "in-progress") return theme.fg("warning", icon.trim());
+  if (status === "in_progress") return theme.fg("warning", icon.trim());
   return theme.fg("dim", icon);
 }
 
 function formatTodoTitle(todo: TodoItem, theme: Theme): string {
   if (todo.status === "completed") {
-    return theme.fg("dim", theme.strikethrough(todo.title));
+    return theme.fg("dim", theme.strikethrough(todo.content ?? ""));
   }
-  if (todo.status === "in-progress") {
-    return theme.fg("warning", todo.title);
+  if (todo.status === "in_progress") {
+    return theme.fg("warning", todo.content ?? "");
   }
-  return theme.fg("muted", todo.title);
+  return theme.fg("muted", todo.content ?? "");
 }
 
 /** Clear the widget */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@pi-archimedes/core':
         specifier: workspace:*
         version: link:../core
+      '@pi-archimedes/todo':
+        specifier: workspace:*
+        version: link:../todo
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: ^0.84.2


### PR DESCRIPTION
## Summary

- **New todo item schema (Claude Code prior, ADR 0009)** — `manage_todo_list` items are now `{content, status: pending|in_progress|completed, description?}`. The model-invented `id` and `title` are dropped; display numbering is array position. Frozen open-weight models (Qwen3.x) systematically fight strict invented-id schemas, so the repair layer accepts canonical plus legacy shapes (`title`, `step`, `activeForm`, dashed/aliased statuses, bare strings, stringified/mangled-quote JSON) and normalizes them to canonical form.
- **Repair layer as single authority** — `prepare-args.ts` gains an exported `normalizeTodoItems()`; session restore (`loadFromSession`) funnels legacy persisted items through the same normalizer, so old session files keep working.
- **Bus consumer guard (todo package)** — every incoming `TODOS_UPDATE` payload is normalized before storage; unrecoverable/empty payloads are not mirrored. The widget can no longer print `undefined` titles or phantom subagent columns.
- **Subagent mirrors only accepted state** — `stream.ts` stops forwarding raw `tool_execution_start` args (pi emits those before repair/validation runs). It instead correlates by `toolCallId` and, on `tool_execution_end`, mirrors the child's accepted state: `result.details.todos` preferred, normalized stowed start-args as fallback, nothing mirrored on either error encoding (`event.isError` or `result.isError`).
- **New workspace edge `subagent → todo`** (exports map on `@pi-archimedes/todo`; release workflow already publishes todo before subagent).
- **Baseline fix** — removed dead `vitest.config.ts` from the two test-less packages (image-paste, notify) that made per-package `npx vitest run` exit 1.

Plan: `docs/plans/plan-029-todo-schema-alignment.md` · ADR: `docs/adr/0009-todo-schema-cc-alignment.md`

## Test plan

- [x] `npx tsc --noEmit` green in all 10 packages + `meta/` (11/11)
- [x] vitest green — 1196 tests (todo 64, subagent 118, core 282, mcp 490, diff 162, footer 66, ask 14)
- [x] Reviewed loops until clean (2 iterations, 3 nits fixed: icon spacing, TODOS_CLEAR source regression-guard test, AGENTS.md dep edge)
- [x] Live verification in a fresh session on this branch: child `manage_todo_list` usage mirrored into the parent todo widget via accepted state only; column dropped on child exit