### PR TITLE
fix: mcp — guard client.close() in 401 path so needs-auth state survives

### DIFF
--- a/packages/mcp/src/server-client.ts
+++ b/packages/mcp/src/server-client.ts
@@ -364,7 +364,10 @@ export class ServerClient {
           if (e instanceof StreamableHTTPError && e.code === 401) {
             const c = this.client;
             this.client = null;
-            await c.close().catch(() => {});
+            // A failed connect auto-closes the transport (SDK Client.connect())
+            // which fires onclose and may already have nulled this.client —
+            // without this guard the TypeError masked the needs-auth state.
+            if (c) await c.close().catch(() => {});
             this._status = "needs-auth";
             this._error = NEEDS_AUTH_MESSAGE;
             return;


### PR DESCRIPTION
## Summary

Fixes #46. When an OAuth-configured HTTP server returns 401 on connect, the background probe logged a TypeError instead of the intended needs-auth warning, so the user never learned to run `/mcp auth <server>`.

## Root cause

1. `client.connect(transport)` throws `StreamableHTTPError(401)` (no SDK auth provider — OAuth is app-level via `getValidToken`)
2. The SDK's `Client.connect` catch-handler auto-closes the transport (`void this.close()`) — verified in SDK 1.30.0 source
3. That close fires the registered `onclose` (from `oncloseFor`) **before the throw reaches our catch block**; the guard passes (same generation, same client) and sets `this.client = null`
4. The catch block then reads `const c = this.client` — already null — and `c.close()` throws a **synchronous** TypeError that `.catch()` cannot see
5. The TypeError propagates to the background probe (`proxy-tool.ts:517`) and the client never settles into `needs-auth`

## Fix

Null guard, matching the pattern already in `tearDownClient()` and `close()`:

```ts
const c = this.client;
this.client = null;
if (c) await c.close().catch(() => {});
```

The 401 path now settles into `needs-auth` and the probe prints the intended "requires authentication" warning.

Reviewed + verified against `@modelcontextprotocol/sdk@1.30.0` (the version ``mcp` declares).