### PR TITLE
fix(footer): add max entry to thinkingLevelColors

### DIFF
--- a/packages/footer/src/utils/format.test.ts
+++ b/packages/footer/src/utils/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatGitStatusIndicators,
   formatThinkingIndicator,
 } from "./format.js";
+import { thinkingLevelColors } from "./icons.js";
 import type { ColorFn } from "./icons.js";
 
 // ── Mock ColorFn ────────────────────────────────────────────────────────────
@@ -147,5 +148,10 @@ describe("formatThinkingIndicator", () => {
     expect(formatThinkingIndicator("medium", mockColor)).toBe("◐ medium");
     expect(formatThinkingIndicator("high", mockColor)).toBe("◐ high");
     expect(formatThinkingIndicator("xhigh", mockColor)).toBe("◐ xhigh");
+    expect(formatThinkingIndicator("max", mockColor)).toBe("◐ max");
+  });
+
+  it("max uses the thinkingMax theme token", () => {
+    expect(thinkingLevelColors["max"]).toBe("thinkingMax");
   });
 });

--- a/packages/footer/src/utils/icons.ts
+++ b/packages/footer/src/utils/icons.ts
@@ -31,6 +31,7 @@ export const thinkingLevelColors: Record<string, string> = {
   medium: "thinkingMedium",
   high: "thinkingHigh",
   xhigh: "thinkingXhigh",
+  max: "thinkingMax",
 };
 
 // Color function type used by formatting functions


### PR DESCRIPTION
Closes #41

Adds the missing `max` entry to `thinkingLevelColors` so the footer thinking indicator uses the theme's `thinkingMax` color instead of falling back to dim/grey at max level.

Also adds test coverage: assertion that `thinkingLevelColors[max]` is `thinkingMax` and a new `max` level in the indicator format tests.

Verified: `tsc --noEmit` and footer test suite (67 tests) pass. Safe because pi's Theme class always backfills `thinkingMax` from `thinkingXhigh` when a custom theme omits it.