### PR TITLE
feat: sync to pi 0.84.4 — native notify triggers, typed Theme.fg

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Most question tools only work when the main agent calls them. Ask works everywhe
 
 Desktop notifications when you've stepped away — with a circuit breaker that cancels if you interact.
 
-- Delayed notification on task complete or unanswered questions
+- Delayed notification on settled tasks or when any extension prompt (ask, sudo, mcp OAuth) needs your attention
 - Terminal-aware dispatch: Ghostty, WezTerm, iTerm2, Kitty, Windows Terminal
 - tmux passthrough for all OSC sequences
 - Configurable delay and per-trigger toggles

--- a/docs/adr/0013-notify-on-pi-native-events.md
+++ b/docs/adr/0013-notify-on-pi-native-events.md
@@ -10,6 +10,6 @@ The bus `ASK_REQUEST` event is **not** retired — it remains ask↔subagent tra
 
 Consequences:
 - Notify no longer imports `@pi-archimedes/core/bus` (it keeps core for `settings-io`).
-- No `ui_prompt_end` listener, no reusing `event.title` in the copy, no kind filter: answering any prompt necessarily passes through terminal input, which already cancels the timer; the notification copy is unchanged ("A question needs your answer"); every `UIPromptKind` mid-run is a "come back" moment.
+- No reusing `event.title` in the copy, no kind filter; the notification copy is unchanged ("A question needs your answer"). A `ui_prompt_end` handler cancels the question timer when a prompt closes — needed for prompts that close without terminal input (e.g. the mcp OAuth `done()`), which the earlier "answers pass through terminal input" assumption got wrong; it is scoped so it never wipes a pending "task complete" timer.
 - Accepted edge: a user AFK on a `/mcp` panel mid-run gets a question notification — same tolerated trade as `agent_end` already made, defused by the delay and any-key cancel.
 - Asymmetric peer floors across the monorepo are deliberate: packages whose new code only needs *types* from pi (`pi-tui` floor, `Theme.fg` cleanup) stay `>=0.1.0` peers because those call sites are runtime-safe on older pi.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -34,6 +34,7 @@
 | 31 | [Plugin enable/disable via a single global gate](done/plan-031-plugin-manager.md) | ✅ COMPLETED (PR #39) | 2026-08-28 |
 | 32 | [Plugin gate in each package's own namespace](done/plan-032-gate-in-package-namespace.md) | ✅ COMPLETED (PR #39) | 2026-08-28 |
 | 30 | [archimedes-sudo — safe privileged execution](done/plan-030-archimedes-sudo.md) | ✅ COMPLETED (PR #40) | 2026-08-28 |
+| 33 | [Pi 0.84.4 sync](done/plan-033-pi-0844-sync.md) | ✅ COMPLETED (PR #42, `30e2457`) | 2026-08-28 |
 
 > **Notes:**
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.
@@ -44,13 +45,11 @@
 
 | # | Plan | Status | Created |
 |---|------|--------|---------|
-| 33 | [Pi 0.84.4 sync](plan-033-pi-0844-sync.md) | IN PROGRESS | 2026-08-28 |
-
 ## Quick Stats
 
 - Total Plans: 33
-- Completed: 32
-- In Progress: 1
+- Completed: 33
+- In Progress: 0
 - Backlog: 0
 
 > **MCP port (plans 025–027):** A three-phase port of `pi-mcp-adapter` into `@pi-archimedes/mcp`. Phase 1 = core reliability (cache, lifecycle, connection hardening); Phase 2 = OAuth (`/mcp-auth`, keyring, callback server); Phase 3 = `/mcp` command + panels. Design decisions in ADRs 0001–0003. Execute in order (026 needs 025; 027 needs both).

--- a/meta/package.json
+++ b/meta/package.json
@@ -28,8 +28,8 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/packages/ask/package.json
+++ b/packages/ask/package.json
@@ -19,8 +19,8 @@
     "typebox": ">=1.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typebox": "^1.1.38",
     "typescript": "^6.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,8 +27,8 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/packages/core/src/thinking/theme.ts
+++ b/packages/core/src/thinking/theme.ts
@@ -1,5 +1,8 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { highlightCode as piHighlightCode } from "@earendil-works/pi-coding-agent";
+import {
+  highlightCode as piHighlightCode,
+  initTheme as piInitTheme,
+} from "@earendil-works/pi-coding-agent";
 import type { MarkdownTheme } from "@earendil-works/pi-tui";
 import {
   deriveDimColor,
@@ -22,6 +25,26 @@ const DEFAULT_CODE_DEFAULT_L = 0.85;
 // We intentionally only target fg color escapes; bg (48;...) and style escapes
 // (bold/italic/reset/etc.) are left untouched.
 const FG_COLOR_ESCAPE_RE = /\x1b\[38;(?:2;\d{1,3};\d{1,3};\d{1,3}|5;\d{1,3})m/g;
+
+// pi 0.84.4's module-level `highlightCode` reads a *global* Theme
+// singleton that throws until `initTheme()` runs. pi's interactive
+// mode initializes it at startup, but contexts that build the muted
+// theme without going through that initialization (e.g. unit tests)
+// would otherwise get "Theme not initialized. Call initTheme() first."
+// We probe on first use and, only when the global is not set, call
+// `initTheme("dark")` — built-in theme, no file watcher attached.
+let piThemeReady = false;
+function ensurePiHighlightable(): void {
+  if (piThemeReady) return;
+  piThemeReady = true;
+  try {
+    piHighlightCode(""); // probe: throws when the global is unset
+  } catch (err) {
+    // Only fall back when the probe failed for the known reason, so an
+    // already-established pi theme is never clobbered by a surprise. 
+    if (String(err).includes("Theme not initialized")) piInitTheme("dark");
+  }
+}
 
 /**
  * Rewrite every foreground-color SGR escape in `line` to its dimmed truecolor
@@ -114,6 +137,7 @@ export function buildMutedMarkdownTheme(
     strikethrough: (text) => `\x1b[9m${fg("dim", text)}\x1b[29m`,
     underline: (text) => `\x1b[4m${fg("thinkingText", text)}\x1b[24m`,
     highlightCode: (code, lang) => {
+      ensurePiHighlightable();
       const lines = piHighlightCode(code, lang);
       return lines.map((l) => {
         const dimmed = dimAnsiLine(l, anchorL, saturationFactor, dimCache);

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -24,8 +24,8 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "@types/diff": "^7.0.2",
     "typescript": "^6.0.0"
   },

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -22,8 +22,8 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/packages/image-paste/package.json
+++ b/packages/image-paste/package.json
@@ -15,8 +15,8 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/packages/image-paste/src/preview.ts
+++ b/packages/image-paste/src/preview.ts
@@ -12,10 +12,6 @@ interface PreviewDetails {
 export function registerImagePreview(pi: ExtensionAPI): void {
   pi.registerMessageRenderer<PreviewDetails>(CUSTOM_TYPE, (message, _options, theme) => {
     try {
-      // Theme.fg is runtime-available but not exposed in the Theme type definition
-      const fg = (theme as any).fg?.bind(theme) as ((color: string, text: string) => string) | undefined;
-      if (!fg) return undefined;
-
       // Extract image data from content array
       const content = message.content;
       if (!Array.isArray(content) || content.length === 0) return undefined;
@@ -28,7 +24,7 @@ export function registerImagePreview(pi: ExtensionAPI): void {
           container.addChild(new Spacer(1));
           container.addChild(
             new Image(item.data, item.mimeType, {
-              fallbackColor: (text: string) => fg("toolOutput", text),
+              fallbackColor: (text: string) => theme.fg("toolOutput", text),
             }, {
               maxWidthCells: 60,
             }),

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,8 +19,8 @@
     "typebox": ">=1.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "@types/node": "^22.0.0",
     "typebox": "^1.1.38",
     "typescript": "^6.0.3"

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -11,7 +11,7 @@ Get notified when Pi finishes long tasks or needs an answer, without constant po
 - **Terminal-aware dispatch** — auto-detects your terminal and uses the optimal protocol (OSC 99, OSC 9, OSC 777, or PowerShell toasts)
 - **tmux passthrough** — all sequences wrapped via DCS for correct rendering inside tmux
 - **Per-trigger toggles** — independently enable/disable notifications for task completion and unanswered questions
-- **Bus-driven** — listens for `agent_end` and `ASK_REQUEST` bus events, so it works with any package that emits them
+- **Pi-native triggers** — keyed on pi's `agent_settled` and `ui_prompt_start` lifecycle events, so task completion works and *any* blocking extension prompt (ask, sudo, mcp OAuth) can hold your attention
 
 ## Install
 
@@ -27,7 +27,7 @@ pi install npm:pi-archimedes
 
 ## Usage
 
-When the agent finishes a task (`agent_end`) or a question is asked (`ASK_REQUEST`), a timer starts. If you don't interact for the configured delay, a desktop notification fires. Any keystroke — even just pressing a key without submitting — cancels the timer immediately.
+When the agent's run has settled (`agent_settled`) or an extension opens a blocking prompt (`ui_prompt_start` — ask, sudo, mcp OAuth), a timer starts. If you don't interact for the configured delay, a desktop notification fires. Any keystroke — even just pressing a key without submitting — cancels the timer immediately.
 
 ## Settings
 
@@ -54,6 +54,6 @@ Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.notify`
 
 ## Integration
 
-When installed via `pi-archimedes` (the meta package), the notify package is automatically registered and its settings appear in the `/archimedes` settings panel. Standalone installs work independently — any package emitting `agent_end` or `ASK_REQUEST` bus events will trigger notifications.
+When installed via `pi-archimedes` (the meta package), the notify package is automatically registered and its settings appear in the `/archimedes` settings panel. Standalone installs work independently — any blocking extension UI prompt will trigger the question notification.
 
 ← Back to [pi-archimedes](../../README.md)

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -17,7 +17,7 @@
     "@pi-archimedes/core": "workspace:*"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.1.0",
+    "@earendil-works/pi-coding-agent": ">=0.84.4",
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -21,8 +21,8 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/packages/notify/src/default-export.test.ts
+++ b/packages/notify/src/default-export.test.ts
@@ -14,6 +14,7 @@ describe("notify default export (standalone factory)", () => {
 		expect(events).toEqual(
 			expect.arrayContaining([
 				"agent_settled",
+				"ui_prompt_end",
 			"ui_prompt_start",
 				"input",
 				"before_agent_start",

--- a/packages/notify/src/default-export.test.ts
+++ b/packages/notify/src/default-export.test.ts
@@ -13,7 +13,8 @@ describe("notify default export (standalone factory)", () => {
 		const events = on.mock.calls.map((c: Array<unknown>) => c[0]);
 		expect(events).toEqual(
 			expect.arrayContaining([
-				"agent_end",
+				"agent_settled",
+			"ui_prompt_start",
 				"input",
 				"before_agent_start",
 				"agent_start",

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -1,14 +1,13 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SettingItem } from "@earendil-works/pi-tui";
 import { loadConfig, saveConfig } from "@pi-archimedes/core/settings-io";
-import { getBus, Events } from "@pi-archimedes/core/bus";
 import { execFile } from "node:child_process";
 
 // ── Trigger constants ────────────────────────────────────────────────────────
 
 const TRIGGER = {
-  AGENT_END: "agent_end",
-  ASK_REQUEST: "ask_request",
+  AGENT_SETTLED: "agent_settled",
+  UI_PROMPT: "ui_prompt",
 } as const;
 type TriggerType = (typeof TRIGGER)[keyof typeof TRIGGER];
 
@@ -153,11 +152,11 @@ export function scheduleNotify(trigger: TriggerType): void {
   // Load config fresh on each trigger
   const config = loadNotifyConfig();
 
-  if (trigger === TRIGGER.AGENT_END && !config.notifyOnAgentEnd) {
+  if (trigger === TRIGGER.AGENT_SETTLED && !config.notifyOnAgentEnd) {
     return;
   }
 
-  if (trigger === TRIGGER.ASK_REQUEST && !config.notifyOnQuestion) {
+  if (trigger === TRIGGER.UI_PROMPT && !config.notifyOnQuestion) {
     return;
   }
 
@@ -174,7 +173,7 @@ export function scheduleNotify(trigger: TriggerType): void {
 
 /** Fire the actual notification based on the pending trigger. */
 function fireNotification(trigger: TriggerType | null): void {
-  if (trigger === TRIGGER.AGENT_END) {
+  if (trigger === TRIGGER.AGENT_SETTLED) {
     notify("Pi", "Task complete — waiting for input");
   } else {
     notify("Pi", "A question needs your answer");
@@ -185,15 +184,13 @@ function fireNotification(trigger: TriggerType | null): void {
 
 /** Register the notify extension with the Pi agent. */
 export function registerNotify(pi: ExtensionAPI): void {
-  pi.on("agent_end", () => scheduleNotify(TRIGGER.AGENT_END));
+  pi.on("agent_settled", () => scheduleNotify(TRIGGER.AGENT_SETTLED));
+  // Any blocking extension UI prompt (ask, sudo, mcp OAuth) — fires in the
+  // parent process for direct and subagent-relayed prompts alike.
+  pi.on("ui_prompt_start", (_event) => scheduleNotify(TRIGGER.UI_PROMPT));
   pi.on("input", () => cancelPending());
   pi.on("before_agent_start", () => cancelPending());
   pi.on("agent_start", () => cancelPending());
-
-  // Listen for ask requests from the bus (ask package emits this)
-  const unsubAskRequest = getBus().on(Events.ASK_REQUEST, () =>
-    scheduleNotify(TRIGGER.ASK_REQUEST),
-  );
 
   // Listen for raw terminal keystrokes — cancel on any key press
   let unsubTerminalInput: (() => void) | null = null;

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -191,6 +191,15 @@ export function registerNotify(pi: ExtensionAPI): void {
   pi.on("input", () => cancelPending());
   pi.on("before_agent_start", () => cancelPending());
   pi.on("agent_start", () => cancelPending());
+  // A prompt that closes without terminal input (e.g. the mcp OAuth
+  // loader finishing from the browser's `done()`) cancels the question
+  // timer so a long-gone prompt does not fire a stale "question needs
+  // your answer". Scoped so it never wipes a pending "task complete" timer.
+  pi.on("ui_prompt_end", () => {
+    if (pendingTrigger === TRIGGER.UI_PROMPT) {
+      cancelPending();
+    }
+  });
 
   // Listen for raw terminal keystrokes — cancel on any key press
   let unsubTerminalInput: (() => void) | null = null;

--- a/packages/session-name/package.json
+++ b/packages/session-name/package.json
@@ -16,9 +16,9 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.2",
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/packages/subagent/package.json
+++ b/packages/subagent/package.json
@@ -21,9 +21,9 @@
     "typebox": ">=1.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.2",
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "@types/node": "^22.0.0",
     "typebox": "^1.1.38",
     "typescript": "^6.0.3"

--- a/packages/sudo/package.json
+++ b/packages/sudo/package.json
@@ -23,8 +23,8 @@
     "typebox": ">=1.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typebox": "^1.1.38",
     "typescript": "^6.0.0"
   },

--- a/packages/todo/package.json
+++ b/packages/todo/package.json
@@ -23,9 +23,9 @@
     "@earendil-works/pi-tui": ">=0.1.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.2",
-    "@earendil-works/pi-coding-agent": "^0.84.2",
-    "@earendil-works/pi-tui": "^0.84.2",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "typescript": "^6.0.0"
   },
   "pi": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,11 +55,11 @@ importers:
         version: link:../packages/todo
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -71,11 +71,11 @@ importers:
         version: link:../core
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typebox:
         specifier: ^1.1.38
         version: 1.1.38
@@ -86,11 +86,11 @@ importers:
   packages/core:
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -111,11 +111,11 @@ importers:
         version: 4.2.0
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       '@types/diff':
         specifier: ^7.0.2
         version: 7.0.2
@@ -130,11 +130,11 @@ importers:
         version: link:../core
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -142,11 +142,11 @@ importers:
   packages/image-paste:
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -167,11 +167,11 @@ importers:
         version: 10.2.0
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
@@ -189,11 +189,11 @@ importers:
         version: link:../core
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -205,14 +205,14 @@ importers:
         version: link:../core
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -227,14 +227,14 @@ importers:
         version: link:../todo
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
@@ -252,11 +252,11 @@ importers:
         version: link:../core
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typebox:
         specifier: ^1.1.38
         version: 1.3.7
@@ -271,14 +271,14 @@ importers:
         version: link:../core
     devDependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.84.2
-        version: 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.84.4
+        version: 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.84.2
-        version: 0.84.2
+        specifier: ^0.84.4
+        version: 0.84.4
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -399,34 +399,34 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@earendil-works/pi-agent-core@0.84.2':
-    resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
+  '@earendil-works/pi-agent-core@0.84.4':
+    resolution: {integrity: sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.84.2':
-    resolution: {integrity: sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-client@0.84.2':
-    resolution: {integrity: sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-coding-agent@0.84.2':
-    resolution: {integrity: sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==}
+  '@earendil-works/pi-ai@0.84.4':
+    resolution: {integrity: sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-protocol@0.84.2':
-    resolution: {integrity: sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ==}
+  '@earendil-works/pi-client@0.84.4':
+    resolution: {integrity: sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-telemetry@0.84.2':
-    resolution: {integrity: sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==}
+  '@earendil-works/pi-coding-agent@0.84.4':
+    resolution: {integrity: sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-protocol@0.84.4':
+    resolution: {integrity: sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-tui@0.84.2':
-    resolution: {integrity: sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==}
+  '@earendil-works/pi-telemetry@0.84.4':
+    resolution: {integrity: sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.4':
+    resolution: {integrity: sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.28.1':
@@ -754,10 +754,6 @@ packages:
 
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1486,10 +1482,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
@@ -1677,10 +1669,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1756,10 +1744,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -2381,10 +2365,10 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@earendil-works/pi-agent-core@0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-telemetry': 0.84.2
+      '@earendil-works/pi-ai': 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.4
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -2397,13 +2381,12 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@earendil-works/pi-telemetry': 0.84.2
+      '@earendil-works/pi-telemetry': 0.84.4
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
-      '@opentelemetry/api': 1.9.0
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -2418,22 +2401,21 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-client@0.84.2':
+  '@earendil-works/pi-client@0.84.4':
     dependencies:
-      '@earendil-works/pi-protocol': 0.84.2
+      '@earendil-works/pi-protocol': 0.84.4
 
-  '@earendil-works/pi-coding-agent@0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-client': 0.84.2
-      '@earendil-works/pi-protocol': 0.84.2
-      '@earendil-works/pi-tui': 0.84.2
+      '@earendil-works/pi-agent-core': 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.4(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-client': 0.84.4
+      '@earendil-works/pi-protocol': 0.84.4
+      '@earendil-works/pi-tui': 0.84.4
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
       diff: 8.0.4
-      glob: 13.0.6
       grok-mermaid: 0.2.2
       highlight.js: 10.7.3
       hosted-git-info: 9.0.3
@@ -2455,13 +2437,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-protocol@0.84.2':
+  '@earendil-works/pi-protocol@0.84.4':
     dependencies:
       typebox: 1.3.7
 
-  '@earendil-works/pi-telemetry@0.84.2': {}
+  '@earendil-works/pi-telemetry@0.84.4': {}
 
-  '@earendil-works/pi-tui@0.84.2':
+  '@earendil-works/pi-tui@0.84.4':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -2681,8 +2663,6 @@ snapshots:
       '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@nodable/entities@2.1.1': {}
-
-  '@opentelemetry/api@1.9.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -3354,12 +3334,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
   google-auth-library@10.6.2:
     dependencies:
       base64-js: 1.5.1
@@ -3548,8 +3522,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
-  minipass@7.1.3: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
@@ -3608,11 +3580,6 @@ snapshots:
   path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.5.1
-      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 


### PR DESCRIPTION
## Summary
- **notify**: re-based on pi-native lifecycle events per ADR 0013 — "Task complete — waiting for input" now fires on `agent_settled` (fully settled run, no queued continuations/compaction pending) and "A question needs your answer" fires on `ui_prompt_start` (any blocking extension UI prompt: ask direct, ask relayed from a subagent, sudo password + confirm dialog, mcp OAuth). The `ASK_REQUEST` bus listener is removed from notify (the bus event itself is untouched — it remains ask↔subagent transport). Peer floor for `pi-coding-agent` raised to `>=0.84.4`.
- **image-paste**: the `Theme.fg` `as any` runtime workaround is gone; the renderer now calls the typed `theme.fg("toolOutput", text)` directly from pi 0.84.4's exported `Theme` class. Pure type cleanup — no behavioral change; the existing `try/catch → undefined` guard stays as the runtime safety net.
- **pi dev floor**: all 12 workspace packages' `devDependencies` bumped to 0.84.4 (coding-agent, tui, and pi-ai where present).
- **core (unavoidable consequence of the floor bump)**: pi 0.84.4's module-level `highlightCode` now reads a global `Theme` singleton that throws until `initTheme()` runs — the muted-thinking renderer now lazily probes on first use and falls back to `initTheme("dark")` *only* when the probe fails with "Theme not initialized", so an already-established pi theme is never clobbered.

## Commits
- `985d7cf` chore: bump pi dev floor to 0.84.4
- `87154db` feat(notify): key triggers on pi-native agent_settled / ui_prompt_start
- `ad8acaf` fix(core): lazy-init pi 0.84.4 global theme in muted thinking renderer
- `30e2457` refactor(image-paste): use typed Theme.fg, drop any-cast workaround

Docs (ADR 0013, glossary terms, plan 033 + tracking) are already on `main` in `812a2d0`.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile updated by the floor bump)
- [ ] `npx tsc --noEmit` in all 11 `packages/*` + `meta` — 12/12 green on the branch
- [ ] `pnpm test` at repo root — 70 files / 1220 tests, all green on the branch
- [ ] `grep -rn 'pi-(coding-agent|tui|ai): "^0.84.2"' packages/*/package.json meta/package.json` — nothing (floor bump complete)
- [ ] manual: notify — run a task that completes → desktop notification on `agent_settled`; open ask, sudo password prompt, and mcp OAuth dialogs → "A question needs your answer" notification for each
- [ ] manual: image-paste — paste clipboard image in a pi session → inline preview still renders with dimmed fallback color
