### PR TITLE
Fix #36 labelText config + #34 standalone default exports

### DIFF
--- a/packages/ask/src/default-export.test.ts
+++ b/packages/ask/src/default-export.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import defaultExport from "./index.js";
+
+describe("ask default export (standalone factory)", () => {
+	it("is a function that registers the ask extension (registerAsk subscribes its own session events)", () => {
+		expect(typeof defaultExport).toBe("function");
+
+		const on = vi.fn();
+		const registerTool = vi.fn();
+		const pi = { on, registerTool } as any;
+
+		defaultExport(pi);
+
+		// ask tool registered
+		expect(registerTool).toHaveBeenCalled();
+
+		// registerAsk wires its own session lifecycle internally
+		const events = on.mock.calls.map((c: Array<unknown>) => c[0]);
+		expect(events).toEqual(
+			expect.arrayContaining(["session_start", "turn_start", "session_shutdown"]),
+		);
+	});
+});

--- a/packages/ask/src/index.ts
+++ b/packages/ask/src/index.ts
@@ -26,3 +26,12 @@ export function registerAsk(pi: ExtensionAPI) {
 		unsubscribes.length = 0;
 	});
 }
+
+// ── Default export (for standalone pi.extensions loading) ─────────────────
+
+// registerAsk already subscribes its own session_start/turn_start/
+// session_shutdown handlers internally, so the default factory just
+// registers it.
+export default function (pi: ExtensionAPI): void {
+	registerAsk(pi);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,11 +169,14 @@ export function registerCore(pi: ExtensionAPI): void {
       });
     });
 
-    // Patch thinking renderer
-    patchThinkingRenderer(() => ctx.ui.theme);
-
-    // Load config for thinking transformation
+    // Load config for thinking transformation + label overrides
     const config = loadCoreConfig();
+
+    // Patch thinking renderer
+    patchThinkingRenderer(() => ctx.ui.theme, {
+      labelText: config.labelText,
+      labelColor: config.labelColor,
+    });
 
     // Register events
     pi.on("message_end", (event, _ctx) => {

--- a/packages/core/src/thinking/patch.test.ts
+++ b/packages/core/src/thinking/patch.test.ts
@@ -272,4 +272,118 @@ describe("patchThinkingRenderer", () => {
 		// The patched function must be a new closure (not the same reference)
 		expect(MockClass.prototype.updateContent).not.toBe(first);
 	});
+
+	// ── Configurable thinking label (issue #36) ────────────────────────────
+
+	// Patches with a valid AssistantMessageComponent + mocked pi-tui so the
+	// Markdown content rendered for a thinking block can be inspected.
+	async function patchAndRender(
+		config?: { labelText?: string; labelColor?: string },
+		thinkingText = "Let me consider this carefully.",
+	) {
+		const MockClass = function AssistantMessageComponent() {};
+		MockClass.prototype.updateContent = function updateContent() {
+			if (this.content.type === "thinking") {
+				this.markdownTheme.codeBlockIndent = "";
+			}
+		};
+
+		vi.doMock("@earendil-works/pi-coding-agent", () => ({
+			AssistantMessageComponent: MockClass,
+			VERSION: "1.0.0",
+			highlightCode: vi.fn(),
+		}));
+
+		const capturedMarkdown: any[] = [];
+		class MockMarkdown {
+			content: string;
+			constructor(content: string, ..._rest: any[]) {
+				this.content = content;
+				capturedMarkdown.push(this);
+			}
+		}
+		class MockSpacer {}
+		class MockText {}
+		vi.doMock("@earendil-works/pi-tui", () => ({
+			Markdown: MockMarkdown,
+			Spacer: MockSpacer,
+			Text: MockText,
+		}));
+
+		vi.resetModules();
+		const mod = await import("./patch.js");
+		mod.patchThinkingRenderer(
+			() => ({ getFgAnsi: () => "", fg: (_t: string, text: string) => text }) as any,
+			config,
+		);
+
+		const instance = {
+			contentContainer: { clear: vi.fn(), addChild: vi.fn() },
+			isStreaming: false,
+			markdownTheme: { codeBlockIndent: "" },
+			markdownTransformers: [],
+			hideThinkingBlock: false,
+			outputPad: 1,
+		};
+		const message = {
+			content: [{ type: "thinking", thinking: thinkingText }],
+			stopReason: undefined,
+		};
+		MockClass.prototype.updateContent.call(instance, message, false);
+		return capturedMarkdown;
+	}
+
+	it("uses configured labelText/labelColor for the thinking label", async () => {
+		const captured = await patchAndRender({
+			labelText: "Yapping...",
+			labelColor: "255,215,0",
+		});
+
+		expect(captured).toHaveLength(1);
+		expect(
+			captured[0]!.content.startsWith("\x1b[1m\x1b[38;2;255;215;0mYapping...\x1b[39m\x1b[22m\n\n"),
+		).toBe(true);
+	});
+
+	it("defaults to the original Thinking... label when no config is given", async () => {
+		const captured = await patchAndRender();
+
+		expect(captured).toHaveLength(1);
+		// Byte-identical to the previous hardcoded THINKING_LABEL
+		expect(
+			captured[0]!.content.startsWith("\x1b[1m\x1b[38;2;255;215;0mThinking...\x1b[39m\x1b[22m\n\n"),
+		).toBe(true);
+	});
+
+	it("trims whitespace from configured labelText and labelColor", async () => {
+		const captured = await patchAndRender({
+			labelText: "  Yapping...  ",
+			labelColor: " 255, 215, 0 ",
+		});
+
+		expect(
+			captured[0]!.content.startsWith("\x1b[1m\x1b[38;2;255;215;0mYapping...\x1b[39m\x1b[22m\n\n"),
+		).toBe(true);
+	});
+
+	it("falls back to 255,215,0 when labelColor is not a valid RGB triple", async () => {
+		const captured = await patchAndRender({
+			labelText: "Hmm",
+			labelColor: "not-a-color",
+		});
+
+		expect(
+			captured[0]!.content.startsWith("\x1b[1m\x1b[38;2;255;215;0mHmm\x1b[39m\x1b[22m\n\n"),
+		).toBe(true);
+	});
+
+	it("does not double-prepend the label when content already starts with it", async () => {
+		const label = "\x1b[1m\x1b[38;2;255;215;0mYapping...\x1b[39m\x1b[22m";
+		const captured = await patchAndRender(
+			{ labelText: "Yapping...", labelColor: "255,215,0" },
+			`${label}\n\nAlready labelled body.`,
+		);
+
+		expect(captured[0]!.content).toBe(`${label}\n\nAlready labelled body.`);
+	});
 });

--- a/packages/core/src/thinking/patch.ts
+++ b/packages/core/src/thinking/patch.ts
@@ -3,9 +3,6 @@ import { AssistantMessageComponent, VERSION } from "@earendil-works/pi-coding-ag
 import { Markdown, type MarkdownOptions, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import { buildMutedMarkdownTheme } from "./theme.js";
 
-// The label we prepend to visible thinking content.
-const THINKING_LABEL = "\x1b[1m\x1b[38;2;255;215;0mThinking...\x1b[39m\x1b[22m";
-
 // Track which pi version we patched against to detect incompatibility
 const PATCHED_KEY = Symbol.for("archimedes:thinkingPatched");
 const PATCH_VERSION_KEY = Symbol.for("archimedes:thinkingPatchVersion");
@@ -16,8 +13,15 @@ const PATCH_VERSION_KEY = Symbol.for("archimedes:thinkingPatchVersion");
  * to capture a fresh `getTheme` closure (required for /resume).
  *
  * Re-patches when pi version changes to catch breaking upstream changes.
+ *
+ * @param config Optional labelText/labelColor overrides for the thinking
+ *   block header. When omitted (or empty/invalid), the original defaults
+ *   ("Thinking..." / "255,215,0") are used, producing byte-identical output.
  */
-export function patchThinkingRenderer(getTheme: () => Theme): void {
+export function patchThinkingRenderer(
+  getTheme: () => Theme,
+  config?: { labelText?: string; labelColor?: string },
+): void {
   if (!AssistantMessageComponent) return;
 
   const proto = AssistantMessageComponent.prototype;
@@ -83,6 +87,21 @@ export function patchThinkingRenderer(getTheme: () => Theme): void {
 
     this.markdownTheme.codeBlockIndent = "";
     this.contentContainer.clear();
+
+    // Build the thinking-block header from the closure config once per render.
+    // Defaults preserve the original byte-identical output ("Thinking..." in
+    // bold truecolor 255,215,0).
+    const buildThinkingLabel = (): string => {
+      const label = config?.labelText?.trim() ? config.labelText.trim() : "Thinking...";
+      const color = config?.labelColor?.trim() ? config.labelColor.trim() : "255,215,0";
+      const parts = color.split(",").map((p) => p.trim());
+      // Valid iff exactly three 0..255 components (an "R,G,B" triple).
+      const valid =
+        parts.length === 3 &&
+        parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
+      const [r, g, b] = valid ? parts : ["255", "215", "0"];
+      return `\x1b[1m\x1b[38;2;${r};${g};${b}m${label}\x1b[39m\x1b[22m`;
+    };
 
     const hasVisibleContent = message.content.some(
       (c: any) =>
@@ -202,8 +221,9 @@ export function patchThinkingRenderer(getTheme: () => Theme): void {
           }
         } else {
           let thinkingContent = thinkBlocks.join("\n\n");
-          if (!thinkingContent.startsWith(THINKING_LABEL)) {
-            thinkingContent = `${THINKING_LABEL}\n\n${thinkingContent}`;
+          const label = buildThinkingLabel();
+          if (!thinkingContent.startsWith(label)) {
+            thinkingContent = `${label}\n\n${thinkingContent}`;
           }
           const t = ensureTheme();
           if (!t) continue;

--- a/packages/diff/src/default-export.test.ts
+++ b/packages/diff/src/default-export.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import defaultExport from "./index.js";
+
+describe("diff default export (standalone factory)", () => {
+	it("is a function that registers diff tools on session_start with a per-session theme", () => {
+		expect(typeof defaultExport).toBe("function");
+
+		const on = vi.fn();
+		const registerTool = vi.fn();
+		const pi = { on, registerTool } as any;
+
+		defaultExport(pi);
+
+		const startHandler = on.mock.calls.find((c: Array<unknown>) => c[0] === "session_start")?.[1];
+		expect(typeof startHandler).toBe("function");
+
+		// Mirror of meta's wiring: registerDiffTools(pi, getTheme, readConfig)
+		// runs per session with the session's ctx.theme.
+		startHandler!({}, { ui: { theme: {} } });
+
+		// write/edit tool overrides registered when the SDK loaded
+		expect(registerTool).toHaveBeenCalled();
+	});
+});

--- a/packages/diff/src/index.ts
+++ b/packages/diff/src/index.ts
@@ -4,7 +4,7 @@
  * Adapted from pi-ui-hephaestus diff renderer.
  */
 
-import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import type { SettingItem } from "@earendil-works/pi-tui";
 
 import { setConfigGetter as setShikiConfig } from "./shiki.js";
@@ -121,4 +121,16 @@ export function registerDiffTools(
 
 	// Register edit tool override
 	registerEditTool(pi, cwd, home, _sdk.createEditTool);
+}
+
+// ── Default export (for standalone pi.extensions loading) ─────────────────
+
+// Diff tools need a per-session theme, so registration runs on session_start
+// (mirroring meta's wiring: registerDiffTools with a theme getter + config
+// reader). Meta supplies a settings-backed config loader; standalone uses the
+// package defaults.
+export default function (pi: ExtensionAPI): void {
+	pi.on("session_start", (_event, ctx: ExtensionContext) => {
+		registerDiffTools(pi, () => ctx.ui.theme, () => DEFAULT_DIFF_CONFIG);
+	});
 }

--- a/packages/image-paste/src/default-export.test.ts
+++ b/packages/image-paste/src/default-export.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import defaultExport from "./index.js";
+
+describe("image-paste default export (standalone factory)", () => {
+	it("is a function that registers paste + per-session lifecycle on the pi extension", () => {
+		expect(typeof defaultExport).toBe("function");
+
+		const on = vi.fn();
+		const registerShortcut = vi.fn();
+		const registerMessageRenderer = vi.fn();
+
+		const pi = { on, registerShortcut, registerMessageRenderer } as any;
+
+		defaultExport(pi);
+
+		// registerImagePaste wires the preview renderer + shortcuts
+		expect(registerMessageRenderer).toHaveBeenCalled();
+		expect(registerShortcut).toHaveBeenCalled();
+
+		// input handler (from registerImagePaste) + session lifecycle handlers
+		const events = on.mock.calls.map((c: Array<unknown>) => c[0]);
+		expect(events).toEqual(
+			expect.arrayContaining(["input", "session_start", "session_shutdown"]),
+		);
+	});
+
+	it("resets the per-session queue on session_start and clears it on shutdown", () => {
+		const on = vi.fn();
+		const pi = { on, registerShortcut: vi.fn(), registerMessageRenderer: vi.fn() } as any;
+		defaultExport(pi);
+
+		const startHandler = on.mock.calls.find((c: Array<unknown>) => c[0] === "session_start")?.[1];
+		const shutdownHandler = on.mock.calls.find((c: Array<unknown>) => c[0] === "session_shutdown")?.[1];
+		expect(typeof startHandler).toBe("function");
+		expect(typeof shutdownHandler).toBe("function");
+
+		// Must not throw when wired to a session context
+		expect(() => (startHandler as (...a: unknown[]) => unknown)({}, { hasUI: true })).not.toThrow();
+		expect(() => (shutdownHandler as (...a: unknown[]) => unknown)({}, {})).not.toThrow();
+	});
+});

--- a/packages/image-paste/src/index.ts
+++ b/packages/image-paste/src/index.ts
@@ -188,3 +188,19 @@ export function shutdownImagePaste(): void {
   _queue = null;
   _pasting = false;
 }
+
+// ── Default export (for standalone pi.extensions loading) ─────────────────
+
+// Pi's standalone loader requires a default export functioning as the
+// extension factory. Meta imports the named exports directly (register
+// + session lifecycle), so this default export is standalone-only.
+export default function (pi: ExtensionAPI): void {
+  registerImagePaste(pi);
+  // Session lifecycle: pi requires per-session ctx for image pasting.
+  pi.on("session_start", (_event, ctx) => {
+    initImagePasteSession(ctx);
+  });
+  pi.on("session_shutdown", (_event, _ctx) => {
+    shutdownImagePaste();
+  });
+}

--- a/packages/mcp/src/default-export.test.ts
+++ b/packages/mcp/src/default-export.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import defaultExport from "./index.js";
+
+describe("mcp default export (standalone factory)", () => {
+	it("is a function that registers the mcp extension (registerMcp subscribes its own session events)", () => {
+		expect(typeof defaultExport).toBe("function");
+
+		const handlers: Record<string, Array<(...args: unknown[]) => unknown>> = {};
+		const tools: Array<{ name: string }> = [];
+		const commands: Record<string, unknown> = {};
+		const pi = {
+			on: (name: string, fn: (...args: unknown[]) => unknown) => {
+				(handlers[name] ??= []).push(fn);
+			},
+			registerTool: (def: { name: string }) => {
+				tools.push(def);
+			},
+			registerCommand: (name: string, def: unknown) => {
+				commands[name] = def;
+			},
+		} as any;
+
+		defaultExport(pi);
+
+		// session lifecycle handled inside registerMcp
+		expect(handlers["session_start"]?.length).toBeGreaterThan(0);
+		expect(handlers["session_shutdown"]?.length).toBeGreaterThan(0);
+
+		// mcp proxy tool + /mcp command registered
+		expect(tools.some((t) => t.name === "mcp")).toBe(true);
+		expect(commands["mcp"]).toBeDefined();
+	});
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -144,3 +144,12 @@ export function registerMcp(pi: ExtensionAPI): void {
     }),
   });
 }
+
+// ── Default export (for standalone pi.extensions loading) ─────────────────
+
+// registerMcp subscribes its own session_start/session_shutdown handlers
+// internally (top-level, per AGENTS.md), so the default factory just
+// registers it.
+export default function (pi: ExtensionAPI): void {
+  registerMcp(pi);
+}

--- a/packages/notify/src/default-export.test.ts
+++ b/packages/notify/src/default-export.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import defaultExport from "./index.js";
+
+describe("notify default export (standalone factory)", () => {
+	it("is a function that registers the notify handlers (registerNotify subscribes its own session events)", () => {
+		expect(typeof defaultExport).toBe("function");
+
+		const on = vi.fn();
+		const pi = { on } as any;
+
+		defaultExport(pi);
+
+		const events = on.mock.calls.map((c: Array<unknown>) => c[0]);
+		expect(events).toEqual(
+			expect.arrayContaining([
+				"agent_end",
+				"input",
+				"before_agent_start",
+				"agent_start",
+				"session_start",
+				"session_shutdown",
+			]),
+		);
+	});
+});

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -213,6 +213,14 @@ export function registerNotify(pi: ExtensionAPI): void {
   });
 }
 
+// ── Default export (for standalone pi.extensions loading) ─────────────────
+
+// registerNotify subscribes its own session_start/session_shutdown (and
+// agent/input) handlers internally, so the default factory just registers it.
+export default function (pi: ExtensionAPI): void {
+  registerNotify(pi);
+}
+
 // ── Settings UI ─────────────────────────────────────────────────────────────
 
 /** Build settings UI items for the notify package. */


### PR DESCRIPTION
## Summary

Fixes two GitHub issues:

- **#36 — `labelText` not recognized (`@pi-archimedes/core`):** the thinking renderer hardcoded `"Thinking..."` and never read the user's `labelText`/`labelColor` settings. `patchThinkingRenderer` now accepts a config (`{ labelText?, labelColor? }`) and composes the label from it; the session_start wiring passes `loadCoreConfig()` into the patch. Custom colors validated (RGB triple; fallback `255,215,0`); default output byte-identical to before. 5 new tests.

- **#34 — standalone `@pi-archimedes/image-paste` fails to load:** `src/index.ts` had no default extension factory, which pi's standalone loader requires. Added default exports to **image-paste** (register + session lifecycle) **and the same bug class in ask/diff/notify/mcp** (all were standalone-installable with `pi.extensions` but no default export — registered only via meta's named imports). Follows the canonical pattern (todo/core/subagent/session-name). Each package gains a `default-export.test.ts`.

## Test plan

- [x] `npx tsc --noEmit` green in all 10 packages + `meta/` (11/11)
- [x] vitest green: core 287, diff 163, ask 15, mcp 491, footer 66 (plus new default-export tests)
- [x] Default output byte-identical for unconfigured thinking label (no regressions)