### PR TITLE
chore: revamp READMEs — 'Pi, with the good stuff' + meta package README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Then run `/reload` in your session (or start a new one) to pick it up.
 5. **Authenticate and pick a model** (inside the Pi session):
 
    ```text
-   /login   # choose a supported provider — subscription or API key
-   /model   # select a model from your provider
+   /login
+   /model
    ```
 
-Model access comes through Pi's own providers — see Pi's [provider docs](https://pi.dev/docs/providers) for every supported provider and log in with `/login`. Archimedes doesn't ship a model of its own, and it works with whatever model your Pi account can reach. For the broader first run, Pi's [quickstart](https://pi.dev/docs/quickstart) is worth a read.
+`/login` signs you into a supported provider (subscription or API key) and `/model` selects a model from it. Model access comes through the providers you configure in Pi — Pi's [provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) list the supported ones, and Archimedes doesn't ship a model of its own. For the broader first run, Pi's [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) is worth a read.
 
 <p align="center">
   <img src="docs/images/splash-screen.png" width="600" alt="pi-archimedes splash screen">
@@ -114,11 +114,11 @@ The details are easier to catch when they're easier to read.
 
 ## A terminal worth spending your day in.
 
-[Core](packages/core/README.md) frames the editor, animates the border while the agent works, and tidies the thinking blocks — with configurable colours. The [footer](packages/footer/README.md) keeps your branch, model, context usage, and costs in view. [Paste screenshots](packages/image-paste/README.md) straight from the clipboard with inline previews.
+[Paste screenshots](packages/image-paste/README.md) with inline previews. Keep your [branch, model, context usage, and costs](packages/footer/README.md) in view. Give sessions [useful names automatically](packages/session-name/README.md) so they're easier to find later.
 
-[Session naming](packages/session-name/README.md) gives sessions useful names automatically so they're easier to find later. A small extra model call generates the title, so it's a separate (potentially billed) cost that isn't reflected in the footer's totals.
+A [framed editor](packages/core/README.md), animated working indicators, and configurable colours finish the picture. Small touches that make the whole setup feel considered.
 
-A few practical notes: image previews appear when you submit the message (the markers appear as you paste), and both image rendering and desktop alerts depend on your terminal's support — the [notify](packages/notify/README.md) and [image-paste](packages/image-paste/README.md) docs cover what each needs.
+**Practical notes:** the paste markers appear as you paste; image previews appear when you submit the message. Image rendering and desktop alerts both depend on your terminal's support — the [image-paste](packages/image-paste/README.md) and [notify](packages/notify/README.md) docs cover what each needs. Naming is a separate (potentially billed) model call, not included in the footer's totals.
 
 ---
 
@@ -200,7 +200,7 @@ pi install npm:@pi-archimedes/session-name
 
 ## Development
 
-pi-archimedes is a pnpm monorepo with no build step — Pi loads the `.ts` sources at runtime, so verification is `npx tsc --noEmit` per package, not a build.
+pi-archimedes is a pnpm monorepo with no build step — Pi loads the `.ts` sources at runtime, so verification is a type-check per package, not a build.
 
 ```
 .
@@ -208,7 +208,7 @@ pi-archimedes is a pnpm monorepo with no build step — Pi loads the `.ts` sourc
 │   ├── core/          # event bus, chrome, text/color utils, editor, thinking
 │   ├── footer/        # status bar
 │   ├── diff/          # Shiki-powered diff rendering
-│   ├── subagent/      # subagent dispatch, /agents editor
+│   ├── subagent/      # subagent dispatch (live streaming, cost tracking)
 │   ├── todo/          # todo list tool + widget
 │   ├── ask/           # structured question tool
 │   ├── mcp/           # MCP client adapter, /mcp commands
@@ -224,7 +224,8 @@ git clone https://github.com/danielcherubini/pi-archimedes.git
 cd pi-archimedes
 pnpm install            # requires pnpm ≥ 10
 pnpm test              # unit tests
-npx tsc --noEmit       # type-check (run per package directory)
+(cd packages/core && npx tsc --noEmit)
+# repeat the type-check independently in every component directory and in meta
 ```
 
 ### Local testing with Pi

--- a/README.md
+++ b/README.md
@@ -1,338 +1,244 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/splash-screen.png" width="600" alt="pi-archimedes splash screen">
+# Archimedes
+### Pi, with the good stuff.
 
-# pi-archimedes
+An extra pair of eyes on your code. Agents working in parallel. A terminal that keeps you in the loop—and looks good doing it.
 
-**The cohesive extension suite for the Pi coding agent — engineered to turn your terminal into an autonomous AI development cockpit.**
+**Archimedes brings subagents, shared task lists, MCP tools, and a polished interface to [Pi](https://github.com/earendil-works/pi). Install them together, use what you like, and make the setup yours.**
 
 [![npm version](https://img.shields.io/npm/v/pi-archimedes?style=flat-square)](https://www.npmjs.com/package/pi-archimedes)
-[![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen?style=flat-square)](https://nodejs.org)
-[![TypeScript](https://img.shields.io/badge/TypeScript-%3E%3D5.0-blue?style=flat-square)](https://www.typescriptlang.org)
+[![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.19.0-brightgreen?style=flat-square)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](LICENSE)
 
-[Quick Start](#quick-start) • [Why Archimedes?](#why-archimedes) • [Interactive Commands](#interactive-commands) • [Feature Deep Dive](#feature-deep-dive) • [Configuration](#configuration) • [Modular Packages](#modular-packages)
-
-</div>
+[Setup](#setup) • [Commands](#commands) • [Settings](#settings) • [Components](#components) • [Development](#development)
 
 ---
 
-## Why Archimedes?
+## Setup
 
-[Pi](https://github.com/earendil-works/pi) is a fast and lightweight terminal coding agent. But out of the box, extensions don't talk to each other:
-- If you dispatch a subagent, you can't see what it's doing or how many tokens it's burning.
-- When an agent needs a decision, it either guesses or dumps confusing raw text into the chat.
-- There's no built-in way to track multi-step plans across agents without losing context.
-- Terminal diffs are plain text without syntax highlighting.
-- Running `sudo` can hang your session or leak passwords into prompt history.
-- Managing MCP servers means hand-editing JSON files and restarting.
+### You already use Pi
 
-**Archimedes connects all of these pieces together into one seamless terminal experience.**
-
-Instead of installing a bunch of separate plugins that don't know the others exist, Archimedes makes them cooperate:
-- **Subagents stream live in your terminal**, and their token usage and dollar costs roll straight into your footer status bar in real time.
-- **A shared multi-column todo list** shows what your main agent and every subagent are doing side by side, and automatically dismisses itself when the work is done.
-- **Interactive questions (`ask`)**: when an agent needs clarification, it opens a clean interactive prompt right in your terminal, waits for your answer, and keeps going. Even background subagents can ask you questions without breaking execution.
-- **Full MCP management (`/mcp`)**: browse tools, toggle servers on or off, and run OAuth logins from a clean terminal UI instead of hand-editing config files.
-- **Safe sudo execution**: prompts for passwords securely with masked input, caches credentials in memory, and stops agents from hanging on raw `sudo` commands.
-- **Syntax-highlighted diffs**: split side-by-side or unified diffs powered by Shiki, with word-level highlights so you can see exactly what changed before applying edits.
-- **Polished daily details**: paste screenshots straight from your clipboard with `Ctrl+V`, watch an animated spinner on the editor border while the agent works, get a desktop notification when long tasks finish, and let AI name your sessions automatically.
-
-Everything can be toggled with `/plugins` and customized with `/archimedes`.
-
----
-
-## Quick Start
-
-### 1. Install Pi (if you haven't already)
-
-Archimedes requires [Pi](https://github.com/earendil-works/pi) and Node.js >= 22.
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install Archimedes
-
-Install the full, integrated Archimedes suite with a single command:
+One command:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-### 3. Launch
+Then run `/reload` in your session (or start a new one) to pick it up.
+
+### New to Pi
+
+1. **Node.js ≥ 22.19.0** — the requirement [Pi](https://github.com/earendil-works/pi) itself declares.
+2. **Install Pi** (shell):
+
+   ```bash
+   npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+   ```
+
+3. **Install Archimedes** (shell):
+
+   ```bash
+   pi install npm:pi-archimedes
+   ```
+
+4. **Launch** the terminal in the project you want to work on (shell):
+
+   ```bash
+   cd /path/to/your/project
+   pi
+   ```
+
+5. **Authenticate and pick a model** (inside the Pi session):
+
+   ```text
+   /login   # choose a supported provider — subscription or API key
+   /model   # select a model from your provider
+   ```
+
+Model access comes through Pi's own providers — see Pi's [provider docs](https://pi.dev/docs/providers) for every supported provider and log in with `/login`. Archimedes doesn't ship a model of its own, and it works with whatever model your Pi account can reach. For the broader first run, Pi's [quickstart](https://pi.dev/docs/quickstart) is worth a read.
+
+<p align="center">
+  <img src="docs/images/splash-screen.png" width="600" alt="pi-archimedes splash screen">
+</p>
+
+---
+
+## Give your agent some backup.
+
+Have one subagent explore the codebase while another reviews your changes. [Subagents](packages/subagent/README.md) run with your choice of models and tools, stream their progress live into your terminal, and their tasks show up side by side on the [shared todo board](packages/todo/README.md).
+
+Their token usage and costs feed into the same status bar. More work happening at once, without losing sight of it.
+
+See the [subagent guide](packages/subagent/README.md) for dispatching, agent definitions, and the `/agents` editor.
+
+<p align="center">
+  <img src="docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
+</p>
+
+<p align="center">
+  <img src="docs/images/todos-and-subagent.png" width="750" alt="Todos and subagent side-by-side">
+</p>
+
+---
+
+## Keep the decisions. Delegate the work.
+
+When a subagent needs your input, it can ask directly in your session — [ask](packages/ask/README.md) presents the question right in your terminal. Pick an option, add a note, or write your own answer. It gets your decision and carries on.
+
+You don't have to copy messages between terminals to stay involved.
+
+<p align="center">
+  <img src="docs/images/ask-subagent.png" width="750" alt="Interactive ask prompt from a subagent">
+</p>
+
+---
+
+## Bring the tools you already use.
+
+[Connect MCP servers](packages/mcp/README.md), browse their tools, and handle authentication inside Pi. Import server definitions from Cursor, Claude Code, Claude Desktop, or VS Code rather than rebuilding your setup.
+
+Start with `/mcp setup`. Manage it with `/mcp`.
+
+---
+
+## See what changed. Not just that something changed.
+
+[Syntax-highlighted diffs](packages/diff/README.md), side by side when there's room and unified when there isn't. Word-level highlights draw your eye to the changes inside each line.
+
+The details are easier to catch when they're easier to read.
+
+<p align="center">
+  <img src="docs/images/diff-edit.png" width="750" alt="Shiki syntax-highlighted split diff">
+</p>
+
+---
+
+## A terminal worth spending your day in.
+
+[Core](packages/core/README.md) frames the editor, animates the border while the agent works, and tidies the thinking blocks — with configurable colours. The [footer](packages/footer/README.md) keeps your branch, model, context usage, and costs in view. [Paste screenshots](packages/image-paste/README.md) straight from the clipboard with inline previews.
+
+[Session naming](packages/session-name/README.md) gives sessions useful names automatically so they're easier to find later. A small extra model call generates the title, so it's a separate (potentially billed) cost that isn't reflected in the footer's totals.
+
+A few practical notes: image previews appear when you submit the message (the markers appear as you paste), and both image rendering and desktop alerts depend on your terminal's support — the [notify](packages/notify/README.md) and [image-paste](packages/image-paste/README.md) docs cover what each needs.
+
+---
+
+## A little more care with root access.
+
+For tasks that need sudo, [sudo](packages/sudo/README.md) shows you the exact command and its reason before you enter your password in a masked prompt—not the chat. Credentials are cached in memory with an expiry, and `/sudo forget` clears them.
+
+## Step away without losing track.
+
+[Notify](packages/notify/README.md) alerts you when the agent finishes or a prompt needs your attention. Alerts wait before firing, and typing cancels anything pending.
+
+You can leave the terminal to do its thing.
+
+---
+
+## The whole suite. Or just your favourite parts.
+
+One install brings everything together. Switch optional extensions on or off with `/plugins`, then `/reload` to apply. Use `/archimedes` to adjust the available settings.
+
+Only want the diffs, footer, or MCP tools? Each component is available separately — see [Components](#components).
+
+---
+
+## Commands
+
+| Command | Scope | Notes |
+|---------|-------|-------|
+| `/plugins` | Suite | Toggle the ten optional extensions (core is always on and not toggleable). Toggles persist immediately; `/reload` (or a fresh session) applies them. |
+| `/archimedes` | Suite | Interactive settings panel — arrow keys change values, Enter edits supported fields, `s` saves, Esc discards the current edits. Settings captured at startup need `/reload`. Not every setting has a panel control. |
+| `/agents` | Suite, subagent enabled | Browse, create, and edit custom subagent definitions in `.pi/agents/*.md`. |
+| `/todos` | Todo component | Refreshes the todo widget and reports its status. `/todos clear` clears the list. (The board's visibility is not a `/todos` toggle — see the [todo docs](packages/todo/README.md).) |
+| `/mcp`, `/mcp setup` | MCP component | Manage servers and run logins; the setup wizard scaffolds `.mcp.json` or imports configs from Cursor, Claude Code, Claude Desktop, or VS Code. |
+| `/sudo`, `/sudo forget` | Sudo component | Inspect cached credential state; `forget` clears it. |
+| `/reload` | Pi | Applies plugin changes and settings read at startup. |
+
+---
+
+## Settings
+
+Every component keeps its own namespace under `~/.pi/agent/settings.json`, which Pi parses as **strict JSON** (no comments — unlike MCP server configs, which accept JSONC). Each component's README documents its namespace, fields, and defaults — including [core](packages/core/README.md) (chrome, spinner, thinking), [footer](packages/footer/README.md), [diff](packages/diff/README.md), [notify](packages/notify/README.md), [mcp](packages/mcp/README.md), and [sudo](packages/sudo/README.md) (also strict JSON). The `/archimedes` panel covers the settings that have a control; not everything does.
+
+---
+
+## Components
+
+| Component | npm package | What it adds |
+|-----------|-------------|--------------|
+| **Core** | [`@pi-archimedes/core`](packages/core/README.md) | Shared event bus, splash screen, framed editor, working spinner, thinking blocks |
+| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Live subagent dispatch, `/agents`, custom agent definitions |
+| **Todo** | [`@pi-archimedes/todo`](packages/todo/README.md) | Multi-column todo board with subagent columns and auto-clear |
+| **Ask** | [`@pi-archimedes/ask`](packages/ask/README.md) | Structured questions — including subagent questions relayed into your terminal |
+| **MCP** | [`@pi-archimedes/mcp`](packages/mcp/README.md) | `/mcp` management, setup wizard, OAuth, config imports |
+| **Sudo** | [`@pi-archimedes/sudo`](packages/sudo/README.md) | `sudo_exec` with masked password prompt and interactive-sudo guard |
+| **Diff** | [`@pi-archimedes/diff`](packages/diff/README.md) | Syntax-highlighted side-by-side and unified diffs with word-level highlights |
+| **Footer** | [`@pi-archimedes/footer`](packages/footer/README.md) | Branch, model, context usage, and token/cost status bar |
+| **Image Paste** | [`@pi-archimedes/image-paste`](packages/image-paste/README.md) | Clipboard image paste with inline previews |
+| **Notify** | [`@pi-archimedes/notify`](packages/notify/README.md) | Delayed desktop notifications with input cancellation |
+| **Session Name** | [`@pi-archimedes/session-name`](packages/session-name/README.md) | Automatic session titles |
+
+The full suite is the supported connected setup — the integrations above (subagent costs in the footer, subagent columns on the todo board, subagent questions in the terminal) light up when the relevant components are loaded together.
+
+To install just the components you want:
 
 ```bash
-pi
+pi install npm:@pi-archimedes/core
+pi install npm:@pi-archimedes/subagent
+pi install npm:@pi-archimedes/todo
+pi install npm:@pi-archimedes/ask
+pi install npm:@pi-archimedes/mcp
+pi install npm:@pi-archimedes/sudo
+pi install npm:@pi-archimedes/diff
+pi install npm:@pi-archimedes/footer
+pi install npm:@pi-archimedes/image-paste
+pi install npm:@pi-archimedes/notify
+pi install npm:@pi-archimedes/session-name
 ```
-
-You are immediately greeted with the Archimedes splash screen, animated working indicators, live footer status bar, and complete cockpit tooling.
-
-> [!TIP]
-> **Want only specific components?** Archimedes is completely modular. Every package can be installed standalone without the rest of the suite. See [Modular Packages](#modular-packages) below.
-
----
-
-## Interactive Commands
-
-Archimedes adds a set of dedicated TUI commands to manage your agent environment without leaving your session:
-
-| Command | Description |
-|---------|-------------|
-| `/archimedes` | Open the interactive graphical settings panel to configure themes, spinners, and thresholds. |
-| `/plugins` | Live plugin manager — toggle any of the 11 components on or off on the fly. |
-| `/mcp` | Open the Model Context Protocol management panel to browse servers, tools, and run OAuth. |
-| `/mcp setup` | Onboarding wizard to scaffold `.mcp.json` or import configs from Cursor, Claude Code, and VS Code. |
-| `/agents` | Visual CRUD manager for custom subagent personas in `.pi/agents/*.md` with model and tool pickers. |
-| `/todos` | Toggle the live multi-column todo tracking widget (`/todos clear` resets). |
-| `/sudo` | Inspect cached privileged credentials state (`/sudo forget` clears memory). |
-
----
-
-## Feature Deep Dive
-
-### 🤖 Subagents & Live Streaming ([`@pi-archimedes/subagent`](packages/subagent/README.md))
-
-Offload tasks to specialized subagents with real-time visibility. Run single tasks or parallel agents (e.g., a researcher and a reviewer working simultaneously).
-
-- **Live TUI streaming**: Watch subagent reasoning and tool calls execute in real time. Tool states are color-coded (grey while running, green on success, red on failure) with human-readable argument previews.
-- **Unified cost accounting**: Per-subagent token usage (input, output, cache read/write) and exact dollar costs flow through the core bus directly into the footer.
-- **Visual agent manager (`/agents`)**: Create and edit `.pi/agents/*.md` files with a searchable list, model selector, tool toggle picker, and cross-scope collision warnings.
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
-</div>
-
----
-
-### 📋 Coordinated Multi-Column Todo Board ([`@pi-archimedes/todo`](packages/todo/README.md))
-
-Keep long workflows on track with structured task tracking visible to both you and the LLM.
-
-- **`manage_todo_list` tool**: Read and write operations for task planning and execution tracking.
-- **Multi-column display**: Main agent tasks appear on the left; each active subagent gets its own column on the right.
-- **Auto-clearing**: When all tasks complete, the board displays a brief all-done celebration for 2 seconds and automatically dismisses itself.
-- **Session persistence**: Survives `/reload` and session branch reconstruction.
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-and-subagent.png" width="750" alt="Todos and subagent side-by-side">
-</div>
-
----
-
-### 💬 Interactive Questions (`ask`) ([`@pi-archimedes/ask`](packages/ask/README.md))
-
-Stop agents from guessing when instructions are ambiguous. When an agent or a background subagent needs clarification, `ask` presents a clean interactive prompt.
-
-- **Subagent-to-parent TUI IPC**: Most question tools fail when called from background workers. Archimedes routes subagent `ask` calls through bidirectional IPC directly into the user's terminal. The subagent pauses, you answer in the TUI, and the subagent resumes with your choice.
-- **Tabbed multi-question flows**: Review and answer multiple questions at once with keyboard navigation.
-- **Inline notes & custom responses**: Attach notes to individual options or type custom answers via automatic "Other" handling.
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/ask-subagent.png" width="750" alt="Interactive ask prompt from a subagent">
-</div>
-
----
-
-### 🔌 Enterprise-Grade MCP Client ([`@pi-archimedes/mcp`](packages/mcp/README.md))
-
-Integrate any Model Context Protocol server (stdio or HTTP/SSE) with full feature parity with dedicated MCP adapters.
-
-- **Gateway proxy + direct tools**: Call tools via the universal `mcp` gateway or register high-frequency tools directly as `{server}_{tool}` for maximum token efficiency.
-- **Management panel (`/mcp panel`)**: Live status indicators (`●` connected, `⚠` needs auth, `✗` error, `⊘` disabled, `○` cached), tool list inspection, and server toggles.
-- **Setup wizard (`/mcp setup`)**: Scaffold `.mcp.json` or auto-import existing MCP servers from Cursor (`~/.cursor/mcp.json`), Claude Code (`~/.claude.json`), Claude Desktop, and VS Code.
-- **OAuth 2.1 + PKCE**: Browser-based authentication flow with secure OS credential store persistence (macOS Keychain, Linux Secret Service, Windows Credential Manager).
-- **Metadata cache**: Offline tool search and lazy connections via `~/.pi/agent/mcp-cache.json`.
-
----
-
-### 🔐 Safe Privileged Execution (`sudo`) ([`@pi-archimedes/sudo`](packages/sudo/README.md))
-
-Run administrative tasks safely without exposing credentials or causing terminal deadlocks.
-
-- **`sudo_exec` tool**: Executes privileged commands via `sudo -S` with explicit command confirmation and human reason display.
-- **Masked password prompt**: Passwords are entered via a secure TUI mask and piped strictly over stdin — never exposed in argv, environment variables, logs, or LLM context.
-- **Active bash guard**: Automatically detects and blocks interactive `sudo` inside the standard `bash` tool, preventing agent freeze and credential leakage.
-- **In-memory cache**: Secure credential cache with a 15-minute TTL, cleared on session end, authentication failure, or `/sudo forget`. Subagents are strictly prevented from prompting for root access.
-
----
-
-### 🔍 Shiki-Powered Syntax-Highlighted Diffs ([`@pi-archimedes/diff`](packages/diff/README.md))
-
-Inspect code changes with clarity before applying them.
-
-- **Split and unified views**: Side-by-side split view or unified view, automatically adapting based on terminal width.
-- **Shiki syntax engine**: Rich highlighting matching your active Pi theme.
-- **Word-level diff emphasis**: Changed characters within modified lines are emphasized for surgical review.
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/diff-edit.png" width="750" alt="Shiki syntax-highlighted split diff">
-</div>
-
----
-
-### 📊 Adaptive Footer & Cost Tracker ([`@pi-archimedes/footer`](packages/footer/README.md))
-
-A status bar that delivers vital session context without wasting vertical screen space.
-
-- **At-a-glance context**: Current working directory, git branch, linked worktree indicator (`🌲`), active model, and thinking level.
-- **Token & cost accumulator**: Live input/output tokens, cache read/write statistics, and combined session dollar costs (including all subagent usage).
-- **Dynamic context bar**: Color-coded progress bar (green → yellow → red) showing remaining context window capacity.
-- **Adaptive layout**: Automatically wraps from one to two or three lines on narrower viewports without clipping text.
-
----
-
-### 🎬 Visual Chrome & Working Indicators ([`@pi-archimedes/core`](packages/core/README.md))
-
-- **Framed editor**: Clean borders around the input area with double-press quit guard.
-- **Border spinner**: 10 animated spinner styles running along the editor border while the agent is executing (pendulum, typing, pulse, marquee, wave, rain, sparkle), replacing Pi's native "Working" line.
-- **Muted thinking blocks**: Clean styling for chain-of-thought blocks with configurable labels and colors.
-- **Animated splash screen**: 9 configurable opening reveal animations.
-
----
-
-### 🖼️ Clipboard Image Paste ([`@pi-archimedes/image-paste`](packages/image-paste/README.md))
-
-Paste screenshots and UI mockups straight into your terminal prompt with instant inline previews:
-- Press `Ctrl+V` (Linux/macOS) or `Alt+V` (Windows) to attach clipboard images directly.
-- Built-in size guards prevent accidental multi-megabyte blowouts.
-
-> [!NOTE]
-> On Linux, clear Pi's default paste binding in `~/.pi/agent/keybindings.json` (`{ "app.clipboard.pasteImage": [] }`) so Archimedes' preview-enabled handler takes over seamlessly.
-
----
-
-### 🔔 Delayed Desktop Notifications ([`@pi-archimedes/notify`](packages/notify/README.md))
-
-Step away during long builds or model generations with peace of mind.
-- **Delayed trigger**: Alerts trigger only after 30 seconds of inactivity — never spamming you while actively typing.
-- **Keystroke circuit breaker**: Touching any key immediately cancels pending alerts.
-- **Terminal protocol support**: Native OSC 9, OSC 777, OSC 99, and PowerShell toasts with full tmux passthrough.
-
----
-
-### 🏷️ AI Session Auto-Naming ([`@pi-archimedes/session-name`](packages/session-name/README.md))
-
-Never lose track of a past session. After your first exchange, a lightweight background model call generates a concise, descriptive 3–8 word session title so you can resume sessions easily with `pi -r`. Respects manual titles set via `/name`.
-
----
-
-## Configuration
-
-### Interactive Settings Panel
-
-Run `/archimedes` at any time to open the full graphical settings dashboard. Adjust themes, spinner speeds, notification delays, and thresholds with live keyboard controls.
-
-### Plugin Manager
-
-Run `/plugins` to toggle any component on or off. Disabled plugins are cleanly unloaded on the next `/reload`.
-
-### Configuration Reference
-
-Settings are persisted in `~/.pi/agent/settings.json`:
-
-```jsonc
-{
-  // Core visual chrome
-  "archimedes.core": {
-    "editorSpinBorder": true,       // Border animation while agent is working
-    "editorSpinStyle": "pendulum",  // pendulum | typing | pulse | marquee | wave-rows | rain | sparkle
-    "editorSpinSpeed": "normal",    // slow | normal | fast
-    "editorSpinLabel": "Working",   // Label beside spinner
-    "animationStyle": "vertical-up",// Splash animation
-    "mutedTheme": false             // Subdued thinking blocks
-  },
-
-  // Footer status bar
-  "archimedes.footer": {
-    "splitThreshold": 150           // Column width threshold for single-line vs multi-line layout
-  },
-
-  // Shiki diff renderer
-  "archimedes.diff": {
-    "diffTheme": "github-dark",     // Shiki color theme
-    "diffSplitMinWidth": 150        // Minimum terminal columns for side-by-side view
-  },
-
-  // Desktop notifications
-  "archimedes.notify": {
-    "notifyOnAgentEnd": true,
-    "notifyOnQuestion": true,
-    "delayMs": 30000                // Inactivity delay before alerting
-  },
-
-  // MCP Adapter
-  "archimedes.mcp": {
-    "directTools": true,            // Expose {server}_{tool} direct tool definitions
-    "idleTimeout": 10,              // Minutes before idling MCP connections close
-    "autoAuth": false               // Inline OAuth prompt on needs-auth servers
-  },
-
-  // Sudo privilege execution
-  "archimedes.sudo": {
-    "ttlMs": 900000,                // Password cache lifetime (15 minutes)
-    "defaultTimeoutMs": 120000      // Execution timeout per command
-  }
-}
-```
-
----
-
-## Modular Packages
-
-Prefer to cherry-pick? Every component in Archimedes is published as an independent, standalone package:
-
-| Package | npm | Description |
-|---------|-----|-------------|
-| **Core** | [`@pi-archimedes/core`](packages/core/README.md) | Event bus, animated splash screen, framed editor, working spinner |
-| **Footer** | [`@pi-archimedes/footer`](packages/footer/README.md) | Status bar, token counters, real-dollar costs, context window bar |
-| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Subagent dispatch, live streaming, parallel execution, `/agents` TUI |
-| **Todo** | [`@pi-archimedes/todo`](packages/todo/README.md) | Multi-column todo widget with auto-clearing and subagent tracking |
-| **Ask** | [`@pi-archimedes/ask`](packages/ask/README.md) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
-| **MCP** | [`@pi-archimedes/mcp`](packages/mcp/README.md) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |
-| **Sudo** | [`@pi-archimedes/sudo`](packages/sudo/README.md) | Safe `sudo_exec`, masked password prompt, bash interactive guard |
-| **Diff** | [`@pi-archimedes/diff`](packages/diff/README.md) | Shiki-highlighted side-by-side and unified terminal diffs |
-| **Image Paste** | [`@pi-archimedes/image-paste`](packages/image-paste/README.md) | Direct clipboard screenshot paste (`Ctrl+V`) with inline previews |
-| **Notify** | [`@pi-archimedes/notify`](packages/notify/README.md) | Inactivity-delayed desktop alerts with keystroke circuit breaker |
-| **Session Name** | [`@pi-archimedes/session-name`](packages/session-name/README.md) | Automated AI session title generator after first conversation turn |
-
-To install an individual component:
-
-```bash
-pi install npm:@pi-archimedes/<package-name>
-```
-
-> [!IMPORTANT]
-> When installed via the full `pi-archimedes` meta package, all components connect to the shared core bus — enabling subagent costs in the footer, subagent columns in the todo board, subagent question prompts in the TUI, and coordinated theme styling.
 
 ---
 
 ## Development
 
-pi-archimedes is structured as a pnpm monorepo.
+pi-archimedes is a pnpm monorepo with no build step — Pi loads the `.ts` sources at runtime, so verification is `npx tsc --noEmit` per package, not a build.
+
+```
+.
+├── packages/
+│   ├── core/          # event bus, chrome, text/color utils, editor, thinking
+│   ├── footer/        # status bar
+│   ├── diff/          # Shiki-powered diff rendering
+│   ├── subagent/      # subagent dispatch, /agents editor
+│   ├── todo/          # todo list tool + widget
+│   ├── ask/           # structured question tool
+│   ├── mcp/           # MCP client adapter, /mcp commands
+│   ├── sudo/          # sudo_exec tool + guards
+│   ├── image-paste/   # clipboard image paste
+│   ├── notify/        # delayed desktop notifications
+│   └── session-name/  # auto session naming
+└── meta/              # the pi-archimedes orchestrator (depends on all eleven)
+```
 
 ```bash
-# Clone the repository
 git clone https://github.com/danielcherubini/pi-archimedes.git
 cd pi-archimedes
-
-# Install dependencies (requires pnpm >= 10)
-pnpm install
-
-# Type-check all packages
-pnpm -r exec -- tsc --noEmit
-
-# Run unit tests
-pnpm test
+pnpm install            # requires pnpm ≥ 10
+pnpm test              # unit tests
+npx tsc --noEmit       # type-check (run per package directory)
 ```
 
-### Local Testing with Pi
+### Local testing with Pi
 
-To test your local build inside Pi, symlink the repository directly into Pi's extensions directory:
+The monorepo root is itself the Pi package — but create the extensions directory first:
 
 ```bash
-ln -s $(pwd) ~/.pi/agent/extensions/pi-archimedes
+mkdir -p ~/.pi/agent/extensions
+ln -s "$(pwd)" ~/.pi/agent/extensions/pi-archimedes
 ```
 
-Pi's extension loader automatically picks up `meta/src/index.ts` from the root `package.json`.
+Pi's extension loader picks up `meta/src/index.ts` through the root `package.json`.
 
-For contribution conventions, architecture decisions, and release workflows, see [AGENTS.md](AGENTS.md).
+> [!WARNING]
+> Don't run the local symlink and an npm copy of the suite at the same time (`pi install npm:pi-archimedes`) — you'd double-register the components. Remove one before loading the other: `pi remove npm:pi-archimedes`, or delete the symlink.
+
+For conventions, architecture decisions, and the release workflow, see [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -18,24 +18,26 @@
 
 ## Why Archimedes?
 
-[Pi](https://github.com/earendil-works/pi) is a fast, hackable, and lightweight coding agent harness for the terminal. But out of the box, extensions operate in silos:
-- Subagents execute blindly as black boxes, burning tokens invisible to your status bar.
-- Long-running tasks have no shared progress tracking.
-- Clarification questions break agent loops or force clumsy terminal hacks.
-- Reviewing diffs in plain text causes subtle regressions.
-- Privileged commands risk terminal hangs or leaked credentials.
+[Pi](https://github.com/earendil-works/pi) is a fast and lightweight terminal coding agent. But out of the box, extensions don't talk to each other:
+- If you dispatch a subagent, you can't see what it's doing or how many tokens it's burning.
+- When an agent needs a decision, it either guesses or dumps confusing raw text into the chat.
+- There's no built-in way to track multi-step plans across agents without losing context.
+- Terminal diffs are plain text without syntax highlighting.
+- Running `sudo` can hang your session or leak passwords into prompt history.
+- Managing MCP servers means hand-editing JSON files and restarting.
 
-**pi-archimedes transforms Pi from a raw agent runner into a cohesive, production-grade development cockpit.**
+**Archimedes connects all of these pieces together into one seamless terminal experience.**
 
-Instead of eleven disjointed plugins that fight for terminal real estate, Archimedes functions as a **single, reactive nervous system**:
-- **Cooperative Event Bus**: Subagent tool calls and real-dollar costs flow directly into your footer status bar in real time.
-- **Shared Multi-Column Todo Board**: The main agent and every spawned subagent report tasks side by side, automatically clearing when done.
-- **Bidirectional Human-in-the-Loop (`ask`)**: When a background subagent needs a critical decision, it surfaces an interactive multi-tab prompt in your TUI over IPC and resumes the moment you answer.
-- **First-Class MCP Experience**: Connect, inspect, authenticate (OAuth 2.1 PKCE), and toggle Model Context Protocol servers through a dedicated interactive TUI overlay (`/mcp`).
-- **Safe Privileged Execution**: Run root commands with masked interactive password prompts, strictly scoped process-group timeouts, and a bash guard that prevents the agent from hanging on unprotected `sudo`.
-- **Obsessive Visual Polish**: Shiki syntax-highlighted side-by-side diffs, border spinners while the agent works, clipboard image pasting (`Ctrl+V`), and desktop notifications when tasks finish.
+Instead of installing a bunch of separate plugins that don't know the others exist, Archimedes makes them cooperate:
+- **Subagents stream live in your terminal**, and their token usage and dollar costs roll straight into your footer status bar in real time.
+- **A shared multi-column todo list** shows what your main agent and every subagent are doing side by side, and automatically dismisses itself when the work is done.
+- **Interactive questions (`ask`)**: when an agent needs clarification, it opens a clean interactive prompt right in your terminal, waits for your answer, and keeps going. Even background subagents can ask you questions without breaking execution.
+- **Full MCP management (`/mcp`)**: browse tools, toggle servers on or off, and run OAuth logins from a clean terminal UI instead of hand-editing config files.
+- **Safe sudo execution**: prompts for passwords securely with masked input, caches credentials in memory, and stops agents from hanging on raw `sudo` commands.
+- **Syntax-highlighted diffs**: split side-by-side or unified diffs powered by Shiki, with word-level highlights so you can see exactly what changed before applying edits.
+- **Polished daily details**: paste screenshots straight from your clipboard with `Ctrl+V`, watch an animated spinner on the editor border while the agent works, get a desktop notification when long tasks finish, and let AI name your sessions automatically.
 
-Everything is toggleable, theme-aware, and built to be lived in.
+Everything can be toggled with `/plugins` and customized with `/archimedes`.
 
 ---
 
@@ -88,9 +90,9 @@ Archimedes adds a set of dedicated TUI commands to manage your agent environment
 
 ## Feature Deep Dive
 
-### 🤖 Subagent Swarms & Live Streaming ([`@pi-archimedes/subagent`](packages/subagent/README.md))
+### 🤖 Subagents & Live Streaming ([`@pi-archimedes/subagent`](packages/subagent/README.md))
 
-Offload tasks to specialized subagents with real-time visibility. Run single subagents or parallel swarms (e.g., a researcher and a reviewer working simultaneously).
+Offload tasks to specialized subagents with real-time visibility. Run single tasks or parallel agents (e.g., a researcher and a reviewer working simultaneously).
 
 - **Live TUI streaming**: Watch subagent reasoning and tool calls execute in real time. Tool states are color-coded (grey while running, green on success, red on failure) with human-readable argument previews.
 - **Unified cost accounting**: Per-subagent token usage (input, output, cache read/write) and exact dollar costs flow through the core bus directly into the footer.
@@ -117,9 +119,9 @@ Keep long workflows on track with structured task tracking visible to both you a
 
 ---
 
-### 💬 Bidirectional Human-in-the-Loop (`ask`) ([`@pi-archimedes/ask`](packages/ask/README.md))
+### 💬 Interactive Questions (`ask`) ([`@pi-archimedes/ask`](packages/ask/README.md))
 
-Eliminate ambiguous back-and-forth guessing. When an agent or a background subagent needs human guidance, `ask` presents an interactive, structured question flow.
+Stop agents from guessing when instructions are ambiguous. When an agent or a background subagent needs clarification, `ask` presents a clean interactive prompt.
 
 - **Subagent-to-parent TUI IPC**: Most question tools fail when called from background workers. Archimedes routes subagent `ask` calls through bidirectional IPC directly into the user's terminal. The subagent pauses, you answer in the TUI, and the subagent resumes with your choice.
 - **Tabbed multi-question flows**: Review and answer multiple questions at once with keyboard navigation.
@@ -283,7 +285,7 @@ Prefer to cherry-pick? Every component in Archimedes is published as an independ
 |---------|-----|-------------|
 | **Core** | [`@pi-archimedes/core`](packages/core/README.md) | Event bus, animated splash screen, framed editor, working spinner |
 | **Footer** | [`@pi-archimedes/footer`](packages/footer/README.md) | Status bar, token counters, real-dollar costs, context window bar |
-| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Subagent dispatch, live streaming, parallel swarms, `/agents` TUI |
+| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Subagent dispatch, live streaming, parallel execution, `/agents` TUI |
 | **Todo** | [`@pi-archimedes/todo`](packages/todo/README.md) | Multi-column todo widget with auto-clearing and subagent tracking |
 | **Ask** | [`@pi-archimedes/ask`](packages/ask/README.md) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
 | **MCP** | [`@pi-archimedes/mcp`](packages/mcp/README.md) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Only want the diffs, footer, or MCP tools? Each component is available separatel
 | Command | Scope | Notes |
 |---------|-------|-------|
 | `/plugins` | Suite | Toggle the ten optional extensions (core is always on and not toggleable). Toggles persist immediately; `/reload` (or a fresh session) applies them. |
-| `/archimedes` | Suite | Interactive settings panel — arrow keys change values, Enter edits supported fields, `s` saves, Esc discards the current edits. Settings captured at startup need `/reload`. Not every setting has a panel control. |
+| `/archimedes` | Suite | Interactive settings panel — up/down moves, left/right changes values, Enter edits supported fields, `s` saves, Esc discards the current edits. Settings captured at startup need `/reload`. Not every setting has a panel control. |
 | `/agents` | Suite, subagent enabled | Browse, create, and edit custom subagent definitions in `.pi/agents/*.md`. |
 | `/todos` | Todo component | Refreshes the todo widget and reports its status. `/todos clear` clears the list. (The board's visibility is not a `/todos` toggle — see the [todo docs](packages/todo/README.md).) |
 | `/mcp`, `/mcp setup` | MCP component | Manage servers and run logins; the setup wizard scaffolds `.mcp.json` or imports configs from Cursor, Claude Code, Claude Desktop, or VS Code. |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Every component keeps its own namespace under `~/.pi/agent/settings.json`, which
 | Component | npm package | What it adds |
 |-----------|-------------|--------------|
 | **Core** | [`@pi-archimedes/core`](packages/core/README.md) | Shared event bus, splash screen, framed editor, working spinner, thinking blocks |
-| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Live subagent dispatch, `/agents`, custom agent definitions |
+| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Live subagent dispatch, custom agent definitions; `/agents` editor with the suite |
 | **Todo** | [`@pi-archimedes/todo`](packages/todo/README.md) | Multi-column todo board with subagent columns and auto-clear |
 | **Ask** | [`@pi-archimedes/ask`](packages/ask/README.md) | Structured questions — including subagent questions relayed into your terminal |
 | **MCP** | [`@pi-archimedes/mcp`](packages/mcp/README.md) | `/mcp` management, setup wizard, OAuth, config imports |

--- a/README.md
+++ b/README.md
@@ -223,9 +223,13 @@ pi-archimedes is a pnpm monorepo with no build step — Pi loads the `.ts` sourc
 git clone https://github.com/danielcherubini/pi-archimedes.git
 cd pi-archimedes
 pnpm install            # requires pnpm ≥ 10
-pnpm test              # unit tests
+
+# Verification: type-check each package, independently —
+# tsc --noEmit in every component directory and in meta (wait for each)
 (cd packages/core && npx tsc --noEmit)
-# repeat the type-check independently in every component directory and in meta
+
+# Then the full test suite (1300+ tests):
+pnpm test
 ```
 
 ### Local testing with Pi

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -36,6 +36,7 @@
 | 30 | [archimedes-sudo — safe privileged execution](done/plan-030-archimedes-sudo.md) | ✅ COMPLETED (PR #40) | 2026-08-28 |
 | 33 | [Pi 0.84.4 sync](done/plan-033-pi-0844-sync.md) | ✅ COMPLETED (PR #42, `30e2457`) | 2026-08-28 |
 | 34 | [Prompt-slot spinner (border spinner, 10 styles)](../adr/0014-prompt-slot-spinner.md) | ✅ COMPLETED (PR #48) | 2026-09-07 |
+| 35 | [README copy — Pi, with the good stuff](plan-035-readme-copy.md) | ✅ COMPLETED (PR #49) | 2026-09-11 |
 
 > **Notes:**
 > - Diff wide-character width overflow fix (PR #14, 2026-07-03) — no plan file.
@@ -46,8 +47,6 @@
 
 | # | Plan | Status | Created |
 |---|------|--------|---------|
-| 35 | [README copy — Pi, with the good stuff](plan-035-readme-copy.md) | IN PROGRESS (PR #49; implementation pending) | 2026-09-11 |
-
 ## Backlog
 
 | # | Plan | Status | Created |
@@ -55,8 +54,8 @@
 ## Quick Stats
 
 - Total Plans: 35
-- Completed: 34
-- In Progress: 1
+- Completed: 35
+- In Progress: 0
 - Backlog: 0
 
 > **MCP port (plans 025–027):** A three-phase port of `pi-mcp-adapter` into `@pi-archimedes/mcp`. Phase 1 = core reliability (cache, lifecycle, connection hardening); Phase 2 = OAuth (`/mcp-auth`, keyring, callback server); Phase 3 = `/mcp` command + panels. Design decisions in ADRs 0001–0003. Execute in order (026 needs 025; 027 needs both).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -46,15 +46,17 @@
 
 | # | Plan | Status | Created |
 |---|------|--------|---------|
+| 35 | [README copy — Pi, with the good stuff](plan-035-readme-copy.md) | IN PROGRESS (PR #49; implementation pending) | 2026-09-11 |
+
 ## Backlog
 
 | # | Plan | Status | Created |
 |---|------|--------|---------|
 ## Quick Stats
 
-- Total Plans: 34
+- Total Plans: 35
 - Completed: 34
-- In Progress: 0
+- In Progress: 1
 - Backlog: 0
 
 > **MCP port (plans 025–027):** A three-phase port of `pi-mcp-adapter` into `@pi-archimedes/mcp`. Phase 1 = core reliability (cache, lifecycle, connection hardening); Phase 2 = OAuth (`/mcp-auth`, keyring, callback server); Phase 3 = `/mcp` command + panels. Design decisions in ADRs 0001–0003. Execute in order (026 needs 025; 027 needs both).

--- a/docs/plans/plan-035-readme-copy.md
+++ b/docs/plans/plan-035-readme-copy.md
@@ -1,0 +1,192 @@
+# Plan 035: Pi, with the good stuff
+
+**Status:** IN PROGRESS — copy direction approved; implementation pending
+**PR:** [#49](https://github.com/danielcherubini/pi-archimedes/pull/49)
+**Branch:** `feature/improve-readmes` → `main`
+**Goal:** Make Archimedes appealing to a new user through confident, personable, concrete copy, with immediate setup instructions and trustworthy reference documentation.
+**Architecture:** Documentation-only revision of the root README, npm README in `meta/`, and eleven component READMEs. Root and npm landing pages share the approved user-facing copy; component READMEs own detailed usage and caveats. No new build step, README generator, or runtime changes.
+**Format:** GitHub-flavoured Markdown, existing screenshots, package JSON description.
+
+## Approved direction
+
+The user rejected both corporate jargon and a dry list of supposed shortcomings of Pi. They chose “Pi, with the good stuff.”, requested fewer jokes, and approved the copy below. Preserve its voice rather than restarting copy exploration. Display substantive copy/review findings in chat; use `ask` only for the actual question and concise choices.
+
+- Confident and personable, not jokey or inflated. Benefits first, technical details later.
+- No “cockpit”, “enterprise-grade”, “ultimate”, “reactive nervous system”, “swarms”, or claims that other extensions cannot cooperate.
+- Do not disparage Pi or invent limitations to make Archimedes look better.
+- Installation immediately follows the opening, before screenshots, feature stories, command tables, or a “why” essay.
+- No invented benchmarks, adoption statistics, guaranteed reliability, savings, or universal compatibility.
+- Features sell the suite; factual qualifications still belong beside the relevant usage instructions.
+- Follow `CONTEXT.md` terminology for reference material, but avoid exposing internal implementation terms in the opening.
+
+### Approved landing-page copy
+
+Use the following as the editorial baseline. Link the features to their component docs and add the verified qualifications listed later without changing the tone.
+
+> # Archimedes
+> ### Pi, with the good stuff.
+>
+> An extra pair of eyes on your code. Agents working in parallel. A terminal that keeps you in the loop—and looks good doing it.
+>
+> **Archimedes brings subagents, shared task lists, MCP tools, and a polished interface to Pi. Install them together, use what you like, and make the setup yours.**
+>
+> ## Give your agent some backup.
+>
+> Have one subagent explore the codebase while another reviews your changes. Choose their models and tools, watch their progress live, and see their tasks side by side.
+>
+> Their token usage and costs feed into the same status bar. More work happening at once, without losing sight of it.
+>
+> ## Keep the decisions. Delegate the work.
+>
+> When a subagent needs your input, it can ask directly in your session. Pick an option, add a note, or write your own answer. It gets your decision and carries on.
+>
+> You don't have to copy messages between terminals to stay involved.
+>
+> ## Bring the tools you already use.
+>
+> Connect MCP servers, browse their tools, and handle authentication inside Pi. Import server definitions from Cursor, Claude Code, Claude Desktop, or VS Code rather than rebuilding your setup.
+>
+> Start with `/mcp setup`. Manage it with `/mcp`.
+>
+> ## See what changed. Not just that something changed.
+>
+> Syntax-highlighted diffs, side by side when there's room and unified when there isn't. Word-level highlights draw your eye to the changes inside each line.
+>
+> The details are easier to catch when they're easier to read.
+>
+> ## A terminal worth spending your day in.
+>
+> Paste screenshots with inline previews. Keep your branch, model, context usage, and costs in view. Give sessions useful names automatically so they're easier to find later.
+>
+> A framed editor, animated working indicators, and configurable colours finish the picture. Small touches that make the whole setup feel considered.
+>
+> ## A little more care with root access.
+>
+> For tasks that need `sudo`, review the command and its reason before entering your password in a masked prompt—not the chat. Credentials are cached in memory with an expiry, and `/sudo forget` clears them.
+>
+> ## Step away without losing track.
+>
+> Get a notification when the agent finishes or a prompt needs your attention. Alerts wait before firing, and typing cancels anything pending.
+>
+> You can leave the terminal to do its thing.
+>
+> ## The whole suite. Or just your favourite parts.
+>
+> One install brings everything together. Switch optional extensions on or off with `/plugins`, then `/reload` to apply. Use `/archimedes` to adjust the available settings.
+>
+> Only want the diffs, footer, or MCP tools? Each component is available separately.
+>
+> **Start with the setup. Make it yours.**
+
+## Evidence and boundaries
+
+The existing PR contains inaccurate promises and removed reference information. Fix documentation, not implementation. Verify against source, not other README prose.
+
+### Pi setup
+
+- The installed and workspace Pi package is `0.85.1`; its `engines.node` is `>=22.19.0`, not just `>=22`. Verify again when executing; do not invent an Archimedes minimum Pi version from broad peer ranges.
+- Read the installed Pi README and related setup docs completely before editing setup instructions. Base path: `/home/daniel/.local/lib/node_modules/@earendil-works/pi-coding-agent/`. Relevant files: `README.md`, `package.json`, `docs/quickstart.md`, `docs/providers.md`, `docs/packages.md`. Follow relevant cross-references for any additional claims.
+- Current documented global Pi install: `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`.
+- Then `pi install npm:pi-archimedes`, change into the intended project, and run `pi`. Inside Pi, use `/login` for a supported provider and `/model` to select a model. API-key/environment setup can link to Pi's provider docs instead of reproducing a provider catalogue.
+- Include existing-user guidance to run `/reload` after installation and explain model access is supplied through Pi, not bundled with Archimedes. Do not imply all subscriptions include unlimited/free usage.
+- `npm` here installs the global Pi CLI; repository development still uses `pnpm install`. Never run these install commands merely to validate documentation.
+
+### Source-backed corrections
+
+| Area | Required fact / qualification | Source to inspect |
+|---|---|---|
+| Suite controls | Eleven components; **ten optional** extensions, core always registered. `/plugins` toggles persist immediately; registration changes on `/reload`/fresh session. `/archimedes` uses arrows to change values, Enter for supported field edits, `s` to save, Escape to discard edits; use `/reload` for startup-captured settings. `/archimedes` and `/plugins` are suite-only; `/agents` is suite-only with subagent enabled. Not every setting has a panel control. | `meta/src/index.ts`, `meta/src/plugins.ts`, `meta/src/plugin-manager.ts`, `meta/src/settings.ts`, `meta/src/settings-manager.ts` |
+| Standalone integrations | Describe the full suite as the supported connected setup; do not assert the bus can only work through meta or that unrelated extensions cannot communicate. | `packages/core/src/bus.ts`, `meta/src/index.ts` |
+| Subagents | Omitted `agent` is config-less, not a default `general` agent. Execution waits for results; `async` is present in schema but ignored by implementation, so do not sell fire-and-forget or “keep coding in parallel with the main agent”. Model precedence is agent config → task/tool model → parent. Nested subagent tool excluded. Named agents must exist; don't imply reviewer/researcher agents are shipped presets. | `packages/subagent/src/index.ts`, `tool-schema.ts`, `spawn.ts`, `model-validation.ts` (the last three in the same directory) |
+| Agent definitions | Restore discovery scopes, required name/description frontmatter, comma-separated `tools` string, markdown body as prompt, model/thinking fallback, local `agents.local.json` precedence, unknown-field preservation, and optional `childSessionId` result reference. TUI saves move model/thinking to local config. | `packages/subagent/src/agents.ts`, `local-config.ts`, `agent-store.ts`, `frontmatter-io.ts`, `stream.ts` |
+| Diffs | Displays edit/write changes in the tool UI, including call previews; not an approval gate before applying changes. Standalone uses fixed defaults (`github-dark`, 150, 60), not settings-backed config. Meta supplies config reader. Do not promise every syntax colour automatically equals Pi's active theme. | `packages/diff/src/index.ts`, `packages/diff/src/tools/edit.ts`, `packages/diff/src/tools/write.ts`, `meta/src/config.ts` |
+| Footer | Context bar shows consumption, not remaining space. Costs reflect usage/pricing reported through the tools, not a guaranteed exact provider invoice or all background model calls. | `packages/footer/src/index.ts`, `packages/footer/src/cost-accumulator.ts`, `packages/footer/src/utils/stats.ts` |
+| Images | Clipboard markers appear on paste; image attachment/previews on submission. Remaining markers select attachments. 20 MiB per image. Terminal support affects display; model must support images to use them. Restore supported shortcuts and binding-conflict guidance. Linux clipboard backend/display requirements belong in package docs. Do not assert `terminal.showImages` control unless verified through Pi renderer. | `packages/image-paste/src/index.ts`, `clipboard.ts`, `preview.ts` |
+| Notify | Starts a timer on `agent_settled` or `ui_prompt_start`; input cancels rather than restarting an inactivity tracker. No reading/focus detection. Delivery depends on terminal support. These native triggers also work standalone. | `packages/notify/src/index.ts` |
+| Session names | Separate model call, potentially billed, current model by default unless configured; not necessarily cheap and not forwarded to footer by this package. First exchange, manual names respected, ephemeral sessions skipped, title capped at 80 chars. Avoid “never lose a session” and completely silent failure claims. | `packages/session-name/src/index.ts` |
+| Sudo | Guard is a heuristic, not a sandbox or security boundary. Allowed flag list is scanner behavior, not proof no prompt can occur. Headless `sudo_exec` refused; ordinary guard still applies. Process-group cleanup cannot catch deliberately detached descendants. Literal-password output scrubbing is not universal leak protection. Ambiguous failures without reusable ticket use two-failure cache clearing. JSON-only settings. | `packages/sudo/src/guard.ts`, `tool.ts`, `index.ts`; `docs/adr/0010-archimedes-sudo-security.md` |
+| MCP | Keep layered config, auth keyring requirements, no plaintext fallback, public-client refresh limitation, reserved settings and reload/write-back behavior. Avoid “any server” / feature-parity / maximum-token-efficiency promises. | `packages/mcp/README.md`, `packages/mcp/src/index.ts`, `config.ts`, `commands.ts`, `auth-flow.ts`, `auth-storage.ts` |
+| Core/settings | `mutedTheme` is exposed/saved but not consulted by the current thinking renderer: mark currently ineffective, do not implement it. Check remaining spinner/thinking settings individually. Archimedes settings use strict JSON (`JSON.parse`), unlike MCP server configs, which accept JSONC. | `packages/core/src/index.ts`, `packages/core/src/config.ts`, `packages/core/src/thinking/patch.ts`, `packages/core/src/settings-io.ts` |
+| Todo | `/todos` refreshes the widget and reports status, not a visibility toggle; `/todos clear` clears tasks. Writes replace the whole list. Verify auto-clear timing and subagent-column behavior. | `packages/todo/src/index.ts`, `packages/todo/src/tool.ts`, `packages/todo/src/state-manager.ts`, `packages/todo/src/ui/todo-widget.ts` |
+| Ask | Verify single/multi-question navigation, notes, multi-select and custom answers from the actual dialogs. Do not promise mouse interaction or invented keybindings. Explain subagent relay only for supported Archimedes dispatch. | `packages/ask/src/tool.ts`, `packages/ask/src/ipc-relay.ts`, picker/dialog sources under `packages/ask/src/` |
+| npm README | `meta/` is the published `pi-archimedes` directory. The missing file was the cause; npm normally includes a README even when absent from `files`. Keep explicit README entry and physical file. A local pack is not publication. | `meta/package.json`, `.github/workflows/release.yml` |
+
+For removed reference material, compare both `git show 11cdbe1:README.md` and `git show 11cdbe1:packages/<name>/README.md`; restore only source-verified information, not old errors. Build a brief retention checklist mapping removed valid root reference content to a component README destination. In particular, restore the `McpOAuthConfig` object fields (`grantType`, `clientId`, `clientSecret`, `scope`, `redirectUri`, `clientName`, reserved/unused `authorizationServerUrl`) in `packages/mcp/README.md`, checking `packages/mcp/src/types.ts`, `packages/mcp/src/auth-flow.ts`, and `packages/mcp/src/oauth-provider.ts`. The landing page must link there, not duplicate this reference. Relative source shorthand above always means the same directory as the preceding fully qualified source path.
+
+**Before implementation:** Commit this plan and its index entry on `feature/improve-readmes` before Task 1 (`chore: plan the approved README copy revision`). Stage only those two paths, preserve unrelated changes, and update existing PR #49 rather than creating a new branch/PR.
+
+## Task 1: Rewrite the two landing pages and npm description
+
+**Context:** These are the first pages prospective users see. They need a strong opening, a working start path, and proof of the connected experience—not eleven repeated specification sheets.
+
+**Modify:** `README.md`, `meta/README.md`, `meta/package.json`.
+
+**Steps:**
+- [ ] Read the current three files, Pi setup references, and relevant source from the fact table. Note the current failures: buried install, unsupported Node badge, old jargon, missing provider setup, misleading suite controls.
+- [ ] Preserve the existing splash asset and useful npm badge, but put the title/tagline and short opening before large images. Avoid adding a fabricated logo or artwork. Keep visual proof after setup so the hero image does not push setup down the page.
+- [ ] Write setup immediately below the approved opening. Show the one-command suite install prominently for existing Pi users, then the full new-user path (Node requirement, Pi install, Archimedes install, project launch, `/login`, `/model`). Distinguish shell commands from in-session commands.
+- [ ] Use the approved feature stories and existing subagent/todo, ask, and diff screenshots. Link all eleven packages at least once, including core, footer, image-paste, notify, session-name. Add a short extra-model-call usage note for session naming and terminal-dependent preview/notification qualification without overwhelming the opening.
+- [ ] Keep a concise commands table with scope and reload qualifications. Replace the long duplicated JSON settings dump with namespace links to package reference docs; explain settings live in `~/.pi/agent/settings.json` and sudo is JSON-only. Don't promise `/archimedes` controls every setting.
+- [ ] Keep a compact package table, an explicit standalone `pi install npm:@pi-archimedes/<actual-name>` example for each component (a single code block is fine), and the root monorepo layout/development instructions required by `AGENTS.md`. No build step; local symlink instructions must create the extensions directory and warn against loading local and npm suite copies together.
+- [ ] Root links may be repository-relative. In `meta/README.md` use absolute GitHub links for documentation and raw GitHub image URLs. Same user-facing opening/setup/feature copy in both, with an npm-friendly short link to root development instructions instead of duplicating the monorepo developer guide.
+- [ ] Update only `meta/package.json`'s description to: `Parallel agents, shared task lists, MCP tools, and a polished terminal for the Pi coding agent.` Preserve name, versions, dependencies, files, and Pi manifest. Don't alter release workflows or introduce README generation.
+- [ ] Inspect the rendered reading order, all links, and `git diff --check`. Verify the previous content defects no longer appear. Documentation checks replace artificial unit tests for prose: no application behavior is being changed.
+- [ ] Commit: `chore: give Archimedes a clearer and more inviting introduction`.
+
+**Acceptance:** The first screen explains what Archimedes adds without disparaging Pi; setup precedes features; new users can install, authenticate, select a model, and run; all package docs reachable; npm presentation valid; feature claims match code.
+
+## Task 2: Give component READMEs personality without losing the manual
+
+**Context:** A package README is both an independent npm entry point and the detailed reference linked from the suite. Earlier edits removed useful configuration instructions and security caveats. A warmer voice must not reduce its usefulness.
+
+**Modify:**
+- `packages/core/README.md`
+- `packages/footer/README.md`
+- `packages/diff/README.md`
+- `packages/image-paste/README.md`
+- `packages/subagent/README.md`
+- `packages/todo/README.md`
+- `packages/ask/README.md`
+- `packages/notify/README.md`
+- `packages/session-name/README.md`
+- `packages/mcp/README.md`
+- `packages/sudo/README.md`
+
+**Structure:** Package name → short benefit-led opening → install (before any screenshots) → concrete usage → settings/reference/caveats → related suite features.
+
+**Opening directions:** Core: a terminal worth spending your day in. Footer: session details without scrolling. Diff: see what changed. Image-paste: show the screenshot rather than describing it. Subagent: give your agent some backup. Todo: keep the plan in view. Ask: keep the decisions, delegate the work. Notify: step away without losing track. Session-name: find the session you meant. MCP: bring the tools you already use. Sudo: a little more care with root access. These are directions, not jokes to force verbatim into every header.
+
+**Steps:**
+- [ ] Read each README, its relevant source from the fact table, and the pre-PR version. List omissions/inaccuracies before rewriting.
+- [ ] Give each a distinct short introduction in the approved voice; no repeated “development cockpit” paragraphs, exaggerated friction claims, or unnecessary emojis.
+- [ ] Include standalone install, launch/reload instruction, a clearly labelled optional global Pi install command, Node requirement or shared setup link, and `/login`/`/model` guidance via the root setup link. Present suite installation as an alternative, not a second required installation. Use absolute links/assets for npm.
+- [ ] Retain or restore all useful source-backed reference material identified in the fact table. Especially preserve agent-file format/local config, `manage_todo_list` full-list replacement semantics, ask multi-select/custom answers, image markers/on-submit previews, notification cancellation, session naming cost, and sudo limitations.
+- [ ] Make MCP quick start prefer `/mcp setup`. If showing `.mcp.json`, use a JSON example to merge deliberately, not `cat > .mcp.json` which can overwrite existing server settings. Retain command, settings, config precedence, auth, and reserved-field reference below the quick start.
+- [ ] Label JSON versus JSONC accurately and ensure examples match source field types. Don't advertise `async` as working; describe parallel tasks without claiming main-agent fire-and-forget. Show a config-less dispatch example and a complete agent Markdown example before using named agents in examples.
+- [ ] Correct suite-only command/settings references and standalone diff fixed-default behavior. Explain cross-package integrations as requiring the relevant loaded components, without inventing exclusivity to meta.
+- [ ] Read each resulting page as a newcomer, then as someone looking for a specific setting. Check setup order, links, and factual qualifications. Run `git diff --check`.
+- [ ] Commit: `chore: refresh component copy and restore practical reference details`.
+
+**Acceptance:** All eleven pages are independently useful and consistent in voice. Setup precedes screenshots. Existing valid technical documentation is preserved. No package falsely claims suite-only tools or unsupported behavior.
+
+## Task 3: Verify presentation and packaging, then update PR #49
+
+**Context:** Type checks cannot catch misleading copy or npm links. Check the actual docs and package contents as well as repository health. Do not claim to have published anything.
+
+**Modify:** `docs/plans/plan-035-readme-copy.md`, `docs/plans/README.md` at completion; any documentation corrections should be committed with the relevant logical task.
+**Read:** `package.json`, `meta/package.json`, `.github/workflows/release.yml`, all thirteen READMEs, `AGENTS.md`.
+
+**Steps:**
+- [ ] Review the complete PR diff against its base, not just the latest commit. Have a reviewer check the new docs against code for regressions and unsupported claims. Display findings in chat, not inside `ask`.
+- [ ] Validate every local link and fragment against the current tree; validate raw image paths against `docs/images/`. For npm docs, reject relative links that escape the package. Check the package table includes eleven real names and installation commands; inspect heading/anchor rendering and fenced examples. A temporary checker is acceptable; don't add a build/docs framework for this task.
+- [ ] Compare root/meta user-facing sections after normalising link destinations to prevent accidental drift. Open/render Markdown if the available tooling supports it; otherwise report that visual rendering was not checked rather than claiming it was.
+- [ ] Run `git diff --check` and parse `meta/package.json` as JSON.
+- [ ] Following the repository's verification order, run `npx tsc --noEmit` separately in each component directory and `meta`, waiting for each result. Do not use concurrent `pnpm -r exec` for this check. Inspect and report failures; fix only issues caused by the permitted documentation/metadata edits. If a fix requires runtime source, dependency, test, or compiler-config changes, report BLOCKED and leave it for separately authorized work. If a check fails twice without intervening edits, report BLOCKED.
+- [ ] Run `pnpm test` separately after type checks. Report actual counts/warnings; do not reuse earlier test results or claim coverage for suites the workspace excludes.
+- [ ] From `meta/`, run `pnpm pack --pack-destination <fresh temporary directory>` (pnpm 10 has no `pack --dry-run`). Inspect the archive with `tar -tzf` and `tar -xOf`: confirm nonempty `package/README.md`, the intended description, and dependencies rewritten without `workspace:*`. Do not extract into the repository or run any publish/install command.
+- [ ] From each component directory, use `pnpm pack --pack-destination <fresh temporary directory>` and confirm its archive contains a nonempty `package/README.md`. Record evidence without leaving archives in the working tree.
+- [ ] When changes are verified, mark this plan and its index entry COMPLETED per repository convention; update index counts. Commit: `chore: complete the README copy revision plan`.
+- [ ] Push only `feature/improve-readmes` to update existing PR #49. Replace the stale PR body (which still uses the rejected marketing jargon) with a short factual summary and fresh checks. Include rendered branch links to root README and `meta/README.md` so the user can read them without a diff.
+- [ ] Do not merge, tag, bump versions, publish, or open a replacement PR. Confirm the PR's remote head matches the pushed commit and report the link.
+
+**Acceptance:** Reviewable updated PR #49; all thirteen README files packaged/readable as appropriate; accurate fresh verification report; user can inspect rendered docs; no runtime changes or publication.

--- a/docs/plans/plan-035-readme-copy.md
+++ b/docs/plans/plan-035-readme-copy.md
@@ -1,6 +1,6 @@
 # Plan 035: Pi, with the good stuff
 
-**Status:** IN PROGRESS — copy direction approved; implementation pending
+**Status:** COMPLETED (PR #49)
 **PR:** [#49](https://github.com/danielcherubini/pi-archimedes/pull/49)
 **Branch:** `feature/improve-readmes` → `main`
 **Goal:** Make Archimedes appealing to a new user through confident, personable, concrete copy, with immediate setup instructions and trustworthy reference documentation.

--- a/meta/README.md
+++ b/meta/README.md
@@ -167,7 +167,7 @@ Every component keeps its own namespace under `~/.pi/agent/settings.json`, which
 | Component | npm package | What it adds |
 |-----------|-------------|--------------|
 | **Core** | [`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md) | Shared event bus, splash screen, framed editor, working spinner, thinking blocks |
-| **Subagent** | [`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/subagent/README.md) | Live subagent dispatch, `/agents`, custom agent definitions |
+| **Subagent** | [`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/subagent/README.md) | Live subagent dispatch, custom agent definitions; `/agents` editor with the suite |
 | **Todo** | [`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/todo/README.md) | Multi-column todo board with subagent columns and auto-clear |
 | **Ask** | [`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/ask/README.md) | Structured questions — including subagent questions relayed into your terminal |
 | **MCP** | [`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/mcp/README.md) | `/mcp` management, setup wizard, OAuth, config imports |

--- a/meta/README.md
+++ b/meta/README.md
@@ -147,7 +147,7 @@ Only want the diffs, footer, or MCP tools? Each component is available separatel
 | Command | Scope | Notes |
 |---------|-------|-------|
 | `/plugins` | Suite | Toggle the ten optional extensions (core is always on and not toggleable). Toggles persist immediately; `/reload` (or a fresh session) applies them. |
-| `/archimedes` | Suite | Interactive settings panel — arrow keys change values, Enter edits supported fields, `s` saves, Esc discards the current edits. Settings captured at startup need `/reload`. Not every setting has a panel control. |
+| `/archimedes` | Suite | Interactive settings panel — up/down moves, left/right changes values, Enter edits supported fields, `s` saves, Esc discards the current edits. Settings captured at startup need `/reload`. Not every setting has a panel control. |
 | `/agents` | Suite, subagent enabled | Browse, create, and edit custom subagent definitions in `.pi/agents/*.md`. |
 | `/todos` | Todo component | Refreshes the todo widget and reports its status. `/todos clear` clears the list. (The board's visibility is not a `/todos` toggle — see the [todo docs](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/todo/README.md).) |
 | `/mcp`, `/mcp setup` | MCP component | Manage servers and run logins; the setup wizard scaffolds `.mcp.json` or imports configs from Cursor, Claude Code, Claude Desktop, or VS Code. |

--- a/meta/README.md
+++ b/meta/README.md
@@ -166,17 +166,17 @@ Every component keeps its own namespace under `~/.pi/agent/settings.json`, which
 
 | Component | npm package | What it adds |
 |-----------|-------------|--------------|
-| **Core** | [`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md) | Shared event bus, splash screen, framed editor, working spinner, thinking blocks |
-| **Subagent** | [`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/subagent/README.md) | Live subagent dispatch, custom agent definitions; `/agents` editor with the suite |
-| **Todo** | [`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/todo/README.md) | Multi-column todo board with subagent columns and auto-clear |
-| **Ask** | [`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/ask/README.md) | Structured questions — including subagent questions relayed into your terminal |
-| **MCP** | [`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/mcp/README.md) | `/mcp` management, setup wizard, OAuth, config imports |
-| **Sudo** | [`@pi-archimedes/sudo`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/sudo/README.md) | `sudo_exec` with masked password prompt and interactive-sudo guard |
-| **Diff** | [`@pi-archimedes/diff`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/diff/README.md) | Syntax-highlighted side-by-side and unified diffs with word-level highlights |
-| **Footer** | [`@pi-archimedes/footer`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/footer/README.md) | Branch, model, context usage, and token/cost status bar |
-| **Image Paste** | [`@pi-archimedes/image-paste`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) | Clipboard image paste with inline previews |
-| **Notify** | [`@pi-archimedes/notify`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md) | Delayed desktop notifications with input cancellation |
-| **Session Name** | [`@pi-archimedes/session-name`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/session-name/README.md) | Automatic session titles |
+| **Core** | [`@pi-archimedes/core`](https://www.npmjs.com/package/@pi-archimedes/core) | Shared event bus, splash screen, framed editor, working spinner, thinking blocks |
+| **Subagent** | [`@pi-archimedes/subagent`](https://www.npmjs.com/package/@pi-archimedes/subagent) | Live subagent dispatch, custom agent definitions; `/agents` editor with the suite |
+| **Todo** | [`@pi-archimedes/todo`](https://www.npmjs.com/package/@pi-archimedes/todo) | Multi-column todo board with subagent columns and auto-clear |
+| **Ask** | [`@pi-archimedes/ask`](https://www.npmjs.com/package/@pi-archimedes/ask) | Structured questions — including subagent questions relayed into your terminal |
+| **MCP** | [`@pi-archimedes/mcp`](https://www.npmjs.com/package/@pi-archimedes/mcp) | `/mcp` management, setup wizard, OAuth, config imports |
+| **Sudo** | [`@pi-archimedes/sudo`](https://www.npmjs.com/package/@pi-archimedes/sudo) | `sudo_exec` with masked password prompt and interactive-sudo guard |
+| **Diff** | [`@pi-archimedes/diff`](https://www.npmjs.com/package/@pi-archimedes/diff) | Syntax-highlighted side-by-side and unified diffs with word-level highlights |
+| **Footer** | [`@pi-archimedes/footer`](https://www.npmjs.com/package/@pi-archimedes/footer) | Branch, model, context usage, and token/cost status bar |
+| **Image Paste** | [`@pi-archimedes/image-paste`](https://www.npmjs.com/package/@pi-archimedes/image-paste) | Clipboard image paste with inline previews |
+| **Notify** | [`@pi-archimedes/notify`](https://www.npmjs.com/package/@pi-archimedes/notify) | Delayed desktop notifications with input cancellation |
+| **Session Name** | [`@pi-archimedes/session-name`](https://www.npmjs.com/package/@pi-archimedes/session-name) | Automatic session titles |
 
 The full suite is the supported connected setup — the integrations above (subagent costs in the footer, subagent columns on the todo board, subagent questions in the terminal) light up when the relevant components are loaded together.
 

--- a/meta/README.md
+++ b/meta/README.md
@@ -50,11 +50,11 @@ Then run `/reload` in your session (or start a new one) to pick it up.
 5. **Authenticate and pick a model** (inside the Pi session):
 
    ```text
-   /login   # choose a supported provider — subscription or API key
-   /model   # select a model from your provider
+   /login
+   /model
    ```
 
-Model access comes through Pi's own providers — see Pi's [provider docs](https://pi.dev/docs/providers) for every supported provider and log in with `/login`. Archimedes doesn't ship a model of its own, and it works with whatever model your Pi account can reach. For the broader first run, Pi's [quickstart](https://pi.dev/docs/quickstart) is worth a read.
+`/login` signs you into a supported provider (subscription or API key) and `/model` selects a model from it. Model access comes through the providers you configure in Pi — Pi's [provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) list the supported ones, and Archimedes doesn't ship a model of its own. For the broader first run, Pi's [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) is worth a read.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/splash-screen.png" width="600" alt="pi-archimedes splash screen">
@@ -114,11 +114,11 @@ The details are easier to catch when they're easier to read.
 
 ## A terminal worth spending your day in.
 
-[Core](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md) frames the editor, animates the border while the agent works, and tidies the thinking blocks — with configurable colours. The [footer](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/footer/README.md) keeps your branch, model, context usage, and costs in view. [Paste screenshots](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) straight from the clipboard with inline previews.
+[Paste screenshots](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) with inline previews. Keep your [branch, model, context usage, and costs](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/footer/README.md) in view. Give sessions [useful names automatically](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/session-name/README.md) so they're easier to find later.
 
-[Session naming](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/session-name/README.md) gives sessions useful names automatically so they're easier to find later. A small extra model call generates the title, so it's a separate (potentially billed) cost that isn't reflected in the footer's totals.
+A [framed editor](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md), animated working indicators, and configurable colours finish the picture. Small touches that make the whole setup feel considered.
 
-A few practical notes: image previews appear when you submit the message (the markers appear as you paste), and both image rendering and desktop alerts depend on your terminal's support — the [notify](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md) and [image-paste](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) docs cover what each needs.
+**Practical notes:** the paste markers appear as you paste; image previews appear when you submit the message. Image rendering and desktop alerts both depend on your terminal's support — the [image-paste](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) and [notify](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md) docs cover what each needs. Naming is a separate (potentially billed) model call, not included in the footer's totals.
 
 ---
 

--- a/meta/README.md
+++ b/meta/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-%3E%3D5.0-blue?style=flat-square)](https://www.typescriptlang.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](https://github.com/danielcherubini/pi-archimedes/blob/main/LICENSE)
 
-[Quick Start](#quick-start) • [Why Archimedes?](#why-archimedes) • [Interactive Commands](#interactive-commands) • [Feature Deep Dive](#feature-deep-dive) • [Configuration](#configuration) • [Modular Packages](#modular-packages) • [GitHub](https://github.com/danielcherubini/pi-archimedes)
+[Quick Start](#quick-start) • [Why Archimedes?](#why-archimedes) • [Interactive Commands](#interactive-commands) • [Feature Deep Dive](#feature-deep-dive) • [Configuration](#configuration) • [Modular Packages](#modular-packages)
 
 </div>
 
@@ -18,24 +18,26 @@
 
 ## Why Archimedes?
 
-[Pi](https://github.com/earendil-works/pi) is a fast, hackable, and lightweight coding agent harness for the terminal. But out of the box, extensions operate in silos:
-- Subagents execute blindly as black boxes, burning tokens invisible to your status bar.
-- Long-running tasks have no shared progress tracking.
-- Clarification questions break agent loops or force clumsy terminal hacks.
-- Reviewing diffs in plain text causes subtle regressions.
-- Privileged commands risk terminal hangs or leaked credentials.
+[Pi](https://github.com/earendil-works/pi) is a fast and lightweight terminal coding agent. But out of the box, extensions don't talk to each other:
+- If you dispatch a subagent, you can't see what it's doing or how many tokens it's burning.
+- When an agent needs a decision, it either guesses or dumps confusing raw text into the chat.
+- There's no built-in way to track multi-step plans across agents without losing context.
+- Terminal diffs are plain text without syntax highlighting.
+- Running `sudo` can hang your session or leak passwords into prompt history.
+- Managing MCP servers means hand-editing JSON files and restarting.
 
-**pi-archimedes transforms Pi from a raw agent runner into a cohesive, production-grade development cockpit.**
+**Archimedes connects all of these pieces together into one seamless terminal experience.**
 
-Instead of eleven disjointed plugins that fight for terminal real estate, Archimedes functions as a **single, reactive nervous system**:
-- **Cooperative Event Bus**: Subagent tool calls and real-dollar costs flow directly into your footer status bar in real time.
-- **Shared Multi-Column Todo Board**: The main agent and every spawned subagent report tasks side by side, automatically clearing when done.
-- **Bidirectional Human-in-the-Loop (`ask`)**: When a background subagent needs a critical decision, it surfaces an interactive multi-tab prompt in your TUI over IPC and resumes the moment you answer.
-- **First-Class MCP Experience**: Connect, inspect, authenticate (OAuth 2.1 PKCE), and toggle Model Context Protocol servers through a dedicated interactive TUI overlay (`/mcp`).
-- **Safe Privileged Execution**: Run root commands with masked interactive password prompts, strictly scoped process-group timeouts, and a bash guard that prevents the agent from hanging on unprotected `sudo`.
-- **Obsessive Visual Polish**: Shiki syntax-highlighted side-by-side diffs, border spinners while the agent works, clipboard image pasting (`Ctrl+V`), and desktop notifications when tasks finish.
+Instead of installing a bunch of separate plugins that don't know the others exist, Archimedes makes them cooperate:
+- **Subagents stream live in your terminal**, and their token usage and dollar costs roll straight into your footer status bar in real time.
+- **A shared multi-column todo list** shows what your main agent and every subagent are doing side by side, and automatically dismisses itself when the work is done.
+- **Interactive questions (`ask`)**: when an agent needs clarification, it opens a clean interactive prompt right in your terminal, waits for your answer, and keeps going. Even background subagents can ask you questions without breaking execution.
+- **Full MCP management (`/mcp`)**: browse tools, toggle servers on or off, and run OAuth logins from a clean terminal UI instead of hand-editing config files.
+- **Safe sudo execution**: prompts for passwords securely with masked input, caches credentials in memory, and stops agents from hanging on raw `sudo` commands.
+- **Syntax-highlighted diffs**: split side-by-side or unified diffs powered by Shiki, with word-level highlights so you can see exactly what changed before applying edits.
+- **Polished daily details**: paste screenshots straight from your clipboard with `Ctrl+V`, watch an animated spinner on the editor border while the agent works, get a desktop notification when long tasks finish, and let AI name your sessions automatically.
 
-Everything is toggleable, theme-aware, and built to be lived in.
+Everything can be toggled with `/plugins` and customized with `/archimedes`.
 
 ---
 
@@ -88,9 +90,9 @@ Archimedes adds a set of dedicated TUI commands to manage your agent environment
 
 ## Feature Deep Dive
 
-### 🤖 Subagent Swarms & Live Streaming ([`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/subagent#readme))
+### 🤖 Subagents & Live Streaming ([`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/subagent#readme))
 
-Offload tasks to specialized subagents with real-time visibility. Run single subagents or parallel swarms (e.g., a researcher and a reviewer working simultaneously).
+Offload tasks to specialized subagents with real-time visibility. Run single tasks or parallel agents (e.g., a researcher and a reviewer working simultaneously).
 
 - **Live TUI streaming**: Watch subagent reasoning and tool calls execute in real time. Tool states are color-coded (grey while running, green on success, red on failure) with human-readable argument previews.
 - **Unified cost accounting**: Per-subagent token usage (input, output, cache read/write) and exact dollar costs flow through the core bus directly into the footer.
@@ -117,9 +119,9 @@ Keep long workflows on track with structured task tracking visible to both you a
 
 ---
 
-### 💬 Bidirectional Human-in-the-Loop (`ask`) ([`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/ask#readme))
+### 💬 Interactive Questions (`ask`) ([`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/ask#readme))
 
-Eliminate ambiguous back-and-forth guessing. When an agent or a background subagent needs human guidance, `ask` presents an interactive, structured question flow.
+Stop agents from guessing when instructions are ambiguous. When an agent or a background subagent needs clarification, `ask` presents a clean interactive prompt.
 
 - **Subagent-to-parent TUI IPC**: Most question tools fail when called from background workers. Archimedes routes subagent `ask` calls through bidirectional IPC directly into the user's terminal. The subagent pauses, you answer in the TUI, and the subagent resumes with your choice.
 - **Tabbed multi-question flows**: Review and answer multiple questions at once with keyboard navigation.
@@ -281,17 +283,17 @@ Prefer to cherry-pick? Every component in Archimedes is published as an independ
 
 | Package | npm | Description |
 |---------|-----|-------------|
-| **Core** | [`@pi-archimedes/core`](https://www.npmjs.com/package/@pi-archimedes/core) | Event bus, animated splash screen, framed editor, working spinner |
-| **Footer** | [`@pi-archimedes/footer`](https://www.npmjs.com/package/@pi-archimedes/footer) | Status bar, token counters, real-dollar costs, context window bar |
-| **Subagent** | [`@pi-archimedes/subagent`](https://www.npmjs.com/package/@pi-archimedes/subagent) | Subagent dispatch, live streaming, parallel swarms, `/agents` TUI |
-| **Todo** | [`@pi-archimedes/todo`](https://www.npmjs.com/package/@pi-archimedes/todo) | Multi-column todo widget with auto-clearing and subagent tracking |
-| **Ask** | [`@pi-archimedes/ask`](https://www.npmjs.com/package/@pi-archimedes/ask) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
-| **MCP** | [`@pi-archimedes/mcp`](https://www.npmjs.com/package/@pi-archimedes/mcp) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |
-| **Sudo** | [`@pi-archimedes/sudo`](https://www.npmjs.com/package/@pi-archimedes/sudo) | Safe `sudo_exec`, masked password prompt, bash interactive guard |
-| **Diff** | [`@pi-archimedes/diff`](https://www.npmjs.com/package/@pi-archimedes/diff) | Shiki-highlighted side-by-side and unified terminal diffs |
-| **Image Paste** | [`@pi-archimedes/image-paste`](https://www.npmjs.com/package/@pi-archimedes/image-paste) | Direct clipboard screenshot paste (`Ctrl+V`) with inline previews |
-| **Notify** | [`@pi-archimedes/notify`](https://www.npmjs.com/package/@pi-archimedes/notify) | Inactivity-delayed desktop alerts with keystroke circuit breaker |
-| **Session Name** | [`@pi-archimedes/session-name`](https://www.npmjs.com/package/@pi-archimedes/session-name) | Automated AI session title generator after first conversation turn |
+| **Core** | [`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/core#readme) | Event bus, animated splash screen, framed editor, working spinner |
+| **Footer** | [`@pi-archimedes/footer`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/footer#readme) | Status bar, token counters, real-dollar costs, context window bar |
+| **Subagent** | [`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/subagent#readme) | Subagent dispatch, live streaming, parallel execution, `/agents` TUI |
+| **Todo** | [`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/todo#readme) | Multi-column todo widget with auto-clearing and subagent tracking |
+| **Ask** | [`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/ask#readme) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
+| **MCP** | [`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/mcp#readme) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |
+| **Sudo** | [`@pi-archimedes/sudo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/sudo#readme) | Safe `sudo_exec`, masked password prompt, bash interactive guard |
+| **Diff** | [`@pi-archimedes/diff`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/diff#readme) | Shiki-highlighted side-by-side and unified terminal diffs |
+| **Image Paste** | [`@pi-archimedes/image-paste`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/image-paste#readme) | Direct clipboard screenshot paste (`Ctrl+V`) with inline previews |
+| **Notify** | [`@pi-archimedes/notify`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/notify#readme) | Inactivity-delayed desktop alerts with keystroke circuit breaker |
+| **Session Name** | [`@pi-archimedes/session-name`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/session-name#readme) | Automated AI session title generator after first conversation turn |
 
 To install an individual component:
 
@@ -304,8 +306,33 @@ pi install npm:@pi-archimedes/<package-name>
 
 ---
 
-## Repository & Development
+## Development
 
-pi-archimedes is developed openly on GitHub: [github.com/danielcherubini/pi-archimedes](https://github.com/danielcherubini/pi-archimedes).
+pi-archimedes is structured as a pnpm monorepo.
 
-For development setup, local extension symlinking, and guidelines, see the repository README and [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).
+```bash
+# Clone the repository
+git clone https://github.com/danielcherubini/pi-archimedes.git
+cd pi-archimedes
+
+# Install dependencies (requires pnpm >= 10)
+pnpm install
+
+# Type-check all packages
+pnpm -r exec -- tsc --noEmit
+
+# Run unit tests
+pnpm test
+```
+
+### Local Testing with Pi
+
+To test your local build inside Pi, symlink the repository directly into Pi's extensions directory:
+
+```bash
+ln -s $(pwd) ~/.pi/agent/extensions/pi-archimedes
+```
+
+Pi's extension loader automatically picks up `meta/src/index.ts` from the root `package.json`.
+
+For contribution conventions, architecture decisions, and release workflows, see [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).

--- a/meta/README.md
+++ b/meta/README.md
@@ -8,9 +8,9 @@
 [![npm version](https://img.shields.io/npm/v/pi-archimedes?style=flat-square)](https://www.npmjs.com/package/pi-archimedes)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen?style=flat-square)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-%3E%3D5.0-blue?style=flat-square)](https://www.typescriptlang.org)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](https://github.com/danielcherubini/pi-archimedes/blob/main/LICENSE)
 
-[Quick Start](#quick-start) • [Why Archimedes?](#why-archimedes) • [Interactive Commands](#interactive-commands) • [Feature Deep Dive](#feature-deep-dive) • [Configuration](#configuration) • [Modular Packages](#modular-packages)
+[Quick Start](#quick-start) • [Why Archimedes?](#why-archimedes) • [Interactive Commands](#interactive-commands) • [Feature Deep Dive](#feature-deep-dive) • [Configuration](#configuration) • [Modular Packages](#modular-packages) • [GitHub](https://github.com/danielcherubini/pi-archimedes)
 
 </div>
 
@@ -88,7 +88,7 @@ Archimedes adds a set of dedicated TUI commands to manage your agent environment
 
 ## Feature Deep Dive
 
-### 🤖 Subagent Swarms & Live Streaming ([`@pi-archimedes/subagent`](packages/subagent/README.md))
+### 🤖 Subagent Swarms & Live Streaming ([`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/subagent#readme))
 
 Offload tasks to specialized subagents with real-time visibility. Run single subagents or parallel swarms (e.g., a researcher and a reviewer working simultaneously).
 
@@ -102,7 +102,7 @@ Offload tasks to specialized subagents with real-time visibility. Run single sub
 
 ---
 
-### 📋 Coordinated Multi-Column Todo Board ([`@pi-archimedes/todo`](packages/todo/README.md))
+### 📋 Coordinated Multi-Column Todo Board ([`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/todo#readme))
 
 Keep long workflows on track with structured task tracking visible to both you and the LLM.
 
@@ -117,7 +117,7 @@ Keep long workflows on track with structured task tracking visible to both you a
 
 ---
 
-### 💬 Bidirectional Human-in-the-Loop (`ask`) ([`@pi-archimedes/ask`](packages/ask/README.md))
+### 💬 Bidirectional Human-in-the-Loop (`ask`) ([`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/ask#readme))
 
 Eliminate ambiguous back-and-forth guessing. When an agent or a background subagent needs human guidance, `ask` presents an interactive, structured question flow.
 
@@ -131,7 +131,7 @@ Eliminate ambiguous back-and-forth guessing. When an agent or a background subag
 
 ---
 
-### 🔌 Enterprise-Grade MCP Client ([`@pi-archimedes/mcp`](packages/mcp/README.md))
+### 🔌 Enterprise-Grade MCP Client ([`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/mcp#readme))
 
 Integrate any Model Context Protocol server (stdio or HTTP/SSE) with full feature parity with dedicated MCP adapters.
 
@@ -143,7 +143,7 @@ Integrate any Model Context Protocol server (stdio or HTTP/SSE) with full featur
 
 ---
 
-### 🔐 Safe Privileged Execution (`sudo`) ([`@pi-archimedes/sudo`](packages/sudo/README.md))
+### 🔐 Safe Privileged Execution (`sudo`) ([`@pi-archimedes/sudo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/sudo#readme))
 
 Run administrative tasks safely without exposing credentials or causing terminal deadlocks.
 
@@ -154,7 +154,7 @@ Run administrative tasks safely without exposing credentials or causing terminal
 
 ---
 
-### 🔍 Shiki-Powered Syntax-Highlighted Diffs ([`@pi-archimedes/diff`](packages/diff/README.md))
+### 🔍 Shiki-Powered Syntax-Highlighted Diffs ([`@pi-archimedes/diff`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/diff#readme))
 
 Inspect code changes with clarity before applying them.
 
@@ -168,7 +168,7 @@ Inspect code changes with clarity before applying them.
 
 ---
 
-### 📊 Adaptive Footer & Cost Tracker ([`@pi-archimedes/footer`](packages/footer/README.md))
+### 📊 Adaptive Footer & Cost Tracker ([`@pi-archimedes/footer`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/footer#readme))
 
 A status bar that delivers vital session context without wasting vertical screen space.
 
@@ -179,7 +179,7 @@ A status bar that delivers vital session context without wasting vertical screen
 
 ---
 
-### 🎬 Visual Chrome & Working Indicators ([`@pi-archimedes/core`](packages/core/README.md))
+### 🎬 Visual Chrome & Working Indicators ([`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/core#readme))
 
 - **Framed editor**: Clean borders around the input area with double-press quit guard.
 - **Border spinner**: 10 animated spinner styles running along the editor border while the agent is executing (pendulum, typing, pulse, marquee, wave, rain, sparkle), replacing Pi's native "Working" line.
@@ -188,7 +188,7 @@ A status bar that delivers vital session context without wasting vertical screen
 
 ---
 
-### 🖼️ Clipboard Image Paste ([`@pi-archimedes/image-paste`](packages/image-paste/README.md))
+### 🖼️ Clipboard Image Paste ([`@pi-archimedes/image-paste`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/image-paste#readme))
 
 Paste screenshots and UI mockups straight into your terminal prompt with instant inline previews:
 - Press `Ctrl+V` (Linux/macOS) or `Alt+V` (Windows) to attach clipboard images directly.
@@ -199,7 +199,7 @@ Paste screenshots and UI mockups straight into your terminal prompt with instant
 
 ---
 
-### 🔔 Delayed Desktop Notifications ([`@pi-archimedes/notify`](packages/notify/README.md))
+### 🔔 Delayed Desktop Notifications ([`@pi-archimedes/notify`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/notify#readme))
 
 Step away during long builds or model generations with peace of mind.
 - **Delayed trigger**: Alerts trigger only after 30 seconds of inactivity — never spamming you while actively typing.
@@ -208,7 +208,7 @@ Step away during long builds or model generations with peace of mind.
 
 ---
 
-### 🏷️ AI Session Auto-Naming ([`@pi-archimedes/session-name`](packages/session-name/README.md))
+### 🏷️ AI Session Auto-Naming ([`@pi-archimedes/session-name`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/session-name#readme))
 
 Never lose track of a past session. After your first exchange, a lightweight background model call generates a concise, descriptive 3–8 word session title so you can resume sessions easily with `pi -r`. Respects manual titles set via `/name`.
 
@@ -281,17 +281,17 @@ Prefer to cherry-pick? Every component in Archimedes is published as an independ
 
 | Package | npm | Description |
 |---------|-----|-------------|
-| **Core** | [`@pi-archimedes/core`](packages/core/README.md) | Event bus, animated splash screen, framed editor, working spinner |
-| **Footer** | [`@pi-archimedes/footer`](packages/footer/README.md) | Status bar, token counters, real-dollar costs, context window bar |
-| **Subagent** | [`@pi-archimedes/subagent`](packages/subagent/README.md) | Subagent dispatch, live streaming, parallel swarms, `/agents` TUI |
-| **Todo** | [`@pi-archimedes/todo`](packages/todo/README.md) | Multi-column todo widget with auto-clearing and subagent tracking |
-| **Ask** | [`@pi-archimedes/ask`](packages/ask/README.md) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
-| **MCP** | [`@pi-archimedes/mcp`](packages/mcp/README.md) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |
-| **Sudo** | [`@pi-archimedes/sudo`](packages/sudo/README.md) | Safe `sudo_exec`, masked password prompt, bash interactive guard |
-| **Diff** | [`@pi-archimedes/diff`](packages/diff/README.md) | Shiki-highlighted side-by-side and unified terminal diffs |
-| **Image Paste** | [`@pi-archimedes/image-paste`](packages/image-paste/README.md) | Direct clipboard screenshot paste (`Ctrl+V`) with inline previews |
-| **Notify** | [`@pi-archimedes/notify`](packages/notify/README.md) | Inactivity-delayed desktop alerts with keystroke circuit breaker |
-| **Session Name** | [`@pi-archimedes/session-name`](packages/session-name/README.md) | Automated AI session title generator after first conversation turn |
+| **Core** | [`@pi-archimedes/core`](https://www.npmjs.com/package/@pi-archimedes/core) | Event bus, animated splash screen, framed editor, working spinner |
+| **Footer** | [`@pi-archimedes/footer`](https://www.npmjs.com/package/@pi-archimedes/footer) | Status bar, token counters, real-dollar costs, context window bar |
+| **Subagent** | [`@pi-archimedes/subagent`](https://www.npmjs.com/package/@pi-archimedes/subagent) | Subagent dispatch, live streaming, parallel swarms, `/agents` TUI |
+| **Todo** | [`@pi-archimedes/todo`](https://www.npmjs.com/package/@pi-archimedes/todo) | Multi-column todo widget with auto-clearing and subagent tracking |
+| **Ask** | [`@pi-archimedes/ask`](https://www.npmjs.com/package/@pi-archimedes/ask) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
+| **MCP** | [`@pi-archimedes/mcp`](https://www.npmjs.com/package/@pi-archimedes/mcp) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |
+| **Sudo** | [`@pi-archimedes/sudo`](https://www.npmjs.com/package/@pi-archimedes/sudo) | Safe `sudo_exec`, masked password prompt, bash interactive guard |
+| **Diff** | [`@pi-archimedes/diff`](https://www.npmjs.com/package/@pi-archimedes/diff) | Shiki-highlighted side-by-side and unified terminal diffs |
+| **Image Paste** | [`@pi-archimedes/image-paste`](https://www.npmjs.com/package/@pi-archimedes/image-paste) | Direct clipboard screenshot paste (`Ctrl+V`) with inline previews |
+| **Notify** | [`@pi-archimedes/notify`](https://www.npmjs.com/package/@pi-archimedes/notify) | Inactivity-delayed desktop alerts with keystroke circuit breaker |
+| **Session Name** | [`@pi-archimedes/session-name`](https://www.npmjs.com/package/@pi-archimedes/session-name) | Automated AI session title generator after first conversation turn |
 
 To install an individual component:
 
@@ -304,33 +304,8 @@ pi install npm:@pi-archimedes/<package-name>
 
 ---
 
-## Development
+## Repository & Development
 
-pi-archimedes is structured as a pnpm monorepo.
+pi-archimedes is developed openly on GitHub: [github.com/danielcherubini/pi-archimedes](https://github.com/danielcherubini/pi-archimedes).
 
-```bash
-# Clone the repository
-git clone https://github.com/danielcherubini/pi-archimedes.git
-cd pi-archimedes
-
-# Install dependencies (requires pnpm >= 10)
-pnpm install
-
-# Type-check all packages
-pnpm -r exec -- tsc --noEmit
-
-# Run unit tests
-pnpm test
-```
-
-### Local Testing with Pi
-
-To test your local build inside Pi, symlink the repository directly into Pi's extensions directory:
-
-```bash
-ln -s $(pwd) ~/.pi/agent/extensions/pi-archimedes
-```
-
-Pi's extension loader automatically picks up `meta/src/index.ts` from the root `package.json`.
-
-For contribution conventions, architecture decisions, and release workflows, see [AGENTS.md](AGENTS.md).
+For development setup, local extension symlinking, and guidelines, see the repository README and [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).

--- a/meta/README.md
+++ b/meta/README.md
@@ -1,338 +1,203 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/splash-screen.png" width="600" alt="pi-archimedes splash screen">
+# Archimedes
+### Pi, with the good stuff.
 
-# pi-archimedes
+An extra pair of eyes on your code. Agents working in parallel. A terminal that keeps you in the loop—and looks good doing it.
 
-**The cohesive extension suite for the Pi coding agent — engineered to turn your terminal into an autonomous AI development cockpit.**
+**Archimedes brings subagents, shared task lists, MCP tools, and a polished interface to [Pi](https://github.com/earendil-works/pi). Install them together, use what you like, and make the setup yours.**
 
 [![npm version](https://img.shields.io/npm/v/pi-archimedes?style=flat-square)](https://www.npmjs.com/package/pi-archimedes)
-[![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen?style=flat-square)](https://nodejs.org)
-[![TypeScript](https://img.shields.io/badge/TypeScript-%3E%3D5.0-blue?style=flat-square)](https://www.typescriptlang.org)
+[![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.19.0-brightgreen?style=flat-square)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](https://github.com/danielcherubini/pi-archimedes/blob/main/LICENSE)
 
-[Quick Start](#quick-start) • [Why Archimedes?](#why-archimedes) • [Interactive Commands](#interactive-commands) • [Feature Deep Dive](#feature-deep-dive) • [Configuration](#configuration) • [Modular Packages](#modular-packages)
-
-</div>
+[Setup](#setup) • [Commands](#commands) • [Settings](#settings) • [Components](#components)
 
 ---
 
-## Why Archimedes?
+## Setup
 
-[Pi](https://github.com/earendil-works/pi) is a fast and lightweight terminal coding agent. But out of the box, extensions don't talk to each other:
-- If you dispatch a subagent, you can't see what it's doing or how many tokens it's burning.
-- When an agent needs a decision, it either guesses or dumps confusing raw text into the chat.
-- There's no built-in way to track multi-step plans across agents without losing context.
-- Terminal diffs are plain text without syntax highlighting.
-- Running `sudo` can hang your session or leak passwords into prompt history.
-- Managing MCP servers means hand-editing JSON files and restarting.
+### You already use Pi
 
-**Archimedes connects all of these pieces together into one seamless terminal experience.**
-
-Instead of installing a bunch of separate plugins that don't know the others exist, Archimedes makes them cooperate:
-- **Subagents stream live in your terminal**, and their token usage and dollar costs roll straight into your footer status bar in real time.
-- **A shared multi-column todo list** shows what your main agent and every subagent are doing side by side, and automatically dismisses itself when the work is done.
-- **Interactive questions (`ask`)**: when an agent needs clarification, it opens a clean interactive prompt right in your terminal, waits for your answer, and keeps going. Even background subagents can ask you questions without breaking execution.
-- **Full MCP management (`/mcp`)**: browse tools, toggle servers on or off, and run OAuth logins from a clean terminal UI instead of hand-editing config files.
-- **Safe sudo execution**: prompts for passwords securely with masked input, caches credentials in memory, and stops agents from hanging on raw `sudo` commands.
-- **Syntax-highlighted diffs**: split side-by-side or unified diffs powered by Shiki, with word-level highlights so you can see exactly what changed before applying edits.
-- **Polished daily details**: paste screenshots straight from your clipboard with `Ctrl+V`, watch an animated spinner on the editor border while the agent works, get a desktop notification when long tasks finish, and let AI name your sessions automatically.
-
-Everything can be toggled with `/plugins` and customized with `/archimedes`.
-
----
-
-## Quick Start
-
-### 1. Install Pi (if you haven't already)
-
-Archimedes requires [Pi](https://github.com/earendil-works/pi) and Node.js >= 22.
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install Archimedes
-
-Install the full, integrated Archimedes suite with a single command:
+One command:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-### 3. Launch
+Then run `/reload` in your session (or start a new one) to pick it up.
 
-```bash
-pi
-```
+### New to Pi
 
-You are immediately greeted with the Archimedes splash screen, animated working indicators, live footer status bar, and complete cockpit tooling.
+1. **Node.js ≥ 22.19.0** — the requirement [Pi](https://github.com/earendil-works/pi) itself declares.
+2. **Install Pi** (shell):
 
-> [!TIP]
-> **Want only specific components?** Archimedes is completely modular. Every package can be installed standalone without the rest of the suite. See [Modular Packages](#modular-packages) below.
+   ```bash
+   npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+   ```
+
+3. **Install Archimedes** (shell):
+
+   ```bash
+   pi install npm:pi-archimedes
+   ```
+
+4. **Launch** the terminal in the project you want to work on (shell):
+
+   ```bash
+   cd /path/to/your/project
+   pi
+   ```
+
+5. **Authenticate and pick a model** (inside the Pi session):
+
+   ```text
+   /login   # choose a supported provider — subscription or API key
+   /model   # select a model from your provider
+   ```
+
+Model access comes through Pi's own providers — see Pi's [provider docs](https://pi.dev/docs/providers) for every supported provider and log in with `/login`. Archimedes doesn't ship a model of its own, and it works with whatever model your Pi account can reach. For the broader first run, Pi's [quickstart](https://pi.dev/docs/quickstart) is worth a read.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/splash-screen.png" width="600" alt="pi-archimedes splash screen">
+</p>
 
 ---
 
-## Interactive Commands
+## Give your agent some backup.
 
-Archimedes adds a set of dedicated TUI commands to manage your agent environment without leaving your session:
+Have one subagent explore the codebase while another reviews your changes. [Subagents](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/subagent/README.md) run with your choice of models and tools, stream their progress live into your terminal, and their tasks show up side by side on the [shared todo board](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/todo/README.md).
 
-| Command | Description |
-|---------|-------------|
-| `/archimedes` | Open the interactive graphical settings panel to configure themes, spinners, and thresholds. |
-| `/plugins` | Live plugin manager — toggle any of the 11 components on or off on the fly. |
-| `/mcp` | Open the Model Context Protocol management panel to browse servers, tools, and run OAuth. |
-| `/mcp setup` | Onboarding wizard to scaffold `.mcp.json` or import configs from Cursor, Claude Code, and VS Code. |
-| `/agents` | Visual CRUD manager for custom subagent personas in `.pi/agents/*.md` with model and tool pickers. |
-| `/todos` | Toggle the live multi-column todo tracking widget (`/todos clear` resets). |
-| `/sudo` | Inspect cached privileged credentials state (`/sudo forget` clears memory). |
+Their token usage and costs feed into the same status bar. More work happening at once, without losing sight of it.
 
----
+See the [subagent guide](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/subagent/README.md) for dispatching, agent definitions, and the `/agents` editor.
 
-## Feature Deep Dive
-
-### 🤖 Subagents & Live Streaming ([`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/subagent#readme))
-
-Offload tasks to specialized subagents with real-time visibility. Run single tasks or parallel agents (e.g., a researcher and a reviewer working simultaneously).
-
-- **Live TUI streaming**: Watch subagent reasoning and tool calls execute in real time. Tool states are color-coded (grey while running, green on success, red on failure) with human-readable argument previews.
-- **Unified cost accounting**: Per-subagent token usage (input, output, cache read/write) and exact dollar costs flow through the core bus directly into the footer.
-- **Visual agent manager (`/agents`)**: Create and edit `.pi/agents/*.md` files with a searchable list, model selector, tool toggle picker, and cross-scope collision warnings.
-
-<div align="center">
+<p align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
-</div>
+</p>
 
----
-
-### 📋 Coordinated Multi-Column Todo Board ([`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/todo#readme))
-
-Keep long workflows on track with structured task tracking visible to both you and the LLM.
-
-- **`manage_todo_list` tool**: Read and write operations for task planning and execution tracking.
-- **Multi-column display**: Main agent tasks appear on the left; each active subagent gets its own column on the right.
-- **Auto-clearing**: When all tasks complete, the board displays a brief all-done celebration for 2 seconds and automatically dismisses itself.
-- **Session persistence**: Survives `/reload` and session branch reconstruction.
-
-<div align="center">
+<p align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-and-subagent.png" width="750" alt="Todos and subagent side-by-side">
-</div>
+</p>
 
 ---
 
-### 💬 Interactive Questions (`ask`) ([`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/ask#readme))
+## Keep the decisions. Delegate the work.
 
-Stop agents from guessing when instructions are ambiguous. When an agent or a background subagent needs clarification, `ask` presents a clean interactive prompt.
+When a subagent needs your input, it can ask directly in your session — [ask](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/ask/README.md) presents the question right in your terminal. Pick an option, add a note, or write your own answer. It gets your decision and carries on.
 
-- **Subagent-to-parent TUI IPC**: Most question tools fail when called from background workers. Archimedes routes subagent `ask` calls through bidirectional IPC directly into the user's terminal. The subagent pauses, you answer in the TUI, and the subagent resumes with your choice.
-- **Tabbed multi-question flows**: Review and answer multiple questions at once with keyboard navigation.
-- **Inline notes & custom responses**: Attach notes to individual options or type custom answers via automatic "Other" handling.
+You don't have to copy messages between terminals to stay involved.
 
-<div align="center">
+<p align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/ask-subagent.png" width="750" alt="Interactive ask prompt from a subagent">
-</div>
+</p>
 
 ---
 
-### 🔌 Enterprise-Grade MCP Client ([`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/mcp#readme))
+## Bring the tools you already use.
 
-Integrate any Model Context Protocol server (stdio or HTTP/SSE) with full feature parity with dedicated MCP adapters.
+[Connect MCP servers](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/mcp/README.md), browse their tools, and handle authentication inside Pi. Import server definitions from Cursor, Claude Code, Claude Desktop, or VS Code rather than rebuilding your setup.
 
-- **Gateway proxy + direct tools**: Call tools via the universal `mcp` gateway or register high-frequency tools directly as `{server}_{tool}` for maximum token efficiency.
-- **Management panel (`/mcp panel`)**: Live status indicators (`●` connected, `⚠` needs auth, `✗` error, `⊘` disabled, `○` cached), tool list inspection, and server toggles.
-- **Setup wizard (`/mcp setup`)**: Scaffold `.mcp.json` or auto-import existing MCP servers from Cursor (`~/.cursor/mcp.json`), Claude Code (`~/.claude.json`), Claude Desktop, and VS Code.
-- **OAuth 2.1 + PKCE**: Browser-based authentication flow with secure OS credential store persistence (macOS Keychain, Linux Secret Service, Windows Credential Manager).
-- **Metadata cache**: Offline tool search and lazy connections via `~/.pi/agent/mcp-cache.json`.
+Start with `/mcp setup`. Manage it with `/mcp`.
 
 ---
 
-### 🔐 Safe Privileged Execution (`sudo`) ([`@pi-archimedes/sudo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/sudo#readme))
+## See what changed. Not just that something changed.
 
-Run administrative tasks safely without exposing credentials or causing terminal deadlocks.
+[Syntax-highlighted diffs](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/diff/README.md), side by side when there's room and unified when there isn't. Word-level highlights draw your eye to the changes inside each line.
 
-- **`sudo_exec` tool**: Executes privileged commands via `sudo -S` with explicit command confirmation and human reason display.
-- **Masked password prompt**: Passwords are entered via a secure TUI mask and piped strictly over stdin — never exposed in argv, environment variables, logs, or LLM context.
-- **Active bash guard**: Automatically detects and blocks interactive `sudo` inside the standard `bash` tool, preventing agent freeze and credential leakage.
-- **In-memory cache**: Secure credential cache with a 15-minute TTL, cleared on session end, authentication failure, or `/sudo forget`. Subagents are strictly prevented from prompting for root access.
+The details are easier to catch when they're easier to read.
 
----
-
-### 🔍 Shiki-Powered Syntax-Highlighted Diffs ([`@pi-archimedes/diff`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/diff#readme))
-
-Inspect code changes with clarity before applying them.
-
-- **Split and unified views**: Side-by-side split view or unified view, automatically adapting based on terminal width.
-- **Shiki syntax engine**: Rich highlighting matching your active Pi theme.
-- **Word-level diff emphasis**: Changed characters within modified lines are emphasized for surgical review.
-
-<div align="center">
+<p align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/diff-edit.png" width="750" alt="Shiki syntax-highlighted split diff">
-</div>
+</p>
 
 ---
 
-### 📊 Adaptive Footer & Cost Tracker ([`@pi-archimedes/footer`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/footer#readme))
+## A terminal worth spending your day in.
 
-A status bar that delivers vital session context without wasting vertical screen space.
+[Core](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md) frames the editor, animates the border while the agent works, and tidies the thinking blocks — with configurable colours. The [footer](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/footer/README.md) keeps your branch, model, context usage, and costs in view. [Paste screenshots](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) straight from the clipboard with inline previews.
 
-- **At-a-glance context**: Current working directory, git branch, linked worktree indicator (`🌲`), active model, and thinking level.
-- **Token & cost accumulator**: Live input/output tokens, cache read/write statistics, and combined session dollar costs (including all subagent usage).
-- **Dynamic context bar**: Color-coded progress bar (green → yellow → red) showing remaining context window capacity.
-- **Adaptive layout**: Automatically wraps from one to two or three lines on narrower viewports without clipping text.
+[Session naming](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/session-name/README.md) gives sessions useful names automatically so they're easier to find later. A small extra model call generates the title, so it's a separate (potentially billed) cost that isn't reflected in the footer's totals.
 
----
-
-### 🎬 Visual Chrome & Working Indicators ([`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/core#readme))
-
-- **Framed editor**: Clean borders around the input area with double-press quit guard.
-- **Border spinner**: 10 animated spinner styles running along the editor border while the agent is executing (pendulum, typing, pulse, marquee, wave, rain, sparkle), replacing Pi's native "Working" line.
-- **Muted thinking blocks**: Clean styling for chain-of-thought blocks with configurable labels and colors.
-- **Animated splash screen**: 9 configurable opening reveal animations.
+A few practical notes: image previews appear when you submit the message (the markers appear as you paste), and both image rendering and desktop alerts depend on your terminal's support — the [notify](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md) and [image-paste](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) docs cover what each needs.
 
 ---
 
-### 🖼️ Clipboard Image Paste ([`@pi-archimedes/image-paste`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/image-paste#readme))
+## A little more care with root access.
 
-Paste screenshots and UI mockups straight into your terminal prompt with instant inline previews:
-- Press `Ctrl+V` (Linux/macOS) or `Alt+V` (Windows) to attach clipboard images directly.
-- Built-in size guards prevent accidental multi-megabyte blowouts.
+For tasks that need sudo, [sudo](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/sudo/README.md) shows you the exact command and its reason before you enter your password in a masked prompt—not the chat. Credentials are cached in memory with an expiry, and `/sudo forget` clears them.
 
-> [!NOTE]
-> On Linux, clear Pi's default paste binding in `~/.pi/agent/keybindings.json` (`{ "app.clipboard.pasteImage": [] }`) so Archimedes' preview-enabled handler takes over seamlessly.
+## Step away without losing track.
 
----
+[Notify](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md) alerts you when the agent finishes or a prompt needs your attention. Alerts wait before firing, and typing cancels anything pending.
 
-### 🔔 Delayed Desktop Notifications ([`@pi-archimedes/notify`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/notify#readme))
-
-Step away during long builds or model generations with peace of mind.
-- **Delayed trigger**: Alerts trigger only after 30 seconds of inactivity — never spamming you while actively typing.
-- **Keystroke circuit breaker**: Touching any key immediately cancels pending alerts.
-- **Terminal protocol support**: Native OSC 9, OSC 777, OSC 99, and PowerShell toasts with full tmux passthrough.
+You can leave the terminal to do its thing.
 
 ---
 
-### 🏷️ AI Session Auto-Naming ([`@pi-archimedes/session-name`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/session-name#readme))
+## The whole suite. Or just your favourite parts.
 
-Never lose track of a past session. After your first exchange, a lightweight background model call generates a concise, descriptive 3–8 word session title so you can resume sessions easily with `pi -r`. Respects manual titles set via `/name`.
+One install brings everything together. Switch optional extensions on or off with `/plugins`, then `/reload` to apply. Use `/archimedes` to adjust the available settings.
 
----
-
-## Configuration
-
-### Interactive Settings Panel
-
-Run `/archimedes` at any time to open the full graphical settings dashboard. Adjust themes, spinner speeds, notification delays, and thresholds with live keyboard controls.
-
-### Plugin Manager
-
-Run `/plugins` to toggle any component on or off. Disabled plugins are cleanly unloaded on the next `/reload`.
-
-### Configuration Reference
-
-Settings are persisted in `~/.pi/agent/settings.json`:
-
-```jsonc
-{
-  // Core visual chrome
-  "archimedes.core": {
-    "editorSpinBorder": true,       // Border animation while agent is working
-    "editorSpinStyle": "pendulum",  // pendulum | typing | pulse | marquee | wave-rows | rain | sparkle
-    "editorSpinSpeed": "normal",    // slow | normal | fast
-    "editorSpinLabel": "Working",   // Label beside spinner
-    "animationStyle": "vertical-up",// Splash animation
-    "mutedTheme": false             // Subdued thinking blocks
-  },
-
-  // Footer status bar
-  "archimedes.footer": {
-    "splitThreshold": 150           // Column width threshold for single-line vs multi-line layout
-  },
-
-  // Shiki diff renderer
-  "archimedes.diff": {
-    "diffTheme": "github-dark",     // Shiki color theme
-    "diffSplitMinWidth": 150        // Minimum terminal columns for side-by-side view
-  },
-
-  // Desktop notifications
-  "archimedes.notify": {
-    "notifyOnAgentEnd": true,
-    "notifyOnQuestion": true,
-    "delayMs": 30000                // Inactivity delay before alerting
-  },
-
-  // MCP Adapter
-  "archimedes.mcp": {
-    "directTools": true,            // Expose {server}_{tool} direct tool definitions
-    "idleTimeout": 10,              // Minutes before idling MCP connections close
-    "autoAuth": false               // Inline OAuth prompt on needs-auth servers
-  },
-
-  // Sudo privilege execution
-  "archimedes.sudo": {
-    "ttlMs": 900000,                // Password cache lifetime (15 minutes)
-    "defaultTimeoutMs": 120000      // Execution timeout per command
-  }
-}
-```
+Only want the diffs, footer, or MCP tools? Each component is available separately — see [Components](#components).
 
 ---
 
-## Modular Packages
+## Commands
 
-Prefer to cherry-pick? Every component in Archimedes is published as an independent, standalone package:
+| Command | Scope | Notes |
+|---------|-------|-------|
+| `/plugins` | Suite | Toggle the ten optional extensions (core is always on and not toggleable). Toggles persist immediately; `/reload` (or a fresh session) applies them. |
+| `/archimedes` | Suite | Interactive settings panel — arrow keys change values, Enter edits supported fields, `s` saves, Esc discards the current edits. Settings captured at startup need `/reload`. Not every setting has a panel control. |
+| `/agents` | Suite, subagent enabled | Browse, create, and edit custom subagent definitions in `.pi/agents/*.md`. |
+| `/todos` | Todo component | Refreshes the todo widget and reports its status. `/todos clear` clears the list. (The board's visibility is not a `/todos` toggle — see the [todo docs](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/todo/README.md).) |
+| `/mcp`, `/mcp setup` | MCP component | Manage servers and run logins; the setup wizard scaffolds `.mcp.json` or imports configs from Cursor, Claude Code, Claude Desktop, or VS Code. |
+| `/sudo`, `/sudo forget` | Sudo component | Inspect cached credential state; `forget` clears it. |
+| `/reload` | Pi | Applies plugin changes and settings read at startup. |
 
-| Package | npm | Description |
-|---------|-----|-------------|
-| **Core** | [`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/core#readme) | Event bus, animated splash screen, framed editor, working spinner |
-| **Footer** | [`@pi-archimedes/footer`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/footer#readme) | Status bar, token counters, real-dollar costs, context window bar |
-| **Subagent** | [`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/subagent#readme) | Subagent dispatch, live streaming, parallel execution, `/agents` TUI |
-| **Todo** | [`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/todo#readme) | Multi-column todo widget with auto-clearing and subagent tracking |
-| **Ask** | [`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/ask#readme) | Tabbed questions, inline notes, subagent-to-parent TUI IPC |
-| **MCP** | [`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/mcp#readme) | Full MCP client, `/mcp` management panel, setup wizard, OAuth 2.1 |
-| **Sudo** | [`@pi-archimedes/sudo`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/sudo#readme) | Safe `sudo_exec`, masked password prompt, bash interactive guard |
-| **Diff** | [`@pi-archimedes/diff`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/diff#readme) | Shiki-highlighted side-by-side and unified terminal diffs |
-| **Image Paste** | [`@pi-archimedes/image-paste`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/image-paste#readme) | Direct clipboard screenshot paste (`Ctrl+V`) with inline previews |
-| **Notify** | [`@pi-archimedes/notify`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/notify#readme) | Inactivity-delayed desktop alerts with keystroke circuit breaker |
-| **Session Name** | [`@pi-archimedes/session-name`](https://github.com/danielcherubini/pi-archimedes/tree/main/packages/session-name#readme) | Automated AI session title generator after first conversation turn |
+---
 
-To install an individual component:
+## Settings
+
+Every component keeps its own namespace under `~/.pi/agent/settings.json`, which Pi parses as **strict JSON** (no comments — unlike MCP server configs, which accept JSONC). Each component's README documents its namespace, fields, and defaults — including [core](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md) (chrome, spinner, thinking), [footer](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/footer/README.md), [diff](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/diff/README.md), [notify](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md), [mcp](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/mcp/README.md), and [sudo](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/sudo/README.md) (also strict JSON). The `/archimedes` panel covers the settings that have a control; not everything does.
+
+---
+
+## Components
+
+| Component | npm package | What it adds |
+|-----------|-------------|--------------|
+| **Core** | [`@pi-archimedes/core`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/core/README.md) | Shared event bus, splash screen, framed editor, working spinner, thinking blocks |
+| **Subagent** | [`@pi-archimedes/subagent`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/subagent/README.md) | Live subagent dispatch, `/agents`, custom agent definitions |
+| **Todo** | [`@pi-archimedes/todo`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/todo/README.md) | Multi-column todo board with subagent columns and auto-clear |
+| **Ask** | [`@pi-archimedes/ask`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/ask/README.md) | Structured questions — including subagent questions relayed into your terminal |
+| **MCP** | [`@pi-archimedes/mcp`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/mcp/README.md) | `/mcp` management, setup wizard, OAuth, config imports |
+| **Sudo** | [`@pi-archimedes/sudo`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/sudo/README.md) | `sudo_exec` with masked password prompt and interactive-sudo guard |
+| **Diff** | [`@pi-archimedes/diff`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/diff/README.md) | Syntax-highlighted side-by-side and unified diffs with word-level highlights |
+| **Footer** | [`@pi-archimedes/footer`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/footer/README.md) | Branch, model, context usage, and token/cost status bar |
+| **Image Paste** | [`@pi-archimedes/image-paste`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/image-paste/README.md) | Clipboard image paste with inline previews |
+| **Notify** | [`@pi-archimedes/notify`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/notify/README.md) | Delayed desktop notifications with input cancellation |
+| **Session Name** | [`@pi-archimedes/session-name`](https://github.com/danielcherubini/pi-archimedes/blob/main/packages/session-name/README.md) | Automatic session titles |
+
+The full suite is the supported connected setup — the integrations above (subagent costs in the footer, subagent columns on the todo board, subagent questions in the terminal) light up when the relevant components are loaded together.
+
+To install just the components you want:
 
 ```bash
-pi install npm:@pi-archimedes/<package-name>
+pi install npm:@pi-archimedes/core
+pi install npm:@pi-archimedes/subagent
+pi install npm:@pi-archimedes/todo
+pi install npm:@pi-archimedes/ask
+pi install npm:@pi-archimedes/mcp
+pi install npm:@pi-archimedes/sudo
+pi install npm:@pi-archimedes/diff
+pi install npm:@pi-archimedes/footer
+pi install npm:@pi-archimedes/image-paste
+pi install npm:@pi-archimedes/notify
+pi install npm:@pi-archimedes/session-name
 ```
-
-> [!IMPORTANT]
-> When installed via the full `pi-archimedes` meta package, all components connect to the shared core bus — enabling subagent costs in the footer, subagent columns in the todo board, subagent question prompts in the TUI, and coordinated theme styling.
 
 ---
 
 ## Development
 
-pi-archimedes is structured as a pnpm monorepo.
-
-```bash
-# Clone the repository
-git clone https://github.com/danielcherubini/pi-archimedes.git
-cd pi-archimedes
-
-# Install dependencies (requires pnpm >= 10)
-pnpm install
-
-# Type-check all packages
-pnpm -r exec -- tsc --noEmit
-
-# Run unit tests
-pnpm test
-```
-
-### Local Testing with Pi
-
-To test your local build inside Pi, symlink the repository directly into Pi's extensions directory:
-
-```bash
-ln -s $(pwd) ~/.pi/agent/extensions/pi-archimedes
-```
-
-Pi's extension loader automatically picks up `meta/src/index.ts` from the root `package.json`.
-
-For contribution conventions, architecture decisions, and release workflows, see [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).
+`pi-archimedes` is the meta package of a pnpm monorepo — clone it, run `pnpm install`, and test the full suite from source. For the component layout, no-build-step workflow, and local testing with Pi (including a warning about not loading the local copy and an npm copy at the same time), see the [root README's development instructions](https://github.com/danielcherubini/pi-archimedes#development) and [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).

--- a/meta/README.md
+++ b/meta/README.md
@@ -200,4 +200,4 @@ pi install npm:@pi-archimedes/session-name
 
 ## Development
 
-`pi-archimedes` is the meta package of a pnpm monorepo — clone it, run `pnpm install`, and test the full suite from source. For the component layout, no-build-step workflow, and local testing with Pi (including a warning about not loading the local copy and an npm copy at the same time), see the [root README's development instructions](https://github.com/danielcherubini/pi-archimedes#development) and [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).
+`pi-archimedes` is the meta package of a pnpm monorepo — clone it, run `pnpm install`, and test the full suite from source. For the component layout, no-build-step workflow, and local testing with Pi (including a warning about not loading the local copy and an npm copy at the same time), see the [root README's development instructions](https://github.com/danielcherubini/pi-archimedes/blob/main/README.md#development) and [AGENTS.md](https://github.com/danielcherubini/pi-archimedes/blob/main/AGENTS.md).

--- a/meta/package.json
+++ b/meta/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "pi-package"
   ],
-  "description": "The ultimate extension suite for the Pi coding agent — subagents, shared todos, interactive ask IPC, MCP adapter, safe sudo, Shiki diffs, and unified TUI",
+  "description": "Parallel agents, shared task lists, MCP tools, and a polished terminal for the Pi coding agent.",
   "files": [
     "src",
     "README.md"

--- a/meta/package.json
+++ b/meta/package.json
@@ -5,9 +5,10 @@
   "keywords": [
     "pi-package"
   ],
-  "description": "Visual polish and useful context for the Pi coding agent TUI",
+  "description": "The ultimate extension suite for the Pi coding agent — subagents, shared todos, interactive ask IPC, MCP adapter, safe sudo, Shiki diffs, and unified TUI",
   "files": [
-    "src"
+    "src",
+    "README.md"
   ],
   "main": "./src/index.ts",
   "dependencies": {

--- a/packages/ask/README.md
+++ b/packages/ask/README.md
@@ -1,51 +1,43 @@
 # @pi-archimedes/ask
 
-**Structured interactive question tool with tabbed navigation, inline notes, and subagent IPC bridging for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Keep the decisions. Delegate the work.**
 
-When coding agents need architectural guidance or clarification, plain text questions create ambiguity and endless back-and-forth loops. `@pi-archimedes/ask` gives agents a structured prompt tool featuring tabbed multi-part forms, single-click pickers, inline note annotations, and markdown context cards. Uniquely, it bridges subagent questions directly into the parent terminal over bidirectional IPC without breaking execution.
+When an agent needs you, ask turns the need into a structured prompt right in the terminal — options, inline notes, a freeform fallback — so the answer carries your exact intent back. From subagents, too: their questions surface in the parent TUI, the agent waits, and the work carries on with your choice. No copy-pasting messages between panes to stay involved.
 
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/ask-subagent.png" width="700" alt="Ask prompt routed from subagent to parent TUI">
-</div>
+## Install
 
-## Quick Start
-
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/ask
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Bidirectional Subagent IPC** — When a dispatched subagent calls `ask`, the interactive prompt renders directly in your live parent terminal. The subagent safely pauses, you submit your answers, and it resumes immediately with your exact choices.
-- **Tabbed Multi-Question Flows** — Move across multiple interrelated questions using arrow keys and submit a batch review in one atomic step.
-- **Single-Question Quick Picker** — Instant one-click selection for fast binary or multiple-choice questions.
-- **Inline Note Annotations** — Press a key on any option to type custom context, constraints, or caveats that pass back alongside the answer.
-- **Built-in "Other" Input** — Automatic custom response field allows users to type freeform text whenever options don't cover the situation.
-- **Rich Markdown Context** — Renders formatted code blocks, headers, and descriptions above question options.
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the tool up in a running session.
 
----
+## What you get
 
-## Tool Usage
+- **Tabbed multi-question flows** — arrow keys move between related questions; a final batch review submits the whole set in one step.
+- **Single-question picker** — for fast multiple-choice questions, keyboard-driven: up/down to move, `Enter` to submit, `Esc` to cancel. Nothing requires a mouse.
+- **Inline note per option** — `Tab` opens a note editor on the hovered option; `Enter` submits it. Notes travel back with the answer, so context and constraints ride along.
+- **Multiple selection** — `multi: true` collects several answers from one question.
+- **Built-in "Other (type your own)"** — whenever the options don't cover it, a freeform response field is always available.
+- **Markdown context** — the agent can attach formatted descriptions, headers, and code blocks above the options, so the question presents context you can actually read.
 
-### Single Quick Question
+## Tool usage
+
+### Single quick question
 
 ```jsonc
 {
@@ -61,7 +53,7 @@ pi install npm:pi-archimedes
 }
 ```
 
-### Multi-Question with Markdown & Multiple Selection
+### Multi-question flow with markdown context and multiple selection
 
 ```jsonc
 {
@@ -91,10 +83,16 @@ pi install npm:pi-archimedes
 }
 ```
 
----
+An option the agent marks `recommended` is flagged in the UI; `description` renders as markdown above the options.
 
-## Part of the Archimedes Suite
+## Subagent relay
 
-When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/ask` automatically pairs with `@pi-archimedes/subagent` to let background subagents ask you questions directly in your terminal without breaking execution.
+When a subagent dispatched by `@pi-archimedes/subagent` calls `ask`, the same prompt relayed over the bidirectional IPC channel appears in your live terminal, even mid-stream — the subagent blocks while you answer and resumes carrying your exact choices. It works alongside the live streaming and cost tracking, no temp files or pipes. This relay only applies to Archimedes-dispatched subagents; a question from a directly-called agent simply renders in-line.
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/ask-subagent.png" width="700" alt="Ask prompt routed from subagent to parent TUI">
+</div>
+
+On/off is managed by the suite: toggle via `/plugins` (`archimedes.ask.enabled`, default on).
+
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/ask/README.md
+++ b/packages/ask/README.md
@@ -1,37 +1,51 @@
 # @pi-archimedes/ask
 
-Structured question tool with tabbed multi-question flow and inline note editing.
+**Structured interactive question tool with tabbed navigation, inline notes, and subagent IPC bridging for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-When language models need clarification, asking unstructured questions in text leads to guessing and back-and-forth ambiguity. This tool provides structured choice prompts, tabbed navigation for multi-part questions, and inline note editing so users can deliver clear, complete guidance in a single step.
+When coding agents need architectural guidance or clarification, plain text questions create ambiguity and endless back-and-forth loops. `@pi-archimedes/ask` gives agents a structured prompt tool featuring tabbed multi-part forms, single-click pickers, inline note annotations, and markdown context cards. Uniquely, it bridges subagent questions directly into the parent terminal over bidirectional IPC without breaking execution.
 
-## What you get
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/ask-subagent.png" width="700" alt="Ask prompt routed from subagent to parent TUI">
+</div>
 
-- **Tabbed multi-question flow** — submit review for multiple questions at once
-- **Single-question picker** — instant submit for quick decisions
-- **Inline note editing** — add custom notes and context per option
-- **Markdown context descriptions** — rich context descriptions rendered above options
-- **Automatic "Other" handling** — built-in custom response option with auto-focus
-- **Subagent support** — subagents can call `ask` and questions appear in the parent agent's TUI via bidirectional IPC
+## Quick Start
 
-## Screenshots
+### 1. Install Pi (if needed)
 
-![ask from a subagent](../../docs/images/ask-subagent.png)
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
 
-## Install
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/ask
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Usage
+---
 
-Single question example:
+## What You Get
+
+- **Bidirectional Subagent IPC** — When a dispatched subagent calls `ask`, the interactive prompt renders directly in your live parent terminal. The subagent safely pauses, you submit your answers, and it resumes immediately with your exact choices.
+- **Tabbed Multi-Question Flows** — Move across multiple interrelated questions using arrow keys and submit a batch review in one atomic step.
+- **Single-Question Quick Picker** — Instant one-click selection for fast binary or multiple-choice questions.
+- **Inline Note Annotations** — Press a key on any option to type custom context, constraints, or caveats that pass back alongside the answer.
+- **Built-in "Other" Input** — Automatic custom response field allows users to type freeform text whenever options don't cover the situation.
+- **Rich Markdown Context** — Renders formatted code blocks, headers, and descriptions above question options.
+
+---
+
+## Tool Usage
+
+### Single Quick Question
 
 ```jsonc
 {
@@ -47,38 +61,40 @@ Single question example:
 }
 ```
 
-Multi-question with notes example:
+### Multi-Question with Markdown & Multiple Selection
 
 ```jsonc
 {
   "questions": [
     {
       "id": "priority",
-      "question": "What's the implementation priority?",
-      "description": "Choose the order for tackling these tasks.",
+      "question": "What is the implementation priority?",
+      "description": "Choose the initial focus area for this milestone.",
+      "recommended": 0,
       "options": [
-        { "label": "Core features first" },
-        { "label": "Tests first" },
-        { "label": "Design first" }
-      ],
-      "recommended": 0
+        { "label": "Core architecture first" },
+        { "label": "Unit tests first" },
+        { "label": "CLI interface first" }
+      ]
     },
     {
-      "id": "approach",
-      "question": "Any additional constraints?",
+      "id": "constraints",
+      "question": "Select applicable constraints:",
+      "multi": true,
       "options": [
         { "label": "No breaking changes" },
-        { "label": "Performance critical" },
-        { "label": "None" }
-      ],
-      "multi": true
+        { "label": "Zero external dependencies" },
+        { "label": "Strict backward compatibility" }
+      ]
     }
   ]
 }
 ```
 
-## Integration
+---
 
-Depends on [`@pi-archimedes/core`](../core) for the shared event bus used to relay subagent questions. Subagents call `ask` and questions are safely dispatched to the parent agent's TUI over bidirectional IPC with no temporary files.
+## Part of the Archimedes Suite
 
-← Back to [pi-archimedes](../../README.md)
+When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/ask` automatically pairs with `@pi-archimedes/subagent` to provide transparent human-in-the-loop governance for background agent swarms.
+
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/ask/README.md
+++ b/packages/ask/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the tool up in a running session.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the tool up in a running session.
 
 ## What you get
 

--- a/packages/ask/README.md
+++ b/packages/ask/README.md
@@ -95,6 +95,6 @@ pi install npm:pi-archimedes
 
 ## Part of the Archimedes Suite
 
-When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/ask` automatically pairs with `@pi-archimedes/subagent` to provide transparent human-in-the-loop governance for background agent swarms.
+When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/ask` automatically pairs with `@pi-archimedes/subagent` to let background subagents ask you questions directly in your terminal without breaking execution.
 
 ← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,6 +59,6 @@ Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.core` n
 
 ## Part of the Archimedes Suite
 
-`@pi-archimedes/core` is included automatically in the [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) meta package, where it serves as the backbone for the status footer, subagent swarms, question IPC, and todo tracking.
+`@pi-archimedes/core` is included automatically in the [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) meta package, where it serves as the backbone for the status footer, subagents, question IPC, and todo tracking.
 
 ← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,7 +29,7 @@ After installing Pi, choose one installation command above, then `cd` into your 
 ## What you get
 
 - **Splash screen** — an animated greeting when the session launches, in one of nine reveal styles (`diagonal`, `top-right`, `bottom-left`, `bottom-right`, `center-out`, `wave`, `horizontal`, `vertical`, `vertical-up`).
-- **Framed editor** — your input in a clean bordered frame, with a double-press quit guard (`Ctrl+C` twice) so a stray keystroke doesn't end the session.
+- **Framed editor** — your input in a clean bordered frame, with a double-press guard on the quit key (`Ctrl+C` by default) so a stray keystroke doesn't end the session.
 - **Working spinner on the border** — one of ten animating styles (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) traces the editor frame while the agent works, replacing Pi's native "Working" line.
 - **Thinking blocks** — chain-of-thought output gets a consistent label, colour, and layout; `codeUnindent` strips the common indentation so code in reasoning reads flush.
 - **The bus** (`@pi-archimedes/core/bus`) — a global pub/sub event system: `COST_UPDATE`, `ASK_REQUEST`, `TODOS_UPDATE`, `TODOS_CLEAR`… subagent costs flow to the footer through it, subagent todos to the task board, subagent questions to the ask UI.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you into a supported provider and `/model` picks a model; the full walkthrough, including API-key setup, is in the repo's [setup section](https://github.com/danielcherubini/pi-archimedes#setup) and Pi's own [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md). A session that's already running picks up the extension with `/reload`.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you into a supported provider and `/model` picks a model; the full walkthrough, including API-key setup, is in the repo's [setup section](https://github.com/danielcherubini/pi-archimedes#setup) and Pi's own [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md). A session that's already running picks up the extension with `/reload`.
 
 ## What you get
 
@@ -32,7 +32,7 @@ Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on a
 - **Framed editor** — your input in a clean bordered frame, with a double-press quit guard (`Ctrl+C` twice) so a stray keystroke doesn't end the session.
 - **Working spinner on the border** — one of ten animating styles (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) traces the editor frame while the agent works, replacing Pi's native "Working" line.
 - **Thinking blocks** — chain-of-thought output gets a consistent label, colour, and layout; `codeUnindent` strips the common indentation so code in reasoning reads flush.
-- **The bus** (`@pi-archimedes/core/bus`) — a global pub/sub event system: `COST_UPDATE`, `ASK_REQUEST`, `TODOS_UPDATE`, `TODOS_CLEAR`… subagent costs flow to the footer through it; subagent questions flow to the ask UI through it.
+- **The bus** (`@pi-archimedes/core/bus`) — a global pub/sub event system: `COST_UPDATE`, `ASK_REQUEST`, `TODOS_UPDATE`, `TODOS_CLEAR`… subagent costs flow to the footer through it, subagent todos to the task board, subagent questions to the ask UI.
 - **Shared utilities** — text truncation and width measurement, colour formatting, settings I/O, and startup profiling.
 
 ## Settings
@@ -55,6 +55,6 @@ In the suite, `/archimedes` offers panel controls for the settings that have the
 
 ## Part of the suite
 
-In [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), core is always registered — it isn't one of the `/plugins` toggles — and it underpins what the other components share: the bus that feeds subagent costs and todos to the footer and questions to the ask UI, the chrome and colour utilities the diff renderer and TUIs use.
+In [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), core is always registered — it isn't one of the `/plugins` toggles — and it underpins what the other components share: the bus that feeds subagent costs to the footer, subagent todos to the task board, and subagent questions to the ask UI, plus the chrome and colour utilities the TUIs use. The diff renderer is standalone and does not depend on core's chrome — it only shares the suite when it loads.
 
 ← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,51 +1,64 @@
 # @pi-archimedes/core
 
-The visual foundation and shared infrastructure for pi-archimedes.
+**Visual foundation, working spinners, framed editor, and reactive event bus for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Core is what you see first — the animated splash screen, the framed editor, and styled thinking blocks. It is also the invisible glue: an event bus that lets packages talk to each other, shared text and color utilities, and a settings system. Install it standalone for polished chrome, or let the meta package include it automatically.
+Core provides the visual polish you see on every session and the invisible infrastructure powering the entire Archimedes ecosystem. It transforms Pi's default prompt into a framed terminal editor with animated border spinners while the agent works, styles chain-of-thought blocks, and provides the shared reactive bus that lets extensions communicate.
 
-## What you get
+## Quick Start
 
-- **Animated splash screen** — configurable reveal animations (9 styles) that set the tone when Pi starts
-- **Framed editor** — custom editor component with double-press quit guard
-- **Styled thinking blocks** — configurable label text, color, and muted theme option; optional code block unindenting
-- **Event bus** — shared pub/sub channel that lets packages communicate (subagent costs → footer, subagent questions → ask, etc.)
-- **Shared utilities** — text truncation/width calculation, color helpers, config loading, settings I/O, and startup profiling
+### 1. Install Pi (if needed)
 
-## Install
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/core
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Usage
+---
 
-Core works automatically when Pi starts. It sets the session header, editor frame, and thinking block renderer automatically. There are no manual commands or tools to call.
+## What You Get
 
-For configuration:
-- When using the meta package, run `/archimedes` to access the settings panel.
-- For standalone installs, edit `archimedes.core` in `~/.pi/agent/settings.json`.
+- **Framed Editor** — Clean bordered input box with double-press quit guard (`Ctrl+C` twice to exit).
+- **Editor Border Spinner** — 10 gallery-derived animations (pendulum, typing, pulse, marquee, wave-rows, columns, cascade, diagonal-swipe, rain, sparkle) that trace the editor border while the agent works, replacing Pi's native "Working" line.
+- **Animated Splash Screen** — 9 configurable reveal animations that greet you on session launch.
+- **Styled Thinking Blocks** — Clean formatting for chain-of-thought reasoning with custom labels, colors, and muted theme support.
+- **Reactive Event Bus (`@pi-archimedes/core/bus`)** — High-performance pub/sub event bus that enables cross-extension cooperation (e.g. subagent costs routing to the footer, subagent questions routing to the ask UI).
+- **Shared Utilities** — Text truncation, width calculation, color formatting, settings I/O, and startup profiling.
+
+---
 
 ## Settings
 
-Core reads configuration from the `archimedes.core` namespace in `~/.pi/agent/settings.json`.
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.core` namespace (or configured interactively via `/archimedes` when using the full suite):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `mutedTheme` | bool | `false` | Use subdued colors for thinking blocks |
-| `codeUnindent` | bool | `true` | Remove common indentation from code blocks inside thinking sections |
-| `labelText` | string | `Thinking...` | Custom prefix shown before thinking blocks |
-| `labelColor` | string | `255,215,0` | RGB color for the thinking label |
-| `animationStyle` | string | `vertical-up` | Splash animation style (9 options) |
+| `editorSpinBorder` | bool | `true` | Show animated border spinner on the editor while the agent works |
+| `editorSpinStyle` | string | `pendulum` | Spinner animation style (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) |
+| `editorSpinSpeed` | string | `normal` | Border spinner speed (`slow`, `normal`, `fast`) |
+| `editorSpinLabel` | string | `Working` | Text label displayed alongside the border spinner |
+| `animationStyle` | string | `vertical-up` | Splash screen reveal style (9 animation variants) |
+| `mutedTheme` | bool | `false` | Subdue thinking block colors |
+| `codeUnindent` | bool | `true` | Strip common indentation from code blocks in thinking sections |
+| `labelText` | string | `Thinking...` | Prefix displayed before thinking blocks |
+| `labelColor` | string | `255,215,0` | RGB color string for the thinking label |
 
-## Integration
+---
 
-Core is auto-included by the `pi-archimedes` meta package. All other archimedes packages depend on `@pi-archimedes/core` for the event bus, chrome elements, and utilities. Standalone installation provides the visual chrome and bus without the other archimedes features.
+## Part of the Archimedes Suite
 
-← Back to [pi-archimedes](../../README.md)
+`@pi-archimedes/core` is included automatically in the [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) meta package, where it serves as the backbone for the status footer, subagent swarms, question IPC, and todo tracking.
+
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,64 +1,60 @@
 # @pi-archimedes/core
 
-**Visual foundation, working spinners, framed editor, and reactive event bus for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**A terminal worth spending your day in — plus the plumbing that keeps the rest of the suite talking.**
 
-Core provides the visual polish you see on every session and the invisible infrastructure powering the entire Archimedes ecosystem. It transforms Pi's default prompt into a framed terminal editor with animated border spinners while the agent works, styles chain-of-thought blocks, and provides the shared reactive bus that lets extensions communicate.
+Core is the face of every session: the animated splash screen on launch, the framed editor where you type, the border spinner that works while the agent works, and clean, labelled thinking blocks. Under the surface it runs the shared event bus through which the other components pass costs, todos, and questions — and the text, colour, and settings utilities they all build on.
 
-## Quick Start
+## Install
 
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/core
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead (which includes core and the ten optional components):
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Framed Editor** — Clean bordered input box with double-press quit guard (`Ctrl+C` twice to exit).
-- **Editor Border Spinner** — 10 gallery-derived animations (pendulum, typing, pulse, marquee, wave-rows, columns, cascade, diagonal-swipe, rain, sparkle) that trace the editor border while the agent works, replacing Pi's native "Working" line.
-- **Animated Splash Screen** — 9 configurable reveal animations that greet you on session launch.
-- **Styled Thinking Blocks** — Clean formatting for chain-of-thought reasoning with custom labels, colors, and muted theme support.
-- **Reactive Event Bus (`@pi-archimedes/core/bus`)** — High-performance pub/sub event bus that enables cross-extension cooperation (e.g. subagent costs routing to the footer, subagent questions routing to the ask UI).
-- **Shared Utilities** — Text truncation, width calculation, color formatting, settings I/O, and startup profiling.
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you into a supported provider and `/model` picks a model; the full walkthrough, including API-key setup, is in the repo's [setup section](https://github.com/danielcherubini/pi-archimedes#setup) and Pi's own [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md). A session that's already running picks up the extension with `/reload`.
 
----
+## What you get
+
+- **Splash screen** — an animated greeting when the session launches, in one of nine reveal styles (`diagonal`, `top-right`, `bottom-left`, `bottom-right`, `center-out`, `wave`, `horizontal`, `vertical`, `vertical-up`).
+- **Framed editor** — your input in a clean bordered frame, with a double-press quit guard (`Ctrl+C` twice) so a stray keystroke doesn't end the session.
+- **Working spinner on the border** — one of ten animating styles (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) traces the editor frame while the agent works, replacing Pi's native "Working" line.
+- **Thinking blocks** — chain-of-thought output gets a consistent label, colour, and layout; `codeUnindent` strips the common indentation so code in reasoning reads flush.
+- **The bus** (`@pi-archimedes/core/bus`) — a global pub/sub event system: `COST_UPDATE`, `ASK_REQUEST`, `TODOS_UPDATE`, `TODOS_CLEAR`… subagent costs flow to the footer through it; subagent questions flow to the ask UI through it.
+- **Shared utilities** — text truncation and width measurement, colour formatting, settings I/O, and startup profiling.
 
 ## Settings
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.core` namespace (or configured interactively via `/archimedes` when using the full suite):
+Settings live in `~/.pi/agent/settings.json` under `archimedes.core`. The file is **strict JSON — no comments or trailing commas** (unlike the MCP server config files, which accept both).
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `editorSpinBorder` | bool | `true` | Show animated border spinner on the editor while the agent works |
-| `editorSpinStyle` | string | `pendulum` | Spinner animation style (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) |
-| `editorSpinSpeed` | string | `normal` | Border spinner speed (`slow`, `normal`, `fast`) |
-| `editorSpinLabel` | string | `Working` | Text label displayed alongside the border spinner |
-| `animationStyle` | string | `vertical-up` | Splash screen reveal style (9 animation variants) |
-| `mutedTheme` | bool | `false` | Subdue thinking block colors |
+| `editorSpinBorder` | bool | `true` | Show the animated border spinner while the agent works |
+| `editorSpinStyle` | string | `pendulum` | One of the ten spinner styles |
+| `editorSpinSpeed` | string | `normal` | `slow`, `normal`, or `fast` |
+| `editorSpinLabel` | string | `Working` | Label shown alongside the border spinner |
+| `animationStyle` | string | `vertical-up` | Splash-screen reveal style (the nine styles above) |
+| `labelText` | string | `Thinking...` | Prefix before thinking blocks |
+| `labelColor` | string | `255,215,0` | RGB string for the thinking label |
 | `codeUnindent` | bool | `true` | Strip common indentation from code blocks in thinking sections |
-| `labelText` | string | `Thinking...` | Prefix displayed before thinking blocks |
-| `labelColor` | string | `255,215,0` | RGB color string for the thinking label |
+| `mutedTheme` | bool | `false` | Stored, but **not yet effective** — the current thinking renderer doesn't consult it, so treat it as a pending toggle |
 
----
+In the suite, `/archimedes` offers panel controls for the settings that have them; `/reload` applies any that are read at startup.
 
-## Part of the Archimedes Suite
+## Part of the suite
 
-`@pi-archimedes/core` is included automatically in the [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) meta package, where it serves as the backbone for the status footer, subagents, question IPC, and todo tracking.
+In [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), core is always registered — it isn't one of the `/plugins` toggles — and it underpins what the other components share: the bus that feeds subagent costs and todos to the footer and questions to the ask UI, the chrome and colour utilities the diff renderer and TUIs use.
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -1,49 +1,61 @@
 # @pi-archimedes/diff
 
-Shiki-powered diff rendering for the [Pi coding agent](https://github.com/earendil-works/pi).
+**Shiki-powered syntax-highlighted side-by-side and unified diffs for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Syntax-highlighted, word-level diffs make reviewing code changes effortless. By rendering clear side-by-side or unified diffs directly in your terminal with themes matched to your environment, code modifications can be inspected at a glance before committing.
+Reviewing code modifications in raw text diffs leads to missed regressions and eye strain. `@pi-archimedes/diff` brings full syntax highlighting powered by [Shiki](https://shiki.style) directly into your terminal, with adaptive split side-by-side views, word-level change emphasis, and colors that match your active terminal theme.
 
-## What you get
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/diff-edit.png" width="700" alt="Shiki syntax-highlighted split diff">
+</div>
 
-- **Split and unified views** — side-by-side split diff or traditional unified view, auto-selected based on terminal width
-- **Shiki syntax highlighting** — full syntax highlighting powered by [Shiki](https://shiki.style), with auto-derived theme colors
-- **Word-level emphasis** — changed characters within lines are highlighted at word level for precise change tracking
-- **Graceful fallback** — falls back to plain text diff when Shiki is unavailable or the language is unrecognized
-- **Configurable thresholds** — control minimum terminal width for split view and minimum code width per side
+## Quick Start
 
-## Screenshots
+### 1. Install Pi (if needed)
 
-### Split diff view
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
 
-Side-by-side diff with syntax highlighting, word-level emphasis on changed characters, and line numbers:
+### 2. Install
 
-![diff edit](../../docs/images/diff-edit.png)
-
-## Install
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/diff
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
+---
+
+## What You Get
+
+- **Split & Unified Views** — Side-by-side split diff or traditional unified view, automatically selected based on terminal column width.
+- **Shiki Syntax Highlighting** — Full language-aware syntax highlighting powered by Shiki with theme-derived palettes.
+- **Word-Level Emphasis** — Sub-line character diffs highlight exactly which tokens or words were altered.
+- **Graceful Fallback** — Transparently falls back to plain text diffs when Shiki is unavailable or for unrecognized binary/text formats.
+- **Configurable Thresholds** — Fine-tune minimum terminal width and code column budgets for split rendering.
+
+---
+
 ## Settings
+
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.diff` namespace (or configured interactively via `/archimedes`):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `diffTheme` | string | `github-dark` | Shiki syntax-highlighting theme |
-| `diffSplitMinWidth` | number | `150` | Minimum terminal columns to show split diff view (≥ 100) |
+| `diffSplitMinWidth` | number | `150` | Minimum terminal columns required to show split view (≥ 100) |
 | `diffSplitMinCodeWidth` | number | `60` | Minimum code columns per side in split view (≥ 30) |
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.diff` namespace.
+---
 
-## Integration
+## Part of the Archimedes Suite
 
-When installed via `pi-archimedes` (the meta package), the diff tools are registered with callbacks to the current theme and config, ensuring colors match your active Pi theme. Standalone installs use default dark theme colors.
+When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), the diff renderer integrates with Pi's active theme, ensuring syntax colors blend seamlessly into your editor and chrome.
 
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -1,61 +1,58 @@
 # @pi-archimedes/diff
 
-**Shiki-powered syntax-highlighted side-by-side and unified diffs for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**See what changed. Not just that something changed.**
 
-Reviewing code modifications in raw text diffs leads to missed regressions and eye strain. `@pi-archimedes/diff` brings full syntax highlighting powered by [Shiki](https://shiki.style) directly into your terminal, with adaptive split side-by-side views, word-level change emphasis, and colors that match your active terminal theme.
+Raw text diffs make it easy to miss the one line that matters. Diff puts [Shiki](https://shiki.style)-syntax-highlighted changes in front of you — side by side when there's room, unified when there isn't — with word-level emphasis on the parts that actually moved inside each line.
 
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/diff-edit.png" width="700" alt="Shiki syntax-highlighted split diff">
-</div>
+## Install
 
-## Quick Start
-
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/diff
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Split & Unified Views** — Side-by-side split diff or traditional unified view, automatically selected based on terminal column width.
-- **Shiki Syntax Highlighting** — Full language-aware syntax highlighting powered by Shiki with theme-derived palettes.
-- **Word-Level Emphasis** — Sub-line character diffs highlight exactly which tokens or words were altered.
-- **Graceful Fallback** — Transparently falls back to plain text diffs when Shiki is unavailable or for unrecognized binary/text formats.
-- **Configurable Thresholds** — Fine-tune minimum terminal width and code column budgets for split rendering.
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) walks through the first run. A running session picks the diff renderer up with `/reload`.
 
----
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/diff-edit.png" width="700" alt="Shiki syntax-highlighted split diff">
+</div>
 
-## Settings
+## What you get
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.diff` namespace (or configured interactively via `/archimedes`):
+- **Split view, and unified when it isn't** — side-by-side diffs when the terminal is wide enough; a traditional unified view when it isn't. The choice is made automatically from the column width.
+- **Syntax highlighting** — language-aware colouring of the diff body, from a Shiki theme.
+- **Word-level emphasis** — sub-line highlighting that shows exactly which tokens changed inside an otherwise similar line.
+- **Graceful fallback** — when Shiki is unavailable or the format isn't recognised, the change is shown as a plain text diff.
+
+## What it does (and doesn't) do
+
+The renderer displays `edit` and `write` tool changes in the tool UI, including call previews. It is **not an approval gate** — it helps you read changes as they happen; it doesn't hold changes back.
+
+## Appearance
+
+Standalone, the renderer runs on fixed defaults — the `github-dark` theme, a 150-column minimum for split view, and 60 code columns per side — and it does **not** read settings, because standalone has no config reader. In the [suite](https://github.com/danielcherubini/pi-archimedes), its `archimedes.diff` namespace supplies the same three values (`diffTheme`, `diffSplitMinWidth`, `diffSplitMinCodeWidth`) through the suite's config reader:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `diffTheme` | string | `github-dark` | Shiki syntax-highlighting theme |
-| `diffSplitMinWidth` | number | `150` | Minimum terminal columns required to show split view (≥ 100) |
+| `diffSplitMinWidth` | number | `150` | Minimum terminal columns for split view (≥ 100) |
 | `diffSplitMinCodeWidth` | number | `60` | Minimum code columns per side in split view (≥ 30) |
 
----
+The palette is derived from the chosen Shiki theme; it does **not** automatically pick up Pi's active theme colours. If you want a different look, pick a closer theme rather than expecting a live match.
 
-## Part of the Archimedes Suite
+On/off is managed by the suite: toggle via `/plugins` (`archimedes.diff.enabled`, default on).
 
-When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), the diff renderer integrates with Pi's active theme, ensuring syntax colors blend seamlessly into your editor and chrome.
-
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) walks through the first run. A running session picks the diff renderer up with `/reload`.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) walks through the first run. A running session picks the diff renderer up with `/reload`.
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/diff-edit.png" width="700" alt="Shiki syntax-highlighted split diff">

--- a/packages/footer/README.md
+++ b/packages/footer/README.md
@@ -1,55 +1,49 @@
 # @pi-archimedes/footer
 
-**Adaptive status bar with live token accounting, real-dollar costs, and subagent aggregation for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Session details without scrolling.**
 
-Your terminal is already full of information. The footer gives you exactly what you need to know about your session — where you are, what model you're using, how many tokens you've burned, and how close you are to the context limit — laid out at the bottom of your terminal, adapting dynamically to viewport width without ever clipping. When subagents run, their costs merge seamlessly into the same view.
+A long session drags context out of reach fast. The footer keeps the essentials pinned to the bottom of the terminal — where you are, which model you're running, how deep you are into the context window, and what you've spent — laying them out without clipping on any viewport width. When subagents run, their tokens and costs land in the same view, so the number you're watching is the whole run.
 
-## Quick Start
+## Install
 
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/footer
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Session Context at a Glance** — Directory, active git branch (with clean/dirty indicators), active model, and thinking level. Automatically switches the branch icon from `⎇` to `🌲` when inside a linked git worktree.
-- **Token & Cost Counter** — Real-time tracking of input tokens (↑), output tokens (↓), cache read/write, and live accumulated dollar cost.
-- **Dynamic Context Window Bar** — Color-coded progress bar (green → yellow → red) indicating context window consumption.
-- **Adaptive Non-Clipping Layout** — Renders as a single compact line on wide viewports; dynamically wraps to two or three lines on narrower viewports instead of truncating or clipping essential data.
-- **Unified Subagent Cost Aggregation** — When subagents run, their token usage and dollar expenses stream through the core bus and accumulate into the footer automatically.
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) walks through the whole first run. A running session picks the footer up with `/reload`.
 
----
+## What you get
+
+- **Session line** — working directory, active git branch with clean/dirty indicator, worktree badge, active model, and thinking level.
+- **Token ledger** — input (↑) and output (↓) tokens, cache read/write, and the live accumulated dollar cost of the session.
+- **Context bar** — colour-coded (green → yellow → red). It shows **consumption**: how much of the context window is used, not how much headroom is left.
+- **Adaptive layout** — one compact line on wide viewports; it wraps to the lines it needs as the terminal narrows instead of truncating essential data.
+- **Subagent aggregation** — in the suite, subagent token and cost events flow over core's bus into the same accumulator, so worker spend and main-session spend read as one total.
+
+Two honest caveats: the ledger reflects usage and pricing **as reported to the session** — it's a live read of what Pi has accounted, not a guaranteed provider invoice, and not a tally of every background model call. And the context bar tracks consumption, not remaining headroom.
 
 ## Settings
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.footer` namespace (or configured interactively via `/archimedes`):
+`~/.pi/agent/settings.json`, under `archimedes.footer` (strict JSON):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `splitThreshold` | number | `150` | Minimum terminal columns where a single-line layout is allowed. Below this threshold, the footer uses a structured multi-line layout; above it, it stays single-line and wraps only when content exceeds width. |
+| `splitThreshold` | number | `150` | Minimum terminal columns for the single-line layout. Below it, the footer uses the structured multi-line layout; above it, it stays single-line and wraps only if content overflows. |
 
----
+In the suite the setting also appears in `/archimedes` (when the panel has a control for it); `/reload` applies it. On/off is managed by the suite: toggle via `/plugins` (`archimedes.footer.enabled`, default on).
 
-## Part of the Archimedes Suite
-
-When installed as part of [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/footer` listens to cost and token events emitted by `@pi-archimedes/subagent` via the core event bus, giving you an honest, complete overview of your entire agent swarm's burn rate.
-
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/footer/README.md
+++ b/packages/footer/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) walks through the whole first run. A running session picks the footer up with `/reload`.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) walks through the whole first run. A running session picks the footer up with `/reload`.
 
 ## What you get
 

--- a/packages/footer/README.md
+++ b/packages/footer/README.md
@@ -1,45 +1,55 @@
 # @pi-archimedes/footer
 
-A status bar that shows what matters — at a glance, without getting in the way.
+**Adaptive status bar with live token accounting, real-dollar costs, and subagent aggregation for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Your terminal is already full of information. The footer gives you exactly what you need to know about your session — where you are, what model you're using, how many tokens you've burned, and how close you are to the context limit — laid out at the bottom of the terminal, adapting to its width without ever clipping. When subagents run, their costs merge seamlessly into the same view.
+Your terminal is already full of information. The footer gives you exactly what you need to know about your session — where you are, what model you're using, how many tokens you've burned, and how close you are to the context limit — laid out at the bottom of your terminal, adapting dynamically to viewport width without ever clipping. When subagents run, their costs merge seamlessly into the same view.
 
-## What you get
+## Quick Start
 
-- **Session context at a glance** — directory, git branch (with clean/dirty indicators), active model, thinking level; the branch icon switches from `⎇` to `🌲` when cwd is inside a linked worktree — no extra chip, no duplication
-- **Token stats** — input ↑, output ↓, cache read/write, and real-dollar cost, all in one compact display
-- **Context window bar** — color-coded progress bar (green → yellow → red) showing how much of your context window is used
-- **Adaptive layout** — everything on one line when it fits; otherwise it wraps to additional lines (two or three) instead of clipping. Width at which it switches is configurable
-- **Unified subagent costs** — when subagents run, their token usage and cost merge into the main footer automatically
+### 1. Install Pi (if needed)
 
-## Install
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/footer
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Usage
+---
 
-Footer renders automatically at the bottom of the Pi TUI. No commands to run.
+## What You Get
 
-On wide terminals, the footer displays as one compact line with all session context, token usage, cost, and a context window progress bar that fills the remaining space. When that no longer fits on one line, the footer wraps — usage moves to a second line, and sections themselves overflow to a third line if the terminal is truly narrow — so nothing ever gets clipped. Below the configured split threshold, it always uses at least the two-line layout (system info above, stats below).
+- **Session Context at a Glance** — Directory, active git branch (with clean/dirty indicators), active model, and thinking level. Automatically switches the branch icon from `⎇` to `🌲` when inside a linked git worktree.
+- **Token & Cost Counter** — Real-time tracking of input tokens (↑), output tokens (↓), cache read/write, and live accumulated dollar cost.
+- **Dynamic Context Window Bar** — Color-coded progress bar (green → yellow → red) indicating context window consumption.
+- **Adaptive Non-Clipping Layout** — Renders as a single compact line on wide viewports; dynamically wraps to two or three lines on narrower viewports instead of truncating or clipping essential data.
+- **Unified Subagent Cost Aggregation** — When subagents run, their token usage and dollar expenses stream through the core bus and accumulate into the footer automatically.
+
+---
 
 ## Settings
 
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.footer` namespace (or configured interactively via `/archimedes`):
+
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `splitThreshold` | number | `150` | Minimum terminal width (columns) where a single-line footer is still allowed. Below it, the footer always uses at least the two-line layout; above it, it stays on one line as long as the content fits and wraps otherwise — never clipping. |
+| `splitThreshold` | number | `150` | Minimum terminal columns where a single-line layout is allowed. Below this threshold, the footer uses a structured multi-line layout; above it, it stays single-line and wraps only when content exceeds width. |
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.footer` namespace.
+---
 
-## Integration
+## Part of the Archimedes Suite
 
-When installed via the meta package, footer consumes cost events from subagents through the core bus, giving a unified token/cost view across the main agent and any running subagents. Standalone install shows only the main agent's stats.
+When installed as part of [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/footer` listens to cost and token events emitted by `@pi-archimedes/subagent` via the core event bus, giving you an honest, complete overview of your entire agent swarm's burn rate.
 
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/image-paste/README.md
+++ b/packages/image-paste/README.md
@@ -1,62 +1,56 @@
 # @pi-archimedes/image-paste
 
-**Direct clipboard image pasting with inline terminal previews for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Show the screenshot rather than describing it.**
 
-Paste screenshots and UI mockups directly into your prompt from your system clipboard without manually saving temporary image files to disk. Instant inline terminal previews ensure your prompts stay clean, accurate, and visually contextualized before submission.
+"the button above the header and below the nav" is work nobody wants to do. Image-paste puts the image from your clipboard into the prompt as you type: markers land in the text on paste, the matching queued images attach on submit, and a terminal preview shows you what the agent will see.
 
-## Quick Start
+## Install
 
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/image-paste
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0. If you need Pi, [its quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) starts with `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`; then `pi install npm:pi-archimedes`, `cd` into your project, run `pi`, and use `/login` and `/model` inside the session. The [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers it end to end. `/reload` picks the extension up in a running session.
 
-## What You Get
+## How it works
 
-- **Clipboard Image Paste** — Capture a screenshot with your OS tool and hit paste straight into Pi.
-- **Inline Previews** — Renders an inline terminal preview of attached images directly in the TUI.
-- **Marker-Based Attachment** — Clean placeholder markers (`[Image #1]`) indicate attachments without cluttering your prompt text.
-- **Size Protection** — Rejects files over 20MB with a clear warning before wasting context tokens or hanging uploads.
+- **Markers on paste** — pasting inserts a visible `[Image #1]` placeholder at the cursor; each paste gets the next number.
+- **Attachment on submit** — when you send the message, your text is scanned for markers and the matching queued images are attached to it. Delete a marker and its image is not attached — the text is the source of truth.
+- **Inline preview** — a preview of the attached images is sent and rendered in the TUI. Previews appear where your terminal renders inline images; on a terminal that can't show them, the image is still attached — only the preview falls back.
+- **Size guard** — 20 MiB **per image**, rejected with a clear message before it wastes context or hangs the submit.
+- **Model side** — the session's model must support images for the attachment to be usable.
 
----
+## Paste shortcuts
 
-## Usage
-
-With your Pi session focused, press your platform paste shortcut:
-
-| Platform | Shortcut |
-|----------|----------|
-| Linux | `Ctrl+V` |
-| macOS | `Ctrl+V` or `Alt+V` |
-| Windows | `Alt+V` |
+| Platform | Shortcuts |
+|----------|-----------|
+| Linux (X11/Wayland) | `Ctrl+V`, `Alt+V`, `Ctrl+Alt+V` |
+| macOS | `Ctrl+V`, `Alt+V`, `Ctrl+Alt+V` |
+| Windows | `Alt+V`, `Ctrl+Alt+V` |
 
 > [!NOTE]
-> **Linux Shortcut Tip:** On Linux, `Ctrl+V` is also Pi's built-in binding for `app.clipboard.pasteImage`. To enable Archimedes' preview-enhanced handler without warning banners, clear the built-in binding in `~/.pi/agent/keybindings.json`:
+> **On Linux, `Ctrl+V` conflicts with Pi's built-in `app.clipboard.pasteImage` binding.** If both fire, clear the built-in binding in `~/.pi/agent/keybindings.json` so the preview-enhanced handler takes the paste without warning banners:
+>
 > ```json
 > { "app.clipboard.pasteImage": [] }
 > ```
 
----
+## Per-platform requirements
 
-## Part of the Archimedes Suite
+- **Linux** — a graphical session (`DISPLAY` or `WAYLAND_DISPLAY`) and one of `wl-clipboard` (tried first on Wayland sessions), `xclip` (tried first on X11), or the `@mariozechner/clipboard` native module. Termux is not supported.
+- **macOS** — native clipboard access out of the box, with the `@mariozechner/clipboard` module as fallback.
+- **Windows** — native clipboard first, with a PowerShell fallback.
 
-`@pi-archimedes/image-paste` is included in the [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) suite, fully configured to work alongside the framed editor, todo tracker, and status bar.
+## Part of the suite
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+In [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), image-paste works alongside the framed editor, the status bar, and the todo board; on/off is managed by the suite (`/plugins`, `archimedes.imagePaste.enabled`, default on).
+
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/image-paste/README.md
+++ b/packages/image-paste/README.md
@@ -18,7 +18,7 @@ Or the full suite instead:
 pi install npm:pi-archimedes
 ```
 
-New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0. If you need Pi, [its quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) starts with `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`; then `pi install npm:pi-archimedes`, `cd` into your project, run `pi`, and use `/login` and `/model` inside the session. The [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers it end to end. `/reload` picks the extension up in a running session.
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0. If you need Pi, [its quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) starts with `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. After installing Pi, choose one installation command above, then `cd` into your project, run `pi`, and use `/login` and `/model` inside the session. The [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers it end to end. `/reload` picks the extension up in a running session.
 
 ## How it works
 
@@ -46,8 +46,8 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0.
 ## Per-platform requirements
 
 - **Linux** — a graphical session (`DISPLAY` or `WAYLAND_DISPLAY`) and one of `wl-clipboard` (tried first on Wayland sessions), `xclip` (tried first on X11), or the `@mariozechner/clipboard` native module. Termux is not supported.
-- **macOS** — native clipboard access out of the box, with the `@mariozechner/clipboard` module as fallback.
-- **Windows** — native clipboard first, with a PowerShell fallback.
+- **macOS** — the only image reader on macOS is the `@mariozechner/clipboard` native module (no other CLI fallback); it ships inside the `pi-coding-agent` installation but must be importable from the extension's location, so if your Pi install's layout puts it out of resolution reach, a read reports the reader as unavailable — make the module resolvable beside the extension and `/reload`.
+- **Windows** — the `@mariozechner/clipboard` native module first, with a PowerShell fallback.
 
 ## Part of the suite
 

--- a/packages/image-paste/README.md
+++ b/packages/image-paste/README.md
@@ -1,31 +1,45 @@
 # @pi-archimedes/image-paste
 
-Paste images from your clipboard directly into the Pi chat with inline previews.
+**Direct clipboard image pasting with inline terminal previews for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Paste images directly from clipboard into Pi chats without manually saving files to disk first. Sharing visual context like UI mockups or error screenshots becomes instant, while inline previews keep your prompt clean and predictable.
+Paste screenshots and UI mockups directly into your prompt from your system clipboard without manually saving temporary image files to disk. Instant inline terminal previews ensure your prompts stay clean, accurate, and visually contextualized before submission.
 
-## What you get
+## Quick Start
 
-- **Clipboard image paste** — grab a screenshot and paste it straight into the prompt
-- **Inline previews** — images render in the TUI so you can see what you attached
-- **Marker-based attachment** — placeholder markers (`[Image #1]`) are matched and attached on submit
-- **Size guard** — rejects images over 20MB with a clear warning
+### 1. Install Pi (if needed)
 
-## Install
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/image-paste
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
+---
+
+## What You Get
+
+- **Clipboard Image Paste** — Capture a screenshot with your OS tool and hit paste straight into Pi.
+- **Inline Previews** — Renders an inline terminal preview of attached images directly in the TUI.
+- **Marker-Based Attachment** — Clean placeholder markers (`[Image #1]`) indicate attachments without cluttering your prompt text.
+- **Size Protection** — Rejects files over 20MB with a clear warning before wasting context tokens or hanging uploads.
+
+---
+
 ## Usage
 
-With Pi focused, press the paste shortcut and any image in your clipboard is attached:
+With your Pi session focused, press your platform paste shortcut:
 
 | Platform | Shortcut |
 |----------|----------|
@@ -33,30 +47,16 @@ With Pi focused, press the paste shortcut and any image in your clipboard is att
 | macOS | `Ctrl+V` or `Alt+V` |
 | Windows | `Alt+V` |
 
-A `[Image #N]` placeholder is inserted into your draft. When you submit, any images referenced by markers are automatically attached to the message. If you remove the markers before submitting, the images are discarded.
+> [!NOTE]
+> **Linux Shortcut Tip:** On Linux, `Ctrl+V` is also Pi's built-in binding for `app.clipboard.pasteImage`. To enable Archimedes' preview-enhanced handler without warning banners, clear the built-in binding in `~/.pi/agent/keybindings.json`:
+> ```json
+> { "app.clipboard.pasteImage": [] }
+> ```
 
-## Settings
+---
 
-Uses Pi's core `terminal.showImages` setting to control inline previews. No package-specific settings.
+## Part of the Archimedes Suite
 
-## Troubleshooting
+`@pi-archimedes/image-paste` is included in the [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) suite, fully configured to work alongside the framed editor, todo tracker, and status bar.
 
-### `ctrl+v` shortcut conflict on Linux
-
-Pi has a built-in `ctrl+v` handler (`app.clipboard.pasteImage`) that conflicts with this extension. You'll see a warning like:
-
-```
-Extension shortcut conflict: 'ctrl+v' is built-in shortcut for app.clipboard.pasteImage
-```
-
-**Fix:** Clear the built-in binding in `~/.pi/agent/keybindings.json`:
-
-```json
-{
-  "app.clipboard.pasteImage": []
-}
-```
-
-This lets archimedes' handler take over (it does the same thing plus inline previews) without the warning.
-
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,49 +1,42 @@
 # @pi-archimedes/mcp
 
-Full-featured MCP client adapter with a pi-native TUI — feature parity with pi-mcp-adapter.
+**Bring the tools you already use.**
 
-Connect any MCP server (stdio or HTTP/SSE), call its tools through a single `mcp` proxy tool or per-server direct tools, manage servers and OAuth flows interactively, and browse cached tool metadata offline — all without leaving the terminal.
+Your MCP servers — stdio or HTTP/SSE — can talk to Pi without leaving the terminal. One `mcp` tool reaches every server (or per-server direct tools for token-efficient calls), `/mcp` is a single command namespace for management and auth, and the setup wizard imports server definitions from Cursor, Claude Code, Claude Desktop, and VS Code. Start with `/mcp setup`; manage with `/mcp`.
 
-## What you get
+## Install
 
-- **`mcp` gateway tool** — search, describe, and call tools across all configured servers; also handles `status`, per-server tool listing, and eager `connect` without opening every server upfront
-- **Per-server direct tools** — each server's tools registered as `{server}_{tool}` for token-efficient calls; a per-server `directTools` array narrows the set to named tools only
-- **`/mcp` command family** — status, tools, prompts, reconnect, enable/disable, logout, auth, management panel, and setup panel — everything in one command namespace
-- **OAuth 2.1 + PKCE** — browser auth flow for protected servers (Atlassian, Notion, GitHub, …), OS credential-store persistence, SDK-driven token refresh
-- **Lifecycle management** — `keep-alive`, `lazy`, `lazy-keep-alive`, or `eager` per server, with configurable idle timeout
-- **Metadata cache** — `~/.pi/agent/mcp-cache.json` (7-day validity) lets search/describe work offline and persists each server's last connection outcome so `needs-auth`/errors survive restarts
-- **Compact two-line tool rendering** — `mcp <target>` header (cyan + orange) plus a key-arg summary; full args and output hidden until expanded with `ctrl+o`
-- **Layered config** — six config files, lowest → highest precedence; safe single-field write-back that never touches credentials or unrelated servers
-
-## Quick Start
-
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/mcp
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-### 3. Configure Your First Server
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0 — `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`; Pi's [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) covers authentication and [provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) list the supported providers. Then `pi install npm:pi-archimedes`, `cd` into your project, run `pi`, and `/login` + `/model` — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks up both new extensions and new server configs.
 
-Create or edit a config file — the project-shared one is usually the right place:
+## What you get
 
-   ```bash
-   # in your project root
-   cat > .mcp.json <<'EOF'
+- **`mcp` gateway tool** — search, describe, and call tools across all configured servers; also `status`, per-server tool listing, and eager `connect`, without opening every server upfront.
+- **Per-server direct tools** — each server's tools registered as `{server}_{tool}` for direct, token-efficient calls; a per-server `directTools` array narrows the set to named tools.
+- **`/mcp` command family** — status, tools, prompts, reconnect, enable/disable, logout, auth, management panel, setup panel — one namespace.
+- **OAuth 2.1 + PKCE** — interactive browser auth for protected servers, with OS credential-store persistence and SDK-driven refresh.
+- **Lifecycle management** — `keep-alive`, `lazy` (default), `lazy-keep-alive`, or `eager` per server, with an idle timeout.
+- **Metadata cache** — `~/.pi/agent/mcp-cache.json` (7-day validity) lets search/describe work offline and persists each server's last connection outcome, so `needs-auth`/errors survive restarts.
+- **Compact two-line tool rendering** — an `mcp <target>` header with a key-argument summary; full args and output expand with `ctrl+o`.
+- **Layered config** — six config files, lowest → highest precedence, with a safe single-field write-back that never touches credentials or unrelated servers.
+
+## Quick start
+
+1. **`/mcp setup`** — the recommended path. It scaffolds `.mcp.json`, adds curated presets (context7, chrome-devtools, deepwiki, fetch), and imports server definitions from Cursor, Claude Code, Claude Desktop, and VS Code — with a preview of which names will be added before anything is written.
+2. Or edit a config file by hand. The project-shared `<project>/.mcp.json` is usually the right place. **Merge deliberately — do not `cat > .mcp.json`**, which silently destroys settings for other servers:
+
+   ```json
    {
      "mcpServers": {
        "context7": {
@@ -52,14 +45,10 @@ Create or edit a config file — the project-shared one is usually the right pla
        }
      }
    }
-   EOF
    ```
 
-   Or use `/mcp setup` to scaffold it interactively (see below).
-
-2. `/reload` to pick up the new config.
-
-3. The `mcp` tool and direct tools (`context7_*`) are now available. Check with `/mcp status`.
+3. `/reload` to pick up the new config.
+4. The `mcp` tool and direct tools (`context7_*`) are now available; check with `/mcp status`.
 
 ## `/mcp` command reference
 
@@ -117,9 +106,19 @@ Three paths reach the same auth entry point:
 
 Token details:
 
-- Tokens persist in the OS credential store (macOS Keychain / Windows Credential Manager / Linux libsecret) — no plaintext fallback
-- Token refresh is SDK-driven; a pre-registered public client (`clientId` without `clientSecret`) is never auto-refreshed — re-run `/mcp auth <server>` when its token expires
-- The `auth` field on http/sse servers accepts `{ "token": "…" }` (static bearer), `"oauth"` (defaults), or a full `McpOAuthConfig` object
+- Tokens persist in the OS credential store (macOS Keychain / Windows Credential Manager / Linux Secret Service). Storage is **fail-closed**: if the keyring is unavailable, auth operations throw a clear error — there is never a plaintext fallback.
+- Token refresh is SDK-driven; a pre-registered public client (`clientId` without `clientSecret`) is never auto-refreshed — re-run `/mcp auth <server>` when its token expires.
+- The `auth` field on http/sse servers accepts `{ "token": "…" }` (static bearer), `"oauth"` (the default), or a full `McpOAuthConfig` object:
+
+| `McpOAuthConfig` field | Meaning |
+|------------------------|---------|
+| `grantType` | `"authorization_code"` (default) or `"client_credentials"` |
+| `clientId` | client identifier |
+| `clientSecret` | string, literal only — no `!command` resolution |
+| `scope` | space-separated scopes |
+| `redirectUri` | pre-registered clients only |
+| `clientName` | human name, shown in consent screens |
+| `authorizationServerUrl` | reserved — parsed but not yet used |
 
 ## Config files & write-back
 
@@ -134,7 +133,7 @@ Six layers load in order, lowest → highest precedence (per-server field-level 
 | 5 | `<project>/.mcp.json` | Project-shared (committable) |
 | 6 | `<project>/.pi/mcp.json` | Pi override — highest precedence |
 
-Files accept `//` comments and trailing commas. When a higher-precedence layer changes a server's `url`, inherited `auth`/`headers`/`bearerTokenEnv` from lower layers are dropped — credentials are never sent to an endpoint you didn't explicitly configure them for.
+The `mcp.json` files accept `//` comments and trailing commas (**JSONC**). That does not apply to Archimedes settings — `~/.pi/agent/settings.json` is **strict JSON**, parsed without comment support. When a higher-precedence layer changes a server's `url`, inherited `auth`/`headers`/`bearerTokenEnv` from lower layers are dropped — credentials are never sent to an endpoint you didn't explicitly configure them for.
 
 Write-back targets:
 
@@ -145,7 +144,7 @@ Changes take effect on the next `/reload`.
 
 ## Settings
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.mcp` namespace.
+`~/.pi/agent/settings.json`, under `archimedes.mcp` (strict JSON):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
@@ -175,6 +174,6 @@ Per-server overrides (in the `mcp.json` server definition):
 
 ## Integration
 
-When installed via `pi-archimedes` (the meta package), the MCP adapter is automatically registered. Tool rendering uses Core's chrome and color palette. Standalone installation works independently — the full feature set is available without the meta package.
+In the [suite](https://github.com/danielcherubini/pi-archimedes), the MCP adapter is registered with the rest — tool rendering uses core's chrome and colour palette, and a blocking OAuth loader triggers the notify extension's prompts. Standalone, the full feature set works independently. On/off in the suite is managed by `/plugins` (`archimedes.mcp.enabled`, default on).
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,7 +18,7 @@ Or the full suite instead:
 pi install npm:pi-archimedes
 ```
 
-New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0 — `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`; Pi's [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) covers authentication and [provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) list the supported providers. Then `pi install npm:pi-archimedes`, `cd` into your project, run `pi`, and `/login` + `/model` — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks up both new extensions and new server configs.
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0 — `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`; Pi's [quickstart](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/quickstart.md) covers authentication and [provider docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md) list the supported providers. After installing Pi, choose one installation command above, then `cd` into your project and run `pi`, and in the session use `/login` + `/model` — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks up both new extensions and new server configs.
 
 ## What you get
 
@@ -94,7 +94,7 @@ Onboarding for a new project. All writes target the project-shared `.mcp.json`.
 
 - **Scaffold** — writes `{ "mcpServers": {} }` only when the file is absent
 - **Add a known server** — curated preset list (context7, chrome-devtools, deepwiki, fetch); existing entries are never overwritten
-- **Import from another tool** — discovers MCP configs from Cursor, Claude Code, Claude Desktop, and VSCode; shows a preview of which server names will be added before writing; names already in `.mcp.json` are kept untouched
+- **Import from another tool** — discovers MCP configs from Cursor, Claude Code, Claude Desktop, and VS Code. The six candidate files, in scan order, are `~/.cursor/mcp.json` and `<project>/.cursor/mcp.json` (`mcpServers` key), `~/.claude/mcp.json` and `~/.claude.json` (`mcpServers`), `~/.claude/claude_desktop_config.json` (`mcpServers`), and `<project>/.vscode/mcp.json` (its key is `servers`, not `mcpServers`); shows a preview of which server names will be added before writing; names already in `.mcp.json` are kept untouched
 
 ## OAuth
 
@@ -108,7 +108,7 @@ Token details:
 
 - Tokens persist in the OS credential store (macOS Keychain / Windows Credential Manager / Linux Secret Service). Storage is **fail-closed**: if the keyring is unavailable, auth operations throw a clear error — there is never a plaintext fallback.
 - Token refresh is SDK-driven; a pre-registered public client (`clientId` without `clientSecret`) is never auto-refreshed — re-run `/mcp auth <server>` when its token expires.
-- The `auth` field on http/sse servers accepts `{ "token": "…" }` (static bearer), `"oauth"` (the default), or a full `McpOAuthConfig` object:
+- The `auth` field on http/sse servers accepts `{ "token": "…" }` (static bearer), `"oauth"`, or a full `McpOAuthConfig` object. `auth: "oauth"` (or a config object with at least one field below) is what enables OAuth with the default grant settings; a valid object can override them. **Omitting `auth` on a protected server means no authentication** — there is no implicit OAuth default:
 
 | `McpOAuthConfig` field | Meaning |
 |------------------------|---------|
@@ -129,11 +129,11 @@ Six layers load in order, lowest → highest precedence (per-server field-level 
 | 1 | `~/.config/mcp/mcp.json` | Global (standard MCP location) |
 | 2 | `~/.agents/mcp.json` | Cross-agent (home) |
 | 3 | `~/.agents/mcp/mcp.json` | Cross-agent (home, alternate) |
-| 4 | `~/.pi/agent/mcp.json` | Pi agent directory |
+| 4 | `<agentDir>/mcp.json` (agent directory is `$PI_CODING_AGENT_DIR`, defaulting to `~/.pi/agent`) | Pi agent directory |
 | 5 | `<project>/.mcp.json` | Project-shared (committable) |
 | 6 | `<project>/.pi/mcp.json` | Pi override — highest precedence |
 
-The `mcp.json` files accept `//` comments and trailing commas (**JSONC**). That does not apply to Archimedes settings — `~/.pi/agent/settings.json` is **strict JSON**, parsed without comment support. When a higher-precedence layer changes a server's `url`, inherited `auth`/`headers`/`bearerTokenEnv` from lower layers are dropped — credentials are never sent to an endpoint you didn't explicitly configure them for.
+The `mcp.json` files (including layer 4's `<agentDir>/mcp.json`) accept `//` comments and trailing commas (**JSONC**). That does not apply to Archimedes settings — `~/.pi/agent/settings.json` is **strict JSON**, parsed without comment support. When a higher-precedence layer changes a server's `url`, inherited `auth`/`headers`/`bearerTokenEnv` from lower layers are dropped — credentials are never sent to an endpoint you didn't explicitly configure them for.
 
 Write-back targets:
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -15,21 +15,31 @@ Connect any MCP server (stdio or HTTP/SSE), call its tools through a single `mcp
 - **Compact two-line tool rendering** — `mcp <target>` header (cyan + orange) plus a key-arg summary; full args and output hidden until expanded with `ctrl+o`
 - **Layered config** — six config files, lowest → highest precedence; safe single-field write-back that never touches credentials or unrelated servers
 
-## Install
+## Quick Start
+
+### 1. Install Pi (if needed)
+
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/mcp
 ```
 
-Or install the full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Quick start
+### 3. Configure Your First Server
 
-1. Create or edit a config file — the project-shared one is usually the right place:
+Create or edit a config file — the project-shared one is usually the right place:
 
    ```bash
    # in your project root
@@ -167,4 +177,4 @@ Per-server overrides (in the `mcp.json` server definition):
 
 When installed via `pi-archimedes` (the meta package), the MCP adapter is automatically registered. Tool rendering uses Core's chrome and color palette. Standalone installation works independently — the full feature set is available without the meta package.
 
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -108,7 +108,7 @@ Token details:
 
 - Tokens persist in the OS credential store (macOS Keychain / Windows Credential Manager / Linux Secret Service). Storage is **fail-closed**: if the keyring is unavailable, auth operations throw a clear error — there is never a plaintext fallback.
 - Token refresh is SDK-driven; a pre-registered public client (`clientId` without `clientSecret`) is never auto-refreshed — re-run `/mcp auth <server>` when its token expires.
-- The `auth` field on http/sse servers accepts `{ "token": "…" }` (static bearer), `"oauth"`, or a full `McpOAuthConfig` object. `auth: "oauth"` (or a config object with at least one field below) is what enables OAuth with the default grant settings; a valid object can override them. **Omitting `auth` on a protected server means no authentication** — there is no implicit OAuth default:
+- The `auth` field on http/sse servers accepts `{ "token": "…" }` (static bearer), `"oauth"`, or a full `McpOAuthConfig` object. `auth: "oauth"` (or a config object with at least one field below) is what enables OAuth with the default grant settings; a valid object can override them. **Omitting `auth` does not automatically enable OAuth** — there is no implicit OAuth default, but static authentication can still be supplied through `bearerTokenEnv` or `headers`:
 
 | `McpOAuthConfig` field | Meaning |
 |------------------------|---------|

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -1,59 +1,57 @@
 # @pi-archimedes/notify
 
-Delayed desktop notifications with circuit breaker for the [Pi coding agent](https://github.com/earendil-works/pi).
+**Delayed desktop notifications with keystroke circuit breaker for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Get notified when Pi finishes long tasks or needs an answer, without constant popup spam thanks to delayed firing and raw keypress circuit breaking. You can safely switch windows while long-running jobs execute, knowing a desktop alert will trigger only if you aren't already actively typing in the terminal.
+Long-running agent workflows invite you to switch to your browser or other workspaces. `@pi-archimedes/notify` alerts you when Pi finishes a task or requires your input — without constant popup spam. Notifications only fire after an inactivity threshold, and touching any key immediately disarms pending alerts.
 
-## What you get
+## Quick Start
 
-- **Delayed notification** — fires only after a configurable period of inactivity (default 30s), so you're not spammed when actively working
-- **Circuit breaker** — any keystroke immediately cancels a pending notification via raw terminal input listening
-- **Terminal-aware dispatch** — auto-detects your terminal and uses the optimal protocol (OSC 99, OSC 9, OSC 777, or PowerShell toasts)
-- **tmux passthrough** — all sequences wrapped via DCS for correct rendering inside tmux
-- **Per-trigger toggles** — independently enable/disable notifications for task completion and unanswered questions
-- **Pi-native triggers** — keyed on pi's `agent_settled` and `ui_prompt_start` lifecycle events, so task completion works and *any* blocking extension prompt (ask, sudo, mcp OAuth) can hold your attention
+### 1. Install Pi (if needed)
 
-## Install
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/notify
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Usage
+---
 
-When the agent's run has settled (`agent_settled`) or an extension opens a blocking prompt (`ui_prompt_start` — ask, sudo, mcp OAuth), a timer starts. If you don't interact for the configured delay, a desktop notification fires. Any keystroke — even just pressing a key without submitting — cancels the timer immediately.
+## What You Get
+
+- **Delayed Inactivity Dispatch** — Alerts only trigger after you've been inactive for a configurable delay (default 30 seconds), preventing spam while you're actively reading terminal output.
+- **Keystroke Circuit Breaker** — Any keypress in the terminal immediately aborts pending notification timers via raw terminal input listening.
+- **Terminal-Aware Protocols** — Automatically chooses the cleanest protocol for your environment (OSC 99, OSC 9, OSC 777, or native PowerShell toasts).
+- **tmux Passthrough** — All escape sequences are wrapped via DCS sequences to ensure alerts break through tmux sessions reliably.
+- **Lifecycle Integration** — Triggers on Pi's `agent_settled` event and whenever any blocking UI prompt opens (such as `ask`, `sudo`, or MCP OAuth).
+
+---
 
 ## Settings
 
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.notify` namespace (or configured interactively via `/archimedes`):
+
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `notifyOnAgentEnd` | bool | `true` | Notify when agent finishes a task |
-| `notifyOnQuestion` | bool | `true` | Notify when a question needs your answer |
-| `delayMs` | number | `30000` | Milliseconds to wait before sending notification (default 30 seconds) |
+| `notifyOnAgentEnd` | bool | `true` | Notify when the agent completes execution |
+| `notifyOnQuestion` | bool | `true` | Notify when an extension prompt needs your input |
+| `delayMs` | number | `30000` | Inactivity delay in milliseconds before alerting |
 
-On/off is managed by the suite: toggle via `/plugins` (`archimedes.notify.enabled`, default on).
+---
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.notify` namespace.
+## Part of the Archimedes Suite
 
-## Terminal compatibility
+When installed as part of [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/notify` integrates across all extensions, alerting you whenever `@pi-archimedes/ask`, `@pi-archimedes/sudo`, or `@pi-archimedes/mcp` need your attention.
 
-| Terminal | Protocol | Title + Body |
-|----------|----------|--------------|
-| Kitty | OSC 99 | ✅ |
-| iTerm2 | OSC 9 | Body only |
-| Windows Terminal | PowerShell toast | ✅ |
-| Ghostty | OSC 777 | ✅ |
-| WezTerm | OSC 777 | ✅ |
-| tmux (any above) | DCS passthrough | ✅ |
-
-## Integration
-
-When installed via `pi-archimedes` (the meta package), the notify package is automatically registered and its settings appear in the `/archimedes` settings panel. Standalone installs work independently — any blocking extension UI prompt will trigger the question notification.
-
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -1,57 +1,60 @@
 # @pi-archimedes/notify
 
-**Delayed desktop notifications with keystroke circuit breaker for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Step away without losing track.**
 
-Long-running agent workflows invite you to switch to your browser or other workspaces. `@pi-archimedes/notify` alerts you when Pi finishes a task or requires your input — without constant popup spam. Notifications only fire after an inactivity threshold, and touching any key immediately disarms pending alerts.
+Leave the terminal for a coffee. When the work has actually settled — or something needs your decision — notify tells you, once, after a short delay. Type anything and the pending alert is cancelled; there's no inactivity scrutiny, no focus tracking. Keystrokes are the only signal.
 
-## Quick Start
+## Install
 
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/notify
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Delayed Inactivity Dispatch** — Alerts only trigger after you've been inactive for a configurable delay (default 30 seconds), preventing spam while you're actively reading terminal output.
-- **Keystroke Circuit Breaker** — Any keypress in the terminal immediately aborts pending notification timers via raw terminal input listening.
-- **Terminal-Aware Protocols** — Automatically chooses the cleanest protocol for your environment (OSC 99, OSC 9, OSC 777, or native PowerShell toasts).
-- **tmux Passthrough** — All escape sequences are wrapped via DCS sequences to ensure alerts break through tmux sessions reliably.
-- **Lifecycle Integration** — Triggers on Pi's `agent_settled` event and whenever any blocking UI prompt opens (such as `ask`, `sudo`, or MCP OAuth).
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
 
----
+## Triggers
+
+- **Settled runs** — on Pi's `agent_settled` event: the run has fully settled (no automatic retry, compaction, or queued continuation still to fire), not merely "a turn ended".
+- **Blocking prompts** — on `ui_prompt_start`: any extension prompt is waiting on you (a tabbed ask, a sudo password prompt, an MCP OAuth loader) — direct **or** subagent-relayed, since the event fires in the parent process.
+
+The alert fires after a fixed `delayMs` (30 s by default) from the trigger. It is a delay, not an idle timer: nothing measures how long you've been reading. Any input in the terminal cancels pending alerts immediately, a new agent run cancels them, and a prompt that closes without you typing (say, the OAuth loader finishing from the browser) cancels its own timer — so a long-gone question can't ring.
+
+## Terminal delivery
+
+| Environment | Protocol | Notes |
+|-------------|----------|-------|
+| Windows Terminal | PowerShell toast | title + body |
+| Kitty | OSC 99 | title + body |
+| iTerm2 | OSC 9 | body only |
+| tmux over any of the above | DCS passthrough wrap | alerts break through tmux |
+| other terminals | OSC 777 | generic fallback |
+
+Delivery depends on your terminal understanding one of these protocols; if it understands none, no alert will appear. Both triggers work standalone — the extension alone gets you the same behaviour.
 
 ## Settings
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.notify` namespace (or configured interactively via `/archimedes`):
+`~/.pi/agent/settings.json`, under `archimedes.notify` (strict JSON):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `notifyOnAgentEnd` | bool | `true` | Notify when the agent completes execution |
-| `notifyOnQuestion` | bool | `true` | Notify when an extension prompt needs your input |
-| `delayMs` | number | `30000` | Inactivity delay in milliseconds before alerting |
+| `notifyOnAgentEnd` | bool | `true` | Notify when a run has fully settled |
+| `notifyOnQuestion` | bool | `true` | Notify when a blocking prompt needs input |
+| `delayMs` | number | `30000` | Delay after the trigger before the alert fires |
 
----
+In the suite the settings also appear in `/archimedes` (where the panel has a control), and on/off is managed by the suite: toggle via `/plugins` (`archimedes.notify.enabled`, default on).
 
-## Part of the Archimedes Suite
-
-When installed as part of [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/notify` integrates across all extensions, alerting you whenever `@pi-archimedes/ask`, `@pi-archimedes/sudo`, or `@pi-archimedes/mcp` need your attention.
-
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
 
 ## Triggers
 

--- a/packages/session-name/README.md
+++ b/packages/session-name/README.md
@@ -1,46 +1,55 @@
 # @pi-archimedes/session-name
 
-Auto session naming for the [Pi coding agent](https://github.com/earendil-works/pi).
+**Automated AI session titling after first conversation turn for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Automatically generates concise, descriptive session titles using AI after each conversation — so your sessions are easy to find and resume later. Skips sessions already named via `--name` or `/name`, and silently handles errors.
+Finding and resuming past coding sessions shouldn't involve reading arbitrary timestamps or raw hashes. `@pi-archimedes/session-name` uses a lightweight background AI call after your first exchange to generate a concise, descriptive title, making resuming with `pi -r` fast and painless.
 
-## What you get
+## Quick Start
 
-- **Automatic naming** — fires on `agent_end` to generate a title from the first user/assistant exchange
-- **Smart model resolution** — supports canonical `provider/id`, bare `id`, and thinking-suffix tolerance
-- **Respects manual names** — skips sessions already named via `--name` or `/name`
-- **Ephemeral-aware** — only names sessions with a session file (skips temporary sessions)
-- **Race-safe** — re-checks session name before setting to avoid overwriting manual changes
-- **Silent failures** — any error (auth, network, etc.) is caught and ignored
+### 1. Install Pi (if needed)
 
-## Install
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/session-name
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Usage
+---
 
-After a conversation ends (`agent_end`), the extension extracts the first user message and assistant response, sends them to the AI with a title-generation prompt, and sets the session name via `pi.setSessionName()`. The title is limited to 80 characters and stripped of surrounding quotes.
+## What You Get
+
+- **Automatic Title Generation** — Triggers after the first user/assistant exchange to name the session based on actual intent.
+- **Respects Manual Naming** — Leaves existing custom session names alone if passed via `--name` or set via `/name`.
+- **Ephemeral Session Aware** — Only names persisted sessions, skipping temporary or discardable agent sessions.
+- **Smart Model Resolution** — Supports canonical `provider/id`, bare IDs, and thinking-suffix model formats.
+- **Silent & Non-Blocking** — Executes in the background; failures (e.g. rate limits or offline mode) are gracefully ignored without interrupting work.
+
+---
 
 ## Settings
 
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.sessionName` namespace (or configured interactively via `/archimedes`):
+
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `model` | string | _(current model)_ | Override model for title generation (e.g., `openai/gpt-4o-mini`) |
+| `model` | string | `(current model)` | Model override for title generation (e.g., `openai/gpt-4o-mini`) |
 
-On/off is managed by the suite: toggle via `/plugins` (`archimedes.sessionName.enabled`, default on).
+---
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.sessionName` namespace.
+## Part of the Archimedes Suite
 
-## Integration
+`@pi-archimedes/session-name` is included in [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), where it ensures every session in your history has clear, readable context.
 
-When installed via `pi-archimedes` (the meta package), the session-name package is automatically registered. Standalone installs work independently — it listens for `agent_end` events and uses the Pi extension API to set session names.
-
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/session-name/README.md
+++ b/packages/session-name/README.md
@@ -1,55 +1,46 @@
 # @pi-archimedes/session-name
 
-**Automated AI session titling after first conversation turn for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Find the session you meant.**
 
-Finding and resuming past coding sessions shouldn't involve reading arbitrary timestamps or raw hashes. `@pi-archimedes/session-name` uses a lightweight background AI call after your first exchange to generate a concise, descriptive title, making resuming with `pi -r` fast and painless.
+Timestamps and raw hash names don't tell you what a session was *for*. Session-name gives every session a short, descriptive name based on your first exchange, so `pi -r` stops being a guessing game.
 
-## Quick Start
+## Install
 
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/session-name
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Automatic Title Generation** — Triggers after the first user/assistant exchange to name the session based on actual intent.
-- **Respects Manual Naming** — Leaves existing custom session names alone if passed via `--name` or set via `/name`.
-- **Ephemeral Session Aware** — Only names persisted sessions, skipping temporary or discardable agent sessions.
-- **Smart Model Resolution** — Supports canonical `provider/id`, bare IDs, and thinking-suffix model formats.
-- **Silent & Non-Blocking** — Executes in the background; failures (e.g. rate limits or offline mode) are gracefully ignored without interrupting work.
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
 
----
+## How it works
+
+- After the first user + assistant exchange settles, it takes the first exchange (500 characters per side), asks a model to write a 3–8-word title, caps it at 80 characters, and sets the session name — with a final re-check so a name you set yourself can never be overwritten.
+- **Manual names win.** If you named the session (`--name` or `/name`), naming is skipped, and it re-checks before writing.
+- **It uses your current model unless you configure another.** The title is a separate model call outside the main run — with its own cost, **not reflected in the footer's totals**. A `model` setting (e.g. a cheap model) avoids spending your main model on titles.
+- **Skips and retries** — Ephemeral sessions (no session file) are skipped; if the model has no configured auth, the call is skipped. Transient failures print to the console and re-try on later `agent_end` events, giving up for the session after three. It is non-blocking and unobtrusive, but "silent" is too strong: failures are logged.
 
 ## Settings
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.sessionName` namespace (or configured interactively via `/archimedes`):
+`~/.pi/agent/settings.json`, under `archimedes.sessionName` (strict JSON):
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `model` | string | `(current model)` | Model override for title generation (e.g., `openai/gpt-4o-mini`) |
+| `model` | string | _(current model)_ | Model used for title generation (e.g. `openai/gpt-4o-mini`). Canonical `provider/id`, bare IDs, and thinking-suffix forms are all resolved. Empty = current model. |
 
----
+On/off is managed by the suite: toggle via `/plugins` (`archimedes.sessionName.enabled`, default on).
 
-## Part of the Archimedes Suite
-
-`@pi-archimedes/session-name` is included in [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), where it ensures every session in your history has clear, readable context.
-
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/session-name/README.md
+++ b/packages/session-name/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
 
 ## How it works
 

--- a/packages/subagent/README.md
+++ b/packages/subagent/README.md
@@ -1,103 +1,116 @@
 # @pi-archimedes/subagent
 
-**Subagent dispatch with live TUI streaming, parallel execution, and unified cost tracking for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Give your agent some backup.**
 
-Don't let complex reasoning or multi-file refactors block your main agent. `@pi-archimedes/subagent` enables you to dispatch specialized subagents to offload research, code reviews, and implementation tasks with live TUI streaming, parallel execution, independent model overrides, and real-time cost accounting.
+Big thinking and multi-file refactors are expensive to do in the main line. Subagent lets your agent delegate that work: it dispatches child agents — singly or in parallel — with a model and tool set of your choice per role, streams their progress live, and books their tokens and costs into the same status bar. You watch the whole team at once.
 
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
-</div>
+## Install
 
-## Quick Start
-
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/subagent
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **Single & Parallel Execution** — Dispatch one targeted subtask or fan out multiple tasks across distinct agents simultaneously.
-- **Live TUI Streaming** — Watch subagents think and execute tools in real time with color-coded status chips (grey while running, green on success, red on failure) and readable argument previews.
-- **Visual `/agents` Manager** — Interactive full-screen TUI to create, configure, and inspect custom subagent personas with model and tool pickers.
-- **Per-Agent Model Selection** — Assign different models per subagent (e.g. fast cheap models for research, high-reasoning models for code review).
-- **Comprehensive Cost Accounting** — Real-time tracking of input tokens, output tokens, cache read/write, and dollar cost per subagent, flowing into the footer.
-- **Multi-Scope Agent Discovery** — Reads agent definitions from project (`<repo>/.pi/agents/`), user (`~/.pi/agent/agents/`), and cross-agent (`~/.agents/agents/`) scopes with collision detection.
-
----
-
-## Screenshots
-
-### Agent Details & Persona View
-
-Inspect agent prompts, assigned models, and tool configurations:
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the dispatch tool up in a running session.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-agent-view.png" width="650" alt="Subagents agent details view">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
 </div>
 
-### Model & Tool Pickers
+## Dispatching
 
-Assign specific models and toggle allowed tools directly from the TUI:
+### Config-less — the default
 
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-model-selection.png" width="48%" alt="Model selection">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-tool-selection.png" width="48%" alt="Tool selection">
-</div>
-
----
-
-## Usage
-
-### The `subagent` Tool
-
-Single task dispatch:
+The `agent` field is optional. Omit it and the task runs with the **parent's model and all tools**:
 
 ```jsonc
 {
-  "agent": "reviewer",                     // optional persona name (defaults to "general")
-  "task": "review the PR diff",            // task description
-  "model": "openrouter/anthropic/claude-4",// optional model override
-  "cwd": "/path/to/project"                // optional working directory
+  "task": "review the uncommitted changes and list the risks",
+  "model": "openrouter/anthropic/claude-sonnet-4",  // optional per-call override
+  "cwd": "/path/to/project"                        // optional working directory
 }
 ```
 
-Parallel swarm dispatch:
+### Named agents
+
+With an `agent` name, the dispatch runs under a defined agent file (format below). Unknown names are refused and list the available agents, so a typo fails cheap:
+
+```jsonc
+{
+  "agent": "reviewer",
+  "task": "review the PR diff"
+}
+```
+
+### Parallel work
+
+Independent tasks go in a `tasks` array — distinct agents, distinct models, one call:
 
 ```jsonc
 {
   "tasks": [
     { "agent": "researcher", "task": "find all usages of the deprecated API" },
-    { "agent": "reviewer", "task": "review the proposed migration plan" }
+    { "agent": "reviewer",   "task": "review the proposed migration plan" }
   ]
 }
 ```
 
-### The `/agents` Command
+**The dispatch waits.** A call — single or parallel — blocks until every task completes and returns the combined results, each optionally carrying the child's `childSessionId`. There is an `async` field in the schema; the implementation ignores it, so don't plan on fire-and-forget: batch the work into `tasks` and let the call block on all of it.
 
-Run `/agents` to launch the interactive persona manager. Browse existing agents, create new ones, configure system prompts, and toggle available tools.
+### Model resolution
 
+Per dispatch, in order: **the agent config's `model`, then the per-call `model`, then the parent's model.** The same rule holds for thinking level, except there is no per-call thinking field — agent config or parent.
+
+## Agent files
+
+Custom agents are `.md` files with YAML frontmatter:
+
+```markdown
 ---
+name: reviewer
+description: Reviews diffs and flags risks before code lands
+model: openrouter/anthropic/claude-sonnet-4
+tools: read, bash
+thinking: medium
+---
+You are a meticulous code reviewer. Read the diff, flag real risks,
+and name the lines you checked.
+```
 
-## Part of the Archimedes Suite
+- `name` and `description` are **required** — a file without them is skipped. `tools` is a **comma-separated string**. The markdown body is the agent's system prompt.
+- **Scopes, in precedence order:** project (`<repo>/.pi/agents/`), user (`~/.pi/agent/agents/`), and global — the repository's `.agents/agents/` or, falling back, `~/.agents/agents/`.
+- Unknown frontmatter fields are preserved on edit, not interpreted.
+- Model and thinking picked in the `/agents` TUI are saved to `~/.pi/agent/agents.local.json` (machine-local, not committed), take precedence over the frontmatter, and are stripped from the `.md` on save. Hand-written `model:`/`thinking:` in frontmatter remain the fallback.
+- At runtime, the subagent tool is excluded from a child's tool set, so a worker can't spawn workers.
 
-When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), subagent tokens and expenses automatically accumulate in the `@pi-archimedes/footer` status bar, subagent tasks display in side-by-side columns on the `@pi-archimedes/todo` board, and subagents can ask you interactive questions via `@pi-archimedes/ask` IPC.
+## The `/agents` command
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+Available with the suite (and subagent enabled), `/agents` opens the interactive manager: a searchable list, model and tool pickers, cross-scope collision warnings, and dirty-tracking on save.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-agent-view.png" width="650" alt="Subagents agent details view">
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-model-selection.png" width="48%" alt="Model selection">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-tool-selection.png" width="48%" alt="Tool selection">
+</p>
+
+## Part of the suite
+
+The full suite is the supported connected setup. With the relevant components loaded together, subagent token and cost events flow over core's bus into the footer, subagent tasks get their own columns on the todo board, and subagent `ask` questions surface in your terminal. On/off is managed by the suite: toggle via `/plugins` (`archimedes.subagent.enabled`, default on).
+
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/subagent/README.md
+++ b/packages/subagent/README.md
@@ -1,6 +1,6 @@
 # @pi-archimedes/subagent
 
-**Subagent dispatch with live TUI streaming, parallel swarms, and unified cost tracking for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Subagent dispatch with live TUI streaming, parallel execution, and unified cost tracking for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
 Don't let complex reasoning or multi-file refactors block your main agent. `@pi-archimedes/subagent` enables you to dispatch specialized subagents to offload research, code reviews, and implementation tasks with live TUI streaming, parallel execution, independent model overrides, and real-time cost accounting.
 

--- a/packages/subagent/README.md
+++ b/packages/subagent/README.md
@@ -1,103 +1,103 @@
 # @pi-archimedes/subagent
 
-Subagent dispatch with live TUI streaming and cost tracking for the [Pi coding agent](https://github.com/earendil-works/pi).
+**Subagent dispatch with live TUI streaming, parallel swarms, and unified cost tracking for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Dispatch specialized subagents to offload complex tasks with live TUI streaming, parallel execution, cost tracking, and per-agent model overrides. By fanning out work to dedicated subagents, complex workflows can be executed concurrently while maintaining full visibility into progress and token usage.
+Don't let complex reasoning or multi-file refactors block your main agent. `@pi-archimedes/subagent` enables you to dispatch specialized subagents to offload research, code reviews, and implementation tasks with live TUI streaming, parallel execution, independent model overrides, and real-time cost accounting.
 
-## What you get
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
+</div>
 
-- **Single & parallel execution** — dispatch one task or fan out multiple tasks across different agents simultaneously
-- **Live TUI streaming** — watch subagent progress in real-time with color-coded tool calls (grey while running, green/red on completion), readable argument previews, token counts, and cost updates
-- **Agent discovery** — auto-discovers agents from `.pi/agents/*.md` files at project, user, and global scope
-- **Per-agent model override** — each subagent can use its own model, falling back to the parent's selection
-- **Cost tracking** — detailed token usage (input, output, cache read/write) and cost per subagent, emitted through the core bus for the footer to consume
-- **Trace correlation** — results expose the ephemeral child's logical Pi session UUID as optional `childSessionId` when Pi emits a valid session event
-- **`/agents` command** — full CRUD TUI for managing agent definitions with model picker, tool picker, and cross-scope collision warnings (available via the meta package)
+## Quick Start
 
-## Screenshots
+### 1. Install Pi (if needed)
 
-### Main view — parallel execution
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
 
-Live progress panel showing two parallel subagents with token stats, cost, and recent output:
+### 2. Install
 
-![subagents main view](../../docs/images/subagents-main-view.png)
-
-### Agent details view
-
-Browse and inspect agent configurations — name, model, tools, system prompt, and more:
-
-![subagents agent view](../../docs/images/subagents-agent-view.png)
-
-### Model selection
-
-Pick from all available models registered in Pi's model registry:
-
-![subagents model selection](../../docs/images/subagents-model-selection.png)
-
-### Tool selection
-
-Toggle which tools are available to an agent from Pi's full toolset:
-
-![subagents tool selection](../../docs/images/subagents-tool-selection.png)
-
-## Install
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/subagent
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
+---
+
+## What You Get
+
+- **Single & Parallel Execution** — Dispatch one targeted subtask or fan out multiple tasks across distinct agents simultaneously.
+- **Live TUI Streaming** — Watch subagents think and execute tools in real time with color-coded status chips (grey while running, green on success, red on failure) and readable argument previews.
+- **Visual `/agents` Manager** — Interactive full-screen TUI to create, configure, and inspect custom subagent personas with model and tool pickers.
+- **Per-Agent Model Selection** — Assign different models per subagent (e.g. fast cheap models for research, high-reasoning models for code review).
+- **Comprehensive Cost Accounting** — Real-time tracking of input tokens, output tokens, cache read/write, and dollar cost per subagent, flowing into the footer.
+- **Multi-Scope Agent Discovery** — Reads agent definitions from project (`<repo>/.pi/agents/`), user (`~/.pi/agent/agents/`), and cross-agent (`~/.agents/agents/`) scopes with collision detection.
+
+---
+
+## Screenshots
+
+### Agent Details & Persona View
+
+Inspect agent prompts, assigned models, and tool configurations:
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-agent-view.png" width="650" alt="Subagents agent details view">
+</div>
+
+### Model & Tool Pickers
+
+Assign specific models and toggle allowed tools directly from the TUI:
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-model-selection.png" width="48%" alt="Model selection">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-tool-selection.png" width="48%" alt="Tool selection">
+</div>
+
+---
+
 ## Usage
 
-### As a tool
+### The `subagent` Tool
 
-The `subagent` tool accepts either a single `task` or an array of `tasks` for parallel execution:
+Single task dispatch:
 
 ```jsonc
 {
-  "agent": "reviewer",     // optional, defaults to "general"
-  "task": "review the PR", // single task
-  "model": "openrouter/anthropic/claude-4", // optional override
-  "cwd": "/path/to/dir"    // optional working directory
+  "agent": "reviewer",                     // optional persona name (defaults to "general")
+  "task": "review the PR diff",            // task description
+  "model": "openrouter/anthropic/claude-4",// optional model override
+  "cwd": "/path/to/project"                // optional working directory
 }
 ```
 
-Parallel mode:
+Parallel swarm dispatch:
 
 ```jsonc
 {
   "tasks": [
-    { "agent": "researcher", "task": "find all usages of foo" },
-    { "agent": "reviewer", "task": "review the implementation plan" }
+    { "agent": "researcher", "task": "find all usages of the deprecated API" },
+    { "agent": "reviewer", "task": "review the proposed migration plan" }
   ]
 }
 ```
 
-### As a command
+### The `/agents` Command
 
-Run `/agents` to open the interactive Agents Manager for creating, editing, and deleting agent definitions.
+Run `/agents` to launch the interactive persona manager. Browse existing agents, create new ones, configure system prompts, and toggle available tools.
 
-## Agent files
+---
 
-Agents are defined as `.md` files with YAML frontmatter, placed in one of:
+## Part of the Archimedes Suite
 
-- **Project scope:** `<repo root>/.pi/agents/` — available only in this project
-- **User scope:** `~/.pi/agent/agents/` — available across all projects
-- **Global scope:** `<repo root>/.agents/agents/` or `~/.agents/agents/` — shared or installed subagents
+When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), subagent tokens and expenses automatically accumulate in the `@pi-archimedes/footer` status bar, subagent tasks display in side-by-side columns on the `@pi-archimedes/todo` board, and subagents can ask you interactive questions via `@pi-archimedes/ask` IPC.
 
-Frontmatter supports: `name`, `description`, `model`, `tools`, and `thinking`. The markdown body becomes the agent's system prompt. Unknown frontmatter fields are preserved on edit but not interpreted.
-
-Per-agent `model` and `thinking` assignments made in the `/agents` TUI are stored in `~/.pi/agent/agents.local.json` (machine-local, not committed) and take precedence over frontmatter values; on save, the TUI also strips these fields from the `.md` frontmatter. Frontmatter `model:` and `thinking:` still work as a fallback for hand-written agent files.
-
-## Integration
-
-When installed via `pi-archimedes` (the meta package), subagent cost events flow through `@pi-archimedes/core/bus` and are consumed by `@pi-archimedes/footer`'s `CostAccumulator`. This merges subagent tokens and cost into the main status bar for a unified view.
-
-The `/agents` command is also only registered by the meta package (not by standalone `@pi-archimedes/subagent`).
-
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/subagent/README.md
+++ b/packages/subagent/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the dispatch tool up in a running session.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the dispatch tool up in a running session.
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/subagents-main-view.png" width="750" alt="Subagents parallel streaming view">
@@ -32,9 +32,9 @@ Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on a
 
 ## Dispatching
 
-### Config-less — the default
+### Config-less — omit `agent`
 
-The `agent` field is optional. Omit it and the task runs with the **parent's model and all tools**:
+The `agent` field is optional — omitting it is not a built-in default agent, and **no agents are shipped** with the package. Without an agent file, the model falls back to the per-call `model` override and then the parent's active model, and tools follow Pi's normal selection at spawn — except the `subagent` tool itself is always excluded, so a worker can't spawn workers:
 
 ```jsonc
 {
@@ -44,39 +44,17 @@ The `agent` field is optional. Omit it and the task runs with the **parent's mod
 }
 ```
 
-### Named agents
-
-With an `agent` name, the dispatch runs under a defined agent file (format below). Unknown names are refused and list the available agents, so a typo fails cheap:
-
-```jsonc
-{
-  "agent": "reviewer",
-  "task": "review the PR diff"
-}
-```
-
-### Parallel work
-
-Independent tasks go in a `tasks` array — distinct agents, distinct models, one call:
-
-```jsonc
-{
-  "tasks": [
-    { "agent": "researcher", "task": "find all usages of the deprecated API" },
-    { "agent": "reviewer",   "task": "review the proposed migration plan" }
-  ]
-}
-```
-
 **The dispatch waits.** A call — single or parallel — blocks until every task completes and returns the combined results, each optionally carrying the child's `childSessionId`. There is an `async` field in the schema; the implementation ignores it, so don't plan on fire-and-forget: batch the work into `tasks` and let the call block on all of it.
 
-### Model resolution
+### Model and thinking resolution
 
-Per dispatch, in order: **the agent config's `model`, then the per-call `model`, then the parent's model.** The same rule holds for thinking level, except there is no per-call thinking field — agent config or parent.
+Per dispatch, the model resolves in order: **the agent config's `model`, then the per-call `model`, then the parent's active model** (the first entry doesn't apply to config-less dispatch).
+
+The thinking level is **not** inherited from the parent session's active thinking. It comes from the agent file's explicit `thinking` when present; otherwise Pi works out its own (the selected model, its configuration, or the model's default).
 
 ## Agent files
 
-Custom agents are `.md` files with YAML frontmatter:
+Named agents are `.md` files with YAML frontmatter — a complete definition:
 
 ```markdown
 ---
@@ -94,7 +72,30 @@ and name the lines you checked.
 - **Scopes, in precedence order:** project (`<repo>/.pi/agents/`), user (`~/.pi/agent/agents/`), and global — the repository's `.agents/agents/` or, falling back, `~/.agents/agents/`.
 - Unknown frontmatter fields are preserved on edit, not interpreted.
 - Model and thinking picked in the `/agents` TUI are saved to `~/.pi/agent/agents.local.json` (machine-local, not committed), take precedence over the frontmatter, and are stripped from the `.md` on save. Hand-written `model:`/`thinking:` in frontmatter remain the fallback.
-- At runtime, the subagent tool is excluded from a child's tool set, so a worker can't spawn workers.
+
+### Named agents
+
+With an `agent` name, the dispatch runs under that defined agent file — no agents are bundled, so the name must exist in one of these files. Unknown names are refused and list the available agents, so a typo fails cheap:
+
+```jsonc
+{
+  "agent": "reviewer",
+  "task": "review the PR diff"
+}
+```
+
+### Parallel work
+
+Independent tasks go in a `tasks` array — mix defined agents and config-less tasks, distinct models, one call:
+
+```jsonc
+{
+  "tasks": [
+    { "agent": "reviewer", "task": "review the proposed migration plan" },
+    { "task": "find all usages of the deprecated API" }   // config-less — the model/tools fall back as above
+  ]
+}
+```
 
 ## The `/agents` command
 

--- a/packages/sudo/README.md
+++ b/packages/sudo/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
 
 ## What you get
 
@@ -32,7 +32,7 @@ Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on a
 - **Masked password prompt** — the password is typed into a masked UI and passed to sudo via stdin only. It is never in argv, environment variables, command logs, or the LLM context.
 - **Defensive output scrubbing** — command output lines that contain the password are redacted before they reach the tool result. That is a literal-substring scrub: it catches common cases, and it is **not** universal leak protection.
 - **Credential cache** — a single in-memory cache with a TTL (15 minutes by default, `ttlMs`); cleared on authentication failure, at `session_start`/`session_shutdown`, and by `/sudo forget`.
-- **Timeout kills the group** — the abort signal propagates to the command's entire process group, so root children, not just the direct sudo process, are terminated. Deliberately detached descendants (`setsid`, daemonising) leave the process group and survive any user-space kill — such commands should be given a managed lifecycle flag (e.g. `--foreground`) instead.
+- **Timeout/abort cleanup** — on timeout or abort, the tool attempts to kill the command's entire process group, falling back to the direct sudo process, so root children, not just the direct sudo process, are the target of the cleanup. Deliberately detached descendants (`setsid`, daemonising) leave the process group and are outside its scope — use a flag to keep the child a process in the group (e.g. `--foreground`).
 - **Headless sessions refused** — `sudo_exec` requires an interactive (TUI) session; subagent and headless sessions get a clear error instead of a prompt. The masked prompt only ever appears in front of a human.
 - **Active bash guard** — a `tool_call` veto on the built-in `bash` tool (per [ADR 0010](https://github.com/danielcherubini/pi-archimedes/blob/main/docs/adr/0010-archimedes-sudo-security.md)) blocks interactive `sudo`, funneling privileged execution toward `sudo_exec`.
 
@@ -53,7 +53,7 @@ Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on a
 The scanned `bash` commands:
 
 - **Blocked:** `sudo` in command position without a no-prompt flag — including through runner wrappers (`env`, `nohup`, `timeout`, `xargs`, …), nested shells (`bash -c`, `su -c`), `eval`, compound keywords, and heredoc bodies.
-- **Allowed:** non-interactive sudo (`sudo -n`, `-l`, `-v`, `-K`, `-k`, `--non-interactive`) — these cannot prompt and pass through untouched.
+- **Allowed:** sudo occurrences that carry a no-prompt flag (`-n`, `-l`, `-v`, `-K`, `-k`, `--non-interactive`, or merged short flags composed solely of those) — the scanner's allow-list exception, mirroring the typical non-interactive usage.
 
 The guard is a **heuristic with accepted residual bypasses** documented in the [ADR 0010 design notes](https://github.com/danielcherubini/pi-archimedes/blob/main/docs/adr/0010-archimedes-sudo-security.md) — for example cross-token variable indirection, and `sudo` inside `$(...)`/backtick interpolation the word-position model cannot see. Over-blocking is the safe direction; the tested no-prompt flag set is a stable contract of the scanner, **not** a guarantee that no prompt can occur.
 
@@ -71,9 +71,12 @@ The guard is a **heuristic with accepted residual bypasses** documented in the [
 | `ttlMs` | number | `900000` | Password cache TTL in milliseconds (default 15 minutes) |
 | `defaultTimeoutMs` | number | `120000` | `sudo_exec` default command timeout in milliseconds (default 120 seconds) |
 
-### Credential limitation on sudoers that retain no reusable ticket
+### Credential handling when sudo retains no verifiable ticket
 
-On sudoers policies that retain no reusable credential ticket (e.g. `timestamp_timeout=0` with strict `Defaults`), an authenticated but failed command is indistinguishable from an authentication failure to any non-interactive check. The tool applies a two-consecutive-failure rule: the first failure keeps the cached password (with a visible warning), the second clears it. A wrong password on such a sudo is therefore detected on the second failure, not the first — the bounded cost of a policy that exposes no ticket to verify against.
+On sudoers policies that retain no reusable credential ticket (e.g. `timestamp_timeout=0` with strict `Defaults`), an authenticated but failed command is indistinguishable from an authentication failure unless the ticket can be verified with `sudo -n -v`.
+
+- A **recognized wrong password** (sudo's `incorrect password` output alongside its prompt) clears the credential **immediately**, on that failure.
+- The **two-strike rule** applies to **ambiguous** failures where the ticket probe cannot verify the credential: the first strike keeps the cached password (with a visible one-more-attempt warning), the second consecutive strike clears it and re-prompts. Success resets the streak, and transport failures don't count as strikes.
 
 ## Part of the suite
 

--- a/packages/sudo/README.md
+++ b/packages/sudo/README.md
@@ -1,66 +1,82 @@
 # @pi-archimedes/sudo
 
-Safe privileged execution for the [Pi coding agent](https://github.com/earendil-works/pi): a dedicated `sudo_exec` tool with a masked password prompt, plus a guard that keeps the ordinary `bash` tool from driving interactive `sudo`.
+**Safe privileged execution and interactive-sudo guard for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-## What you get
+When coding agents attempt to install system packages or execute administrative tasks using ordinary shell execution, interactive `sudo` prompts cause terminal deadlocks and risk exposing root credentials in LLM context. `@pi-archimedes/sudo` provides a dedicated `sudo_exec` tool with masked password entry, in-memory credential caching, and an active bash guard that prevents the agent from running unprotected interactive sudo commands.
 
-- **`sudo_exec` tool** — runs a privileged command via `sudo -S`, showing the exact command and reason for confirmation before any credential is requested; on timeout/abort the kill applies to the command's entire process group, so privileged (root) descendants are killed too, not just the direct sudo process — except a command that intentionally detaches itself into its own session (`setsid`/daemonizing), which leaves the group by definition and is beyond any user-space kill (the same reach as `tmux kill-pane`): give such commands a managed lifecycle flag (e.g. `--foreground`) instead
-- **Masked password prompt** — the password is entered only through a masked UI, cached in memory for the session, and passed to sudo via stdin only — never in argv, env, logs, or files
-- **Defensive scrubbing** — command output lines containing the password are redacted before they appear in tool results
-- **Credential lifecycle** — single in-memory cache with TTL (default 15 min, `ttlMs`); cleared on auth failure, `session_start`/`session_shutdown`, and `/sudo forget`
-- **Headless sessions blocked** — subagent/headless sessions get a clear error from `sudo_exec` instead of a prompt; the masked prompt only ever appears in a human's TUI
-- **Bash guard** — active `tool_call` veto (ADR 0010): interactive `sudo` through the built-in `bash` tool is blocked, funneling privileged execution through `sudo_exec`
-- **`/sudo` + `/sudo forget`** — report the credential-cache state or clear it from memory
+## Quick Start
 
-## Install
+### 1. Install Pi (if needed)
+
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+### 2. Install
+
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/sudo
 ```
 
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+
+```bash
+pi install npm:pi-archimedes
+```
+
+---
+
+## What You Get
+
+- **`sudo_exec` Tool** — Executes privileged commands via `sudo -S`, displaying the exact command and human-readable reason for confirmation before any credential prompt is shown.
+- **Masked Password Prompt** — Passwords are typed into a secure masked UI and transmitted strictly over stdin — never visible in argv, environment variables, command logs, or LLM context.
+- **Active Bash Guard** — Intercepts and blocks interactive `sudo` invocations inside the standard `bash` tool, steering the agent toward safe, managed privilege escalation.
+- **Process Group Kill on Timeout** — If a privileged command hangs or times out, the abort signal propagates to the entire process group, ensuring root descendants are terminated cleanly.
+- **In-Memory Credential Cache** — Secure cache with a 15-minute TTL. Cleared on session termination, authentication failure, or manual `/sudo forget`.
+- **Headless Protection** — Background subagents are strictly blocked from requesting root elevation, preventing prompt deadlocks.
+
+---
+
 ## Usage
 
-### The `sudo_exec` tool
+### The `sudo_exec` Tool
 
 ```jsonc
 {
-  "command": "apt install ripgrep", // exact argv string — no leading 'sudo'; no shell syntax (pipes, &&, redirects, env assignments)
-  "reason": "ripgrep is needed for the search tooling", // required — shown to the user before execution
-  "timeoutMs": 120000 // optional override of config.defaultTimeoutMs
+  "command": "apt install ripgrep",                    // exact argv string (no leading 'sudo', no raw shell syntax)
+  "reason": "ripgrep is required for indexing tooling", // human-readable explanation displayed in confirmation prompt
+  "timeoutMs": 120000                                   // optional execution timeout (defaults to 120s)
 }
 ```
 
-The tool uses pi's built-in `renderCall`/`renderResult`; command output is surfaced as plain text, scrubbed with the password masked.
+### The Bash Guard
 
-### The bash guard
+The guard automatically inspects commands submitted to Pi's built-in `bash` tool:
+- **Blocked:** `sudo` in command position without a non-interactive flag (including commands run via `env`, `nohup`, `timeout`, `xargs`, or nested shells like `bash -c`).
+- **Allowed:** Non-interactive sudo commands (`sudo -n`, `-l`, `-v`, `-K`, `-k`, `--non-interactive`) pass through without interception.
 
-A pure, exhaustively-tested scanner vetoes `tool_call` events on the built-in `bash` tool:
+### Commands
 
-- **Blocked:** `sudo` in command position without a no-prompt flag — including through runner wrappers (`env`, `nohup`, `timeout`, `xargs`, …), nested shells (`bash -c`, `su -c`), `eval`, compound keywords, and heredoc bodies
-- **Allowed:** non-interactive sudo (`sudo -n`, `-l`, `-v`, `-K`, `-k`, `--non-interactive`) — these cannot prompt and pass through untouched
+- `/sudo` — Check whether a valid credential is currently held in memory.
+- `/sudo forget` — Immediately flush cached credentials from memory.
 
-The guard is a heuristic with accepted residual bypasses documented in the [ADR 0010 design notes](../../docs/adr/0010-archimedes-sudo-security.md) (e.g. cross-token variable indirection, and sudo inside `$(...)`/backtick interpolation whose text the word-position model cannot see). Over-blocking is the safe direction; the tested no-prompt flag set is a stable contract.
-
-## Commands
-
-- `/sudo` — report whether a credential is cached
-- `/sudo forget` — clear the credential from memory
+---
 
 ## Settings
+
+Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.sudo` namespace:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `ttlMs` | number | `900000` | Password cache TTL in milliseconds (default 15 minutes) |
-| `defaultTimeoutMs` | number | `120000` | `sudo_exec` default command timeout in milliseconds (default 120 seconds) |
+| `defaultTimeoutMs` | number | `120000` | Default execution timeout in milliseconds (default 120 seconds) |
 
-On/off is managed by the suite: toggle via `/plugins` (`archimedes.sudo.enabled`, default on). Config is JSON-only in the `archimedes.sudo` namespace of `~/.pi/agent/settings.json` — there is no settings-panel UI in v1.
+---
 
-### Credential limitation on sudoers that retain no reusable ticket
+## Part of the Archimedes Suite
 
-On sudoers policies that retain no reusable credential ticket (e.g. `timestamp_timeout=0` plus strict `Defaults`), an authenticated **command** failure is indistinguishable from an authentication failure to any non-interactive check — so the tool uses a two-consecutive-failure rule: the first failure keeps the cached password (with a visible warning), the second clears it. A wrong password on such a sudo is therefore detected on the second failure rather than the first — the bounded cost of a policy that exposes no ticket to verify against.
+When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/sudo` operates across both main agent sessions and subagents, ensuring privileged operations are safely managed throughout the swarm.
 
-## Integration
-
-When installed via `pi-archimedes` (the meta package), the sudo package is registered and gated by the suite's plugin manifest (ADR 0012); the bash guard and `sudo_exec` are loaded in both the main session and subagent children — the guard still vetoes there, while `sudo_exec` itself refuses to run headless. Standalone installs work independently.
-
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/sudo/README.md
+++ b/packages/sudo/README.md
@@ -1,82 +1,82 @@
 # @pi-archimedes/sudo
 
-**Safe privileged execution and interactive-sudo guard for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**A little more care with root access.**
 
-When coding agents attempt to install system packages or execute administrative tasks using ordinary shell execution, interactive `sudo` prompts cause terminal deadlocks and risk exposing root credentials in LLM context. `@pi-archimedes/sudo` provides a dedicated `sudo_exec` tool with masked password entry, in-memory credential caching, and an active bash guard that prevents the agent from running unprotected interactive sudo commands.
+Interactive `sudo` inside an agent session is a mistake waiting to happen — it can deadlock the terminal and drag root credentials into the LLM's context. Sudo puts a deliberate step between the model and the password: the exact command and its reason for your eyes first, a masked prompt (never the chat) for the credential, and a guard that keeps the ordinary `bash` tool from driving interactive `sudo` at all.
 
-## Quick Start
+## Install
 
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/sudo
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
 
-- **`sudo_exec` Tool** — Executes privileged commands via `sudo -S`, displaying the exact command and human-readable reason for confirmation before any credential prompt is shown.
-- **Masked Password Prompt** — Passwords are typed into a secure masked UI and transmitted strictly over stdin — never visible in argv, environment variables, command logs, or LLM context.
-- **Active Bash Guard** — Intercepts and blocks interactive `sudo` invocations inside the standard `bash` tool, steering the agent toward safe, managed privilege escalation.
-- **Process Group Kill on Timeout** — If a privileged command hangs or times out, the abort signal propagates to the entire process group, ensuring root descendants are terminated cleanly.
-- **In-Memory Credential Cache** — Secure cache with a 15-minute TTL. Cleared on session termination, authentication failure, or manual `/sudo forget`.
-- **Headless Protection** — Background subagents are strictly blocked from requesting root elevation, preventing prompt deadlocks.
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` picks the extension up in a running session.
 
----
+## What you get
+
+- **`sudo_exec` tool** — runs a privileged command via `sudo -S`, showing the exact command and a human-readable **reason** for confirmation before any credential prompt appears. A declined confirmation means nothing runs and no password is requested.
+- **Masked password prompt** — the password is typed into a masked UI and passed to sudo via stdin only. It is never in argv, environment variables, command logs, or the LLM context.
+- **Defensive output scrubbing** — command output lines that contain the password are redacted before they reach the tool result. That is a literal-substring scrub: it catches common cases, and it is **not** universal leak protection.
+- **Credential cache** — a single in-memory cache with a TTL (15 minutes by default, `ttlMs`); cleared on authentication failure, at `session_start`/`session_shutdown`, and by `/sudo forget`.
+- **Timeout kills the group** — the abort signal propagates to the command's entire process group, so root children, not just the direct sudo process, are terminated. Deliberately detached descendants (`setsid`, daemonising) leave the process group and survive any user-space kill — such commands should be given a managed lifecycle flag (e.g. `--foreground`) instead.
+- **Headless sessions refused** — `sudo_exec` requires an interactive (TUI) session; subagent and headless sessions get a clear error instead of a prompt. The masked prompt only ever appears in front of a human.
+- **Active bash guard** — a `tool_call` veto on the built-in `bash` tool (per [ADR 0010](https://github.com/danielcherubini/pi-archimedes/blob/main/docs/adr/0010-archimedes-sudo-security.md)) blocks interactive `sudo`, funneling privileged execution toward `sudo_exec`.
 
 ## Usage
 
-### The `sudo_exec` Tool
+### The `sudo_exec` tool
 
 ```jsonc
 {
-  "command": "apt install ripgrep",                    // exact argv string (no leading 'sudo', no raw shell syntax)
-  "reason": "ripgrep is required for indexing tooling", // human-readable explanation displayed in confirmation prompt
-  "timeoutMs": 120000                                   // optional execution timeout (defaults to 120s)
+  "command": "apt install ripgrep",                    // exact argv string — no leading 'sudo'; no shell syntax (pipes, &&, redirects, env assignments)
+  "reason": "ripgrep is needed for the search tooling", // required — shown before execution
+  "timeoutMs": 120000                                   // optional override of config.defaultTimeoutMs
 }
 ```
 
-### The Bash Guard
+### The bash guard
 
-The guard automatically inspects commands submitted to Pi's built-in `bash` tool:
-- **Blocked:** `sudo` in command position without a non-interactive flag (including commands run via `env`, `nohup`, `timeout`, `xargs`, or nested shells like `bash -c`).
-- **Allowed:** Non-interactive sudo commands (`sudo -n`, `-l`, `-v`, `-K`, `-k`, `--non-interactive`) pass through without interception.
+The scanned `bash` commands:
 
-### Commands
+- **Blocked:** `sudo` in command position without a no-prompt flag — including through runner wrappers (`env`, `nohup`, `timeout`, `xargs`, …), nested shells (`bash -c`, `su -c`), `eval`, compound keywords, and heredoc bodies.
+- **Allowed:** non-interactive sudo (`sudo -n`, `-l`, `-v`, `-K`, `-k`, `--non-interactive`) — these cannot prompt and pass through untouched.
 
-- `/sudo` — Check whether a valid credential is currently held in memory.
-- `/sudo forget` — Immediately flush cached credentials from memory.
+The guard is a **heuristic with accepted residual bypasses** documented in the [ADR 0010 design notes](https://github.com/danielcherubini/pi-archimedes/blob/main/docs/adr/0010-archimedes-sudo-security.md) — for example cross-token variable indirection, and `sudo` inside `$(...)`/backtick interpolation the word-position model cannot see. Over-blocking is the safe direction; the tested no-prompt flag set is a stable contract of the scanner, **not** a guarantee that no prompt can occur.
 
----
+## Commands
+
+- `/sudo` — report whether a credential is currently cached in memory.
+- `/sudo forget` — flush the cached credential immediately.
 
 ## Settings
 
-Settings are stored in `~/.pi/agent/settings.json` under the `archimedes.sudo` namespace:
+`~/.pi/agent/settings.json`, under `archimedes.sudo` — **JSON only**, no settings-panel UI in v1:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `ttlMs` | number | `900000` | Password cache TTL in milliseconds (default 15 minutes) |
-| `defaultTimeoutMs` | number | `120000` | Default execution timeout in milliseconds (default 120 seconds) |
+| `defaultTimeoutMs` | number | `120000` | `sudo_exec` default command timeout in milliseconds (default 120 seconds) |
 
----
+### Credential limitation on sudoers that retain no reusable ticket
 
-## Part of the Archimedes Suite
+On sudoers policies that retain no reusable credential ticket (e.g. `timestamp_timeout=0` with strict `Defaults`), an authenticated but failed command is indistinguishable from an authentication failure to any non-interactive check. The tool applies a two-consecutive-failure rule: the first failure keeps the cached password (with a visible warning), the second clears it. A wrong password on such a sudo is therefore detected on the second failure, not the first — the bounded cost of a policy that exposes no ticket to verify against.
 
-When installed via [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/sudo` operates across both main agent sessions and subagents, ensuring privileged operations are safely managed throughout the swarm.
+## Part of the suite
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+In [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), the package is registered by the plugin manifest; the bash guard and `sudo_exec` are loaded in the main session and in subagent children — the guard still vetoes there, while `sudo_exec` itself refuses to run in headless mode. Standalone works independently. On/off is managed by the suite: toggle via `/plugins` (`archimedes.sudo.enabled`, default on).
+
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/todo/README.md
+++ b/packages/todo/README.md
@@ -1,72 +1,42 @@
 # @pi-archimedes/todo
 
-**Real-time multi-column task board with auto-clear and subagent synchronization for the [Pi coding agent](https://github.com/earendil-works/pi).**
+**Keep the plan in view.**
 
-Keep complex multi-step refactors and feature builds organized. `@pi-archimedes/todo` provides a structured task widget rendered directly in the terminal, giving both you and the LLM clear visibility into current tasks, pending items, and completed steps. When subagents run, their tasks appear side by side in dedicated columns.
+A live task board in the terminal: your agent's plan in the main column, and a named column for each subagent running alongside — so what's asked, what's in flight, and what's finished never leaves the screen. When everything is done, the board clears itself.
 
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-and-subagent.png" width="750" alt="Main agent and subagent todos side by side">
-</div>
+## Install
 
-## Quick Start
-
-### 1. Install Pi (if needed)
-
-```bash
-npm install -g @earendil-works/pi-coding-agent
-```
-
-### 2. Install
-
-Install standalone:
+Standalone:
 
 ```bash
 pi install npm:@pi-archimedes/todo
 ```
 
-Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
+Or the full suite instead:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
----
+New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 
-## What You Get
-
-- **`manage_todo_list` Tool** — First-class tool allowing agents to plan, update, and read structured task lists with `pending`, `in_progress`, and `completed` states.
-- **Side-by-Side Multi-Column Display** — Main agent todos appear in the primary column; spawned subagents dynamically get their own named column to the right.
-- **Automatic Cleanup** — When all tasks reach `completed`, the widget displays a brief confirmation and auto-clears after 2 seconds to free up screen real estate.
-- **Interactive Commands** — Toggle visibility with `/todos` or manually reset with `/todos clear`.
-- **Session Persistence** — Todos survive `/reload` commands via session state reconstruction.
-
----
-
-## Screenshots
-
-### Progress Tracking
-
-Visual status indicators with strikethrough for finished items and highlights for current work:
-
-<div align="center">
-  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-multiple-todos.png" width="600" alt="Multiple todos tracking progress">
-</div>
-
----
-
-## Tool Usage
-
-The `manage_todo_list` tool accepts `read` and `write` operations:
-
-### Read Current Tasks
-
-```jsonc
-{
-  "operation": "read"
-}
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-### Write / Update Tasks
+Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` works two ways here: it picks the extension up, **and** it restores the todo list, which survives `/reload` through session state reconstruction.
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-and-subagent.png" width="750" alt="Main agent and subagent todos side by side">
+</div>
+
+## The `manage_todo_list` tool
+
+Two operations, `write` and `read`:
+
+```jsonc
+{ "operation": "read" }
+```
 
 ```jsonc
 {
@@ -79,10 +49,25 @@ The `manage_todo_list` tool accepts `read` and `write` operations:
 }
 ```
 
----
+**Writes replace the whole list.** There is no partial update: every `write` must carry the complete list — existing items included — or they are replaced and gone.
 
-## Part of the Archimedes Suite
+States are `pending`, `in_progress`, and `completed`. Finished items render struck through; the current one stays highlighted.
 
-When installed as part of [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/todo` listens to `@pi-archimedes/subagent` events over the core bus to dynamically spawn and dismiss subagent columns as workers start and finish.
+<p align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-multiple-todos.png" width="600" alt="Multiple todos tracking progress">
+</p>
 
-← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)
+## Commands
+
+- `/todos` — refreshes the todo widget and reports its status (e.g. `3/7 todos completed.`). It is **not** a visibility toggle; the board shows while there is content.
+- `/todos clear` — clears the list.
+
+## Auto-clear
+
+When every task reaches `completed`, the widget shows a brief confirmation, then clears itself after 2 seconds to give the screen back.
+
+## Part of the suite
+
+With subagents running alongside in the [full suite](https://github.com/danielcherubini/pi-archimedes), each child gets its own named column to the right of yours — spawned when the worker starts and dismissed when it finishes, driven by core-bus events. On/off is managed by the suite: toggle via `/plugins` (`archimedes.todo.enabled`, default on).
+
+← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/todo/README.md
+++ b/packages/todo/README.md
@@ -24,7 +24,7 @@ New to Pi? Pi itself is a one-time global install and needs Node.js ≥ 22.19.0:
 npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 ```
 
-Then `pi install npm:pi-archimedes`, `cd` into the project you want to work on and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` works two ways here: it picks the extension up, **and** it restores the todo list, which survives `/reload` through session state reconstruction.
+After installing Pi, choose one installation command above, then `cd` into your project and run `pi`. Inside the session, `/login` signs you in and `/model` picks a model — the [setup section](https://github.com/danielcherubini/pi-archimedes#setup) covers the first run. `/reload` works two ways here: it picks the extension up, **and** it restores the todo list, which survives `/reload` through session state reconstruction.
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-and-subagent.png" width="750" alt="Main agent and subagent todos side by side">
@@ -68,6 +68,6 @@ When every task reaches `completed`, the widget shows a brief confirmation, then
 
 ## Part of the suite
 
-With subagents running alongside in the [full suite](https://github.com/danielcherubini/pi-archimedes), each child gets its own named column to the right of yours — spawned when the worker starts and dismissed when it finishes, driven by core-bus events. On/off is managed by the suite: toggle via `/plugins` (`archimedes.todo.enabled`, default on).
+With subagents running alongside in the [full suite](https://github.com/danielcherubini/pi-archimedes), each child gets its own named column to the right of yours — it appears on the child's first non-empty todo update over core's bus (not when the worker starts), and is dismissed when the list is cleared or the child exits. On/off is managed by the suite: toggle via `/plugins` (`archimedes.todo.enabled`, default on).
 
 ← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/todo/README.md
+++ b/packages/todo/README.md
@@ -68,6 +68,6 @@ When every task reaches `completed`, the widget shows a brief confirmation, then
 
 ## Part of the suite
 
-With subagents running alongside in the [full suite](https://github.com/danielcherubini/pi-archimedes), each child gets its own named column to the right of yours — it appears on the child's first non-empty todo update over core's bus (not when the worker starts), and is dismissed when the list is cleared or the child exits. On/off is managed by the suite: toggle via `/plugins` (`archimedes.todo.enabled`, default on).
+With subagents running alongside in the [full suite](https://github.com/danielcherubini/pi-archimedes), each child gets its own named column to the right of yours — it appears on the child's first non-empty todo update over core's bus (empty updates are ignored; it does not appear when the worker merely starts), and it is removed when the child exits. The 2-second auto-clear is local to whatever list completed — a child clearing its own list does not dismiss the column in your session. On/off is managed by the suite: toggle via `/plugins` (`archimedes.todo.enabled`, default on).
 
 ← [Back to pi-archimedes](https://github.com/danielcherubini/pi-archimedes)

--- a/packages/todo/README.md
+++ b/packages/todo/README.md
@@ -1,51 +1,64 @@
 # @pi-archimedes/todo
 
-Todo list management with auto-clear and live subagent visibility for the [Pi coding agent](https://github.com/earendil-works/pi).
+**Real-time multi-column task board with auto-clear and subagent synchronization for the [Pi coding agent](https://github.com/earendil-works/pi).**
 
-Track complex multi-step tasks structured in a todo list with automatic clearing on completion and live side-by-side visibility into subagent tasks. Having an active progress display keeps long tasks on track and gives both you and the model clear visibility into completed steps and next actions.
+Keep complex multi-step refactors and feature builds organized. `@pi-archimedes/todo` provides a structured task widget rendered directly in the terminal, giving both you and the LLM clear visibility into current tasks, pending items, and completed steps. When subagents run, their tasks appear side by side in dedicated columns.
 
-## What you get
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-and-subagent.png" width="750" alt="Main agent and subagent todos side by side">
+</div>
 
-- **`manage_todo_list` tool** — structured todo tracking with `read` and `write` operations
-- **Auto-clear** — when all todos are completed, the list clears itself after a brief 2-second delay
-- **Multi-column widget** — main agent todos on the left, each subagent's todos in their own column to the right
-- **Live subagent visibility** — subagent todos stream through the core bus so you can see what they're working on
-- **`/todos` command** — toggle the widget or clear todos (`/todos clear`)
-- **Session persistence** — todos survive `/reload` via session branch reconstruction
+## Quick Start
 
-## Screenshots
+### 1. Install Pi (if needed)
 
-### Multiple todos with progress tracking
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
 
-Widget showing three todos with completion status — completed items dimmed with strikethrough, the item currently being worked on highlighted:
+### 2. Install
 
-![todos multiple todos](../../docs/images/todos-multiple-todos.png)
-
-### Main agent + subagent side by side
-
-Main agent todos (left) alongside a subagent's todos (right), separated by a divider. Subagent column auto-removes when the subagent finishes:
-
-![todos and subagent](../../docs/images/todos-and-subagent.png)
-
-## Install
+Install standalone:
 
 ```bash
 pi install npm:@pi-archimedes/todo
 ```
 
-Or install full meta package:
+Or install the complete [pi-archimedes](https://github.com/danielcherubini/pi-archimedes) development cockpit:
 
 ```bash
 pi install npm:pi-archimedes
 ```
 
-## Usage
+---
 
-### As a tool
+## What You Get
 
-The `manage_todo_list` tool accepts two operations:
+- **`manage_todo_list` Tool** — First-class tool allowing agents to plan, update, and read structured task lists with `pending`, `in_progress`, and `completed` states.
+- **Side-by-Side Multi-Column Display** — Main agent todos appear in the primary column; spawned subagents dynamically get their own named column to the right.
+- **Automatic Cleanup** — When all tasks reach `completed`, the widget displays a brief confirmation and auto-clears after 2 seconds to free up screen real estate.
+- **Interactive Commands** — Toggle visibility with `/todos` or manually reset with `/todos clear`.
+- **Session Persistence** — Todos survive `/reload` commands via session state reconstruction.
 
-**Read current todos:**
+---
+
+## Screenshots
+
+### Progress Tracking
+
+Visual status indicators with strikethrough for finished items and highlights for current work:
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/danielcherubini/pi-archimedes/main/docs/images/todos-multiple-todos.png" width="600" alt="Multiple todos tracking progress">
+</div>
+
+---
+
+## Tool Usage
+
+The `manage_todo_list` tool accepts `read` and `write` operations:
+
+### Read Current Tasks
 
 ```jsonc
 {
@@ -53,38 +66,23 @@ The `manage_todo_list` tool accepts two operations:
 }
 ```
 
-**Write (replace) the todo list:**
+### Write / Update Tasks
 
 ```jsonc
 {
   "operation": "write",
   "todoList": [
-    { "content": "Parse config files", "description": "Read and validate all config files", "status": "in_progress" },
-    { "content": "Build state manager", "description": "Implement TodoStateManager class", "status": "pending" },
-    { "content": "Wire up widget", "description": "Connect widget to bus events", "status": "pending" }
+    { "content": "Parse config files", "description": "Read and validate settings", "status": "completed" },
+    { "content": "Build state manager", "description": "Implement reactive store", "status": "in_progress" },
+    { "content": "Connect UI widget", "description": "Bind to core bus events", "status": "pending" }
   ]
 }
 ```
 
-### As a command
+---
 
-- `/todos` — toggle the todo widget visibility
-- `/todos clear` — clear all todos immediately
+## Part of the Archimedes Suite
 
-## Todo statuses
+When installed as part of [pi-archimedes](https://github.com/danielcherubini/pi-archimedes), `@pi-archimedes/todo` listens to `@pi-archimedes/subagent` events over the core bus to dynamically spawn and dismiss subagent columns as workers start and finish.
 
-| Status | Icon | Description |
-|--------|------|-------------|
-| `pending` | ○ | Not yet begun |
-| `in_progress` | ◉ | Currently being worked on |
-| `completed` | ✓ | Fully finished |
-
-## Auto-clear
-
-When all todos in the list are marked as `completed`, the widget shows the all-done state for 2 seconds, then auto-clears. No need to manually run `/todos clear`.
-
-## Integration
-
-When installed via `pi-archimedes` (the meta package), subagent todo events flow through `@pi-archimedes/core/bus` and appear as separate columns in the widget. Each subagent gets its own column labeled with its agent name. The column auto-removes when the subagent finishes.
-
-← Back to [pi-archimedes](../../README.md)
+← Back to [pi-archimedes](https://github.com/danielcherubini/pi-archimedes)


### PR DESCRIPTION
## Summary

Rewrites the root README, the npm `meta/README.md`, and all eleven `packages/*/README.md` so the project sells itself instead of reading like an extension catalog. The `pi-archimedes` npm package also gets its own README (additionally included in `meta/package.json`'s `files`), so the published package ships with documentation.

**Approved copy direction: "Pi, with the good stuff."** — confident, personable, benefits first. No corporate jargon ("operates in silos", "reactive nervous system", "human-in-the-loop governance"), no invented Pi limitations, no fake benchmarks or guarantees.

### Copy & structure
- **Setup above the fold** — new-user path (Node ≥ 22.19.0, `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`, `pi install npm:pi-archimedes`, launch, `/login`, `/model`) before features and screenshots; existing users get the one-liner + `/reload`.
- Short feature stories (agent backup, delegated work, existing tools that light up, readable diffs, a terminal worth the day, careful root, stepping away) — then the interactive-commands table, modular packages, settings reference, development.
- Every `packages/*/README.md`: distinct opening, install before screenshots, usage detail, settings, caveats, npm-safe links.

### Factual corrections (all verified against source during review)
- `/plugins`: 10 optional plugins + ever-on core; toggles persist immediately and apply on `/reload`; `/archimedes` `s` saves, Esc discards (up/down moves, left/right changes values); `/agents` is suite-only.
- `/todos` updates the list (not a show toggle); `mutedTheme` is inert in the current renderer; Archimedes settings are strict JSON vs MCP server config JSONC.
- Subagent: omitted agent = config-less (no default `general`); `async` is a schema-only field (dispatch is still awaited); full model/thinking/tool resolution order; agent file format + `agents.local.json` precedence.
- Diff: display-only (no approval gate, includes a call preview); standalone uses fixed theme/width defaults, suite config is the meta's.
- Sudo: scanner-based allow-list (a heuristic, not a security boundary); process-group kill is an attempt (detached descendants out of scope); recognized failures clear immediately, two-strike rule only for ambiguous failures.
- MCP: `auth: "oauth"` must be explicit — omission is no auth, `bearerTokenEnv`/`headers` still work; full `McpOAuthConfig` field reference + `McpConfig` behavior; import scan order + `PI_CODING_AGENT_DIR` override; `/mcp` management then auto-restarts the same-process client.
- Notify: `agent_settled` / `ui_prompt_start` triggers (includes relayed prompts), fixed delay, any input cancels (no focus/keystroke-night detection).
- Session naming = one extra model call per session (possibly billable, not in the footer).

### Review fixes (verified by re-review)
- `meta/README.md` "npm package" column now links the 11 npm package pages (was GitHub README links).
- `/archimedes` key wording matched to the panel's actual help line.
- Core framed-editor quit-guard qualified to the `app.clear` binding (`Ctrl+C` by default).
- Meta Development pointer normalized to the canonical README anchor.

### Verification
- `npx tsc --noEmit` per package + meta: 12/12 pass.
- `pnpm test`: 74 files / 1362 tests pass.
- `pnpm pack` (12 tarballs, temp dirs): every packed README present and non-empty; no `workspace:*` leakage; new `meta` description in place.
- All 13 READMEs render via the GitHub Markdown API (HTTP 200); 32/32 unique external links probe 200; all 13 local markdown files, anchors, image references check out.
- Docs-only: no runtime change, no publishes.