### PR TITLE
feat(footer): thinking-level glyph ramp (○/◔/◐/●), off now visible

### DIFF
--- a/packages/footer/src/index.ts
+++ b/packages/footer/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * dir | branch [+status] | worktree | model | ◐thinking | ↑↓R W $cost ━ context%
+ * dir | branch [+status] | worktree | model | ◕thinking | ↑↓R W $cost ━ context%
  *
  * Adaptive layout — wraps to additional lines instead of truncating:
  * - fits width → single line (system info · stats · context bar)

--- a/packages/footer/src/utils/format.test.ts
+++ b/packages/footer/src/utils/format.test.ts
@@ -144,8 +144,8 @@ describe("formatThinkingIndicator", () => {
   it.each([
     ["minimal", "○"],
     ["low", "◔"],
-    ["medium", "◐"],
-    ["high", "●"],
+    ["medium", "◑"],
+    ["high", "◕"],
     ["xhigh", "●"],
     ["max", "●"],
   ])("renders the %s glyph", (level, glyph) => {
@@ -158,6 +158,6 @@ describe("formatThinkingIndicator", () => {
   });
 
   it("falls back for unknown levels", () => {
-    expect(formatThinkingIndicator("unknown", mockColor)).toBe("◐ unknown");
+    expect(formatThinkingIndicator("unknown", mockColor)).toBe("◑ unknown");
   });
 });

--- a/packages/footer/src/utils/format.test.ts
+++ b/packages/footer/src/utils/format.test.ts
@@ -6,7 +6,7 @@ import {
   formatGitStatusIndicators,
   formatThinkingIndicator,
 } from "./format.js";
-import type { ColorFn } from "./icons.js";
+import { thinkingLevelColors, thinkingLevelIcons, type ColorFn } from "./icons.js";
 
 // ── Mock ColorFn ────────────────────────────────────────────────────────────
 // Passthrough — we test structure, not actual coloring.
@@ -137,15 +137,27 @@ describe("formatGitStatusIndicators", () => {
 // ── formatThinkingIndicator ─────────────────────────────────────────────────
 
 describe("formatThinkingIndicator", () => {
-  it("off returns empty string", () => {
-    expect(formatThinkingIndicator("off", mockColor)).toBe("");
+  it("off renders the open circle in dim", () => {
+    expect(formatThinkingIndicator("off", mockColor)).toBe("○ off");
   });
 
-  it("other levels return indicator with level name", () => {
-    expect(formatThinkingIndicator("minimal", mockColor)).toBe("◐ minimal");
-    expect(formatThinkingIndicator("low", mockColor)).toBe("◐ low");
-    expect(formatThinkingIndicator("medium", mockColor)).toBe("◐ medium");
-    expect(formatThinkingIndicator("high", mockColor)).toBe("◐ high");
-    expect(formatThinkingIndicator("xhigh", mockColor)).toBe("◐ xhigh");
+  it.each([
+    ["minimal", "○"],
+    ["low", "◔"],
+    ["medium", "◐"],
+    ["high", "●"],
+    ["xhigh", "●"],
+    ["max", "●"],
+  ])("renders the %s glyph", (level, glyph) => {
+    expect(formatThinkingIndicator(level, mockColor)).toBe(`${glyph} ${level}`);
+  });
+
+  it("uses themed color tokens per level", () => {
+    expect(thinkingLevelColors["max"]).toBe("thinkingMax");
+    expect(thinkingLevelColors["high"]).toBe("thinkingHigh");
+  });
+
+  it("falls back for unknown levels", () => {
+    expect(formatThinkingIndicator("unknown", mockColor)).toBe("◐ unknown");
   });
 });

--- a/packages/footer/src/utils/format.ts
+++ b/packages/footer/src/utils/format.ts
@@ -1,4 +1,4 @@
-import { footerIcons, gitDisplayIcons, gitStatusColors, thinkingLevelColors, type ColorFn } from "./icons.js";
+import { footerIcons, gitDisplayIcons, gitStatusColors, thinkingLevelColors, thinkingLevelIcons, type ColorFn } from "./icons.js";
 
 // Token counts use binary units (1K = 1024)
 const TOKEN_K = 1_024;
@@ -50,5 +50,5 @@ export function formatGitStatusIndicators(
 }
 
 export function formatThinkingIndicator(thinkingLevel: string, colorize: ColorFn): string {
-  return thinkingLevel !== "off" ? colorize(thinkingLevelColors[thinkingLevel] || "dim", "◐ " + thinkingLevel) : "";
+  return colorize(thinkingLevelColors[thinkingLevel] || "dim", `${thinkingLevelIcons[thinkingLevel] || "◐"} ${thinkingLevel}`);
 }

--- a/packages/footer/src/utils/format.ts
+++ b/packages/footer/src/utils/format.ts
@@ -50,5 +50,5 @@ export function formatGitStatusIndicators(
 }
 
 export function formatThinkingIndicator(thinkingLevel: string, colorize: ColorFn): string {
-  return colorize(thinkingLevelColors[thinkingLevel] || "dim", `${thinkingLevelIcons[thinkingLevel] || "◐"} ${thinkingLevel}`);
+  return colorize(thinkingLevelColors[thinkingLevel] || "dim", `${thinkingLevelIcons[thinkingLevel] || "◑"} ${thinkingLevel}`);
 }

--- a/packages/footer/src/utils/icons.ts
+++ b/packages/footer/src/utils/icons.ts
@@ -35,13 +35,13 @@ export const thinkingLevelColors: Record<string, string> = {
 };
 
 // Thinking level glyphs — fill ramp: off/minimal open ○, low 25% ◔,
-// medium 50% ◐, high and above fully filled ● (level still labeled by text)
+// medium 50% ◑, high 75% ◕, xhigh/max fully filled ● (level labeled by text)
 export const thinkingLevelIcons: Record<string, string> = {
   off: "○",
   minimal: "○",
   low: "◔",
-  medium: "◐",
-  high: "●",
+  medium: "◑",
+  high: "◕",
   xhigh: "●",
   max: "●",
 };

--- a/packages/footer/src/utils/icons.ts
+++ b/packages/footer/src/utils/icons.ts
@@ -31,6 +31,19 @@ export const thinkingLevelColors: Record<string, string> = {
   medium: "thinkingMedium",
   high: "thinkingHigh",
   xhigh: "thinkingXhigh",
+  max: "thinkingMax",
+};
+
+// Thinking level glyphs — fill ramp: off/minimal open ○, low 25% ◔,
+// medium 50% ◐, high and above fully filled ● (level still labeled by text)
+export const thinkingLevelIcons: Record<string, string> = {
+  off: "○",
+  minimal: "○",
+  low: "◔",
+  medium: "◐",
+  high: "●",
+  xhigh: "●",
+  max: "●",
 };
 
 // Color function type used by formatting functions

--- a/packages/footer/src/utils/render-smoke.test.ts
+++ b/packages/footer/src/utils/render-smoke.test.ts
@@ -11,7 +11,7 @@ const DIR = "📁 auth";
 const BRANCH = "⎇ feat/plan-040-jwt-cookie-security+~3"; // + fake status
 const WORKTREE = "⛅ feat/plan-040-jwt-cookie-security";
 const MODEL = "🧠 claude-sonnet-4-6";
-const THINKING = "◐ high";
+const THINKING = "◕ high"; // current format for the 'high' level
 const STATS = "↑141 ↓42k R8.7M W220k $4.25 116k/977k";
 
 function buildLines(width: number, pct: number, splitThreshold = 150) {


### PR DESCRIPTION
Replaces the single hard-coded `◐` in the footer thinking indicator with a fill ramp that mirrors the view's `thinking*` color scale:

| Level | Glyph |
|---|---|
| off | ○ (open, dim) |
| minimal | ○ (open) |
| low | ◔ (25%) |
| medium | ◑ (50%) |
| high | ◕ (75%) |
| xhigh / max | ● (full) |

Also includes the `max: "thinkingMax"` color entry so the `max` level renders its themed color (overlaps with #43 in 3 lines; trivial to reconcile if that lands first).

`off` previously rendered as an empty string — it now shows the open circle like every other level.

Verified: `tsc --noEmit` and footer suite (73 tests) pass.
