### PR TITLE
feat(core): quip timer rotation — a subtle random 15–45s re-rotation inside long busy episodes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,7 +69,7 @@ The span from the agent becoming busy (idle → working) back to idle; the unit 
 _Avoid_: Work session, agent turn, working span
 
 **Spin quip**:
-A fun (≤ 64 visible chars, ASCII-only) random label shown in the editor's border spinner window; picked per busy episode whenever `editorSpinLabel` is left at its default (a custom label wins; empty hides).
+A fun (≤ 64 visible chars, ASCII-only) random label shown in the editor's border spinner window; picked per busy episode and re-picked on a subtle random 15–45 s timer while a long episode continues (a new episode always re-picks and resets the window; idle freezes it, so the label survives gaps); it applies whenever `editorSpinLabel` is left at its default (a custom label wins; empty hides).
 _Avoid_: Rotating label, joke text, spinner text
 
 ## Notify terminology

--- a/docs/roadmap/quips-timer-rotation.md
+++ b/docs/roadmap/quips-timer-rotation.md
@@ -1,0 +1,119 @@
+---
+status: committed
+done-when: A long busy episode (>45s) shows a fresh spinner quip re-picked every 15–45 seconds (subtle, never predictable); a new busy episode always starts a fresh quip and resets the rotation; idle persistence, custom/empty `editorSpinLabel`, and `spin: false` behavior are unchanged
+---
+
+# Quip timer rotation Plan
+
+**Goal:** Re-rotate the spinner quip on a subtle random timer (15–45s) during long busy episodes, on top of the existing per-episode pick (plan: spinner quips, PR #50).
+
+**Architecture:** Pure state inside the existing `spinTimer` tick loop in `HephaestusEditor` — no new `setInterval`. A per-episode tick counter (reset on each idle→busy transition, alongside the existing fresh pick) accumulates while busy; at a per-episode random threshold (15–45s converted to ticks) the quip is re-picked via the existing `pickQuip(previous)` (repeat exclusion already handled). Corrupt-config / custom-label / empty / `spin:false` paths are untouched — the quip block is the only place these fields are read.
+
+**Tech Stack:** TypeScript (`.ts` via pi's jiti loader, no build step), vitest, pnpm workspace. Design authority: 2026-09-12 `ask` — **random 15–45s** (not fixed 30/60), **new episode resets the rotation and picks fresh**, zero-config (no new setting "editorSpinLabel family").
+
+---
+
+### Task 1: rotation state in the editor
+
+**Context:** Today the quip is picked only on the idle→busy transition (shipped, PR #50). Long episodes (a 2-min build) show one quip for the whole time. This adds the in-episode re-rotation: a tick counter that accumulates only while busy, and a per-episode random threshold.
+
+**Files:**
+- Modify: `packages/core/src/editor/index.ts` (editor class + option doc comment near `spinLabel`)
+
+**What to implement:**
+
+- New private fields (next to `spinQuip` / `wasBusy`):
+  - `spinQuipTicks: number` — ticks accumulated in the current rotation window (0 on pick/reset; **initializer `= 0`**)
+  - `spinQuipEveryTicks: number` — this window's threshold in ticks (**initializer `= 0`** — safe: never read before the idle→busy branch assigns it, since `spinQuipTicks` only increments after that branch has run)
+  - `quipRand: () => number` — injected random source, **initializer `= Math.random`**; constructor gains **no** signature change — tests override it the way this file's existing test seams work: direct `as any` overwrite of the private member (e.g. `(ed as any).quipRand = () => 0.5`), exactly like the `isIdle` override — **no setter is added to the class**
+  - `spinTickMs` promoted from its local `const` to a `private readonly` field **with initializer `= 32`** (the clamp floor; when `spin: false` it stays at the harmless unused default — doc comment: "tempo set when `spin` is on; the default is inert since `rotationThresholdTicks()` is only reached on busy ticks, which imply spin is on") and **re-assigned inside the existing `if (spin)` block** next to the `setInterval` call (readonly reassignment in the constructor is legal TS; the initializer is required to avoid TS2463 under the root `strict` tsconfig)
+- Constants in `spin-quips.ts`: `export const QUIP_ROTATION_MIN_SECS = 15; export const QUIP_ROTATION_MAX_SECS = 45;`
+- `tickSpin` quip-block extension (case `labelMode === "quip"`):
+  ```ts
+  if (this.labelMode === "quip") {
+    const busy = this.spinEnabled && !this.isIdle();
+    if (busy && !this.wasBusy) {
+      this.spinQuip = pickQuip(this.spinQuip, this.quipRand);
+      this.spinQuipTicks = 0;                                   // episode start: fresh quip + reset
+      this.spinQuipEveryTicks = this.rotationThresholdTicks();  // fresh 15–45s window
+    } else if (busy) {
+      this.spinQuipTicks += 1;
+      if (this.spinQuipTicks >= this.spinQuipEveryTicks) {     // intra-episode re-rotation
+        this.spinQuip = pickQuip(this.spinQuip, this.quipRand);
+        this.spinQuipTicks = 0;
+        this.spinQuipEveryTicks = this.rotationThresholdTicks(); // next window is a new draw
+      }
+    }
+    this.wasBusy = busy;
+  }
+  ```
+  `rotationThresholdTicks()` = `Math.ceil(seconds / this.spinTickMs)` where `seconds` is the **inclusive** 15–45s draw from the injected rand: `QUIP_ROTATION_MIN_SECS + Math.floor(this.quipRand() * (QUIP_ROTATION_MAX_SECS - QUIP_ROTATION_MIN_SECS + 1))` — the ceiling rounding guarantees the window is never shorter than requested.
+  - While **idle** the counter neither accumulates nor resets (consumed window persists; the next busy episode re-starts anyway by the transition branch).
+  - No rotation while `spinEnabled === false` (the quip block already gates on it via `busy`).
+- Update the `spinLabel` option doc comment: "…re-picked on a random 15–45s timer while a busy episode continues".
+
+**Steps:**
+1. Read `packages/core/src/editor/index.ts` (spin timer setup + the shippable quip block) to place the fields and case exactly.
+2. Add the constants to `spin-quips.ts` (export for tests' assertion of window bounds).
+3. Implement the fields + the `rotationThresholdTicks()` + the injected `quipRand` (test seam via `as any`, no setter).
+4. `npx tsc --noEmit` in `packages/core`.
+
+**Notes / what NOT to change:**
+- Do not add a `setInterval`; do not touch idle persistence (`spinQuip` survives idle — consumed, unchanged).
+- No config shape change, no new "editorSpinLabel" family, no settings UI change.
+- The 20-char-fit tier, wave-row case, and all previously-shippable label behavior is byte-unchanged.
+
+---
+
+### Task 2: tests
+
+**Context:** Proven the rotation: (a) re-pick within a single long episode at the randomized interval, (b) episode re-start = new pick + reset, (c) no rotation while idle, (d) 15–45s window bounds, (e) all shippable behavior still holds (regression).
+
+**Files:**
+- Test: `packages/core/src/editor/index.test.ts` (extending the shippable quip cases, `vi.mock("./spin-quips.js")` is already in place)
+- Test: `packages/core/src/editor/spin-quips.test.ts` (exporting the constant boundary)
+
+**What to implement:** (extend the existing harness: `makeEditor(idleSeq)`, direct `tick()` calls, `busyAt(step)`)
+
+- **Window bounds — ceiling form** (the real invariant; `ceil` can overshoot the max by less than one tick, so assert on **elapsed** seconds `seconds = ticks * tickMs / 1000`): `seconds >= 15` AND `seconds < 45 + tickMs / 1000`. Force periods via field override — no setting combination reaches them (`SPIN_INTERVALS` max 80 ms native × 1.5 (slow) = 120 ms): `(ed as any).spinTickMs = <ms>` immediately after `makeEditor(...)`, **before the first `tick()` call** (the window is drawn lazily on the first busy tick), with `(ed as any).quipRand = () => 0 | 0.5 | 1` for the three draws. For **exact** `[15, 45]` bounds use tick periods that divide 15000 / 30000 / 45000 evenly: **300 ms** (rand 0/0.5/1 → exactly 15 / 30 / 45 s), or 1000 ms (exact 15 / 30 / 45 s). The 2000 ms + rand=1 case (ceil(22.5) = 23 ticks = 46 s) exercises the loose ceiling bound.
+- **Re-pick within a single episode:** one long busy run (`idleSeq` false for N ticks), mocked `pickQuip` (**unchanged** — it already ignores the 2nd `rand` argument; the `exclude = prior` assertion goes via the recorded first-arg call sequence), forced min window (rand = 0, tickMs = 300 → threshold T = 50 ticks), with **T < N < 2T (e.g. N = 60)**: the quip changes **exactly once** in-episode (the re-pick at tick 50; the next window re-draws at tick 100, never reached within the run), and each change is consumed with `exclude = prior`.
+- **Idle consumption:** a busy run interrupted by idle: the counter does not accumulate during idle (no rotation across the idle gap), the label persists (shippable) — the tick paths of the two busy sides are the same until the next-episode branch runs.
+- **Episode re-start resets:** after idle, when busy again: a new pick (with the existing exclude) is consumed and the counter resets (a re-rotation in the next episode needs the full window again, not the residual).
+- **`spin:false` invariance** and **custom/empty-label regression** — re-assert the shippable cases are byte-unchanged (no new pick calls in those paths).
+- Real `Math.random` (unmocked) sanity: 10 consecutive windows all within `[15 s, 45 s + 1 tick period)` (loop; loose upper bound made explicit — `ceil` overshoot adds at most one tick period).
+
+**Steps:**
+1. Extend `spin-quips.test.ts` with the boundary for the new exported constant.
+2. Add the editor cases in `index.test.ts` (fake timers are already in the harness — direct `tick()` calls in tick units; no wall-clock advancement needed).
+3. Run the core suite.
+
+**Notes / what NOT to change:**
+- Maintain the existing 12 spin-quip case and 42 editor cases green — only **add** cases; the `as any` field overwrites (`quipRand`, `spinTickMs`) are the only new surface the tests touch.
+
+---
+
+### Task 3: documentation sync
+
+**Context:** The contracts in the README, glossary, and the released plan text say "once per busy episode" — that changes now.
+
+**Files:**
+- Modify: `packages/core/README.md` (spin bullets + the `editorSpinLabel` row)
+- Modify: `CONTEXT.md` (spin-quip glossary entry — "picked per busy episode" → "picked per busy episode, re-picked on a random 15–45s timer while an episode continues")
+
+**What to implement:**
+
+- README bullet: `…the label switches to a random quip per busy episode — re-picked on a subtle random 15–45s timer while long episodes continue; set a custom value to pin it (an empty value still hides it as before).`
+- The `editorSpinLabel` row likewise, in one short clause.
+- Glossary: the spin-quip entry reflects the per-episode pick **and** the in-episode re-rotation; the busy-episode entry is implicitly unchanged.
+
+**Steps:** edit both files; grep the repo for any residual "once per busy episode" in the current docs and bring them in line.
+
+**Notes / what NOT to change:** plans (shippable, history) are never re-edited; no changelog (docs-only wording).
+
+---
+
+## Verification
+
+- `npx tsc --noEmit` in `packages/core` (and the repo-wide sweep as before)
+- `pnpm test` (all packages) — the new cases and **all** shippable cases green
+- Manual smoke: a long busy run (e.g. a 1-minute build via a sub-agent) — QIP changes at **roughly irregular** 15–45s intervals; an idle gap preserves the last QIP; a new episode shows a different QIP immediately; custom `editorSpinLabel` freezes the rotation at that value; the narrow-terminal window-only tier is unchanged

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -30,7 +30,7 @@ After installing Pi, choose one installation command above, then `cd` into your 
 
 - **Splash screen** — an animated greeting when the session launches, in one of nine reveal styles (`diagonal`, `top-right`, `bottom-left`, `bottom-right`, `center-out`, `wave`, `horizontal`, `vertical`, `vertical-up`).
 - **Framed editor** — your input in a clean bordered frame, with a double-press guard on the quit key (`Ctrl+C` by default) so a stray keystroke doesn't end the session.
-- **Working spinner on the border** — one of ten animating styles (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) traces the editor frame while the agent works, replacing Pi's native "Working" line. When `editorSpinLabel` is at its default, the label switches to a random quip once per busy episode; set a custom value to pin a label (an empty value still hides it).
+- **Working spinner on the border** — one of ten animating styles (`pendulum`, `typing`, `pulse`, `marquee`, `wave-rows`, `columns`, `cascade`, `diagonal-swipe`, `rain`, `sparkle`) traces the editor frame while the agent works, replacing Pi's native "Working" line. When `editorSpinLabel` is at its default, the label switches to a random quip per busy episode — re-picked on a subtle random 15–45 s timer while long episodes continue; set a custom value to pin a label (an empty value still hides it).
 - **Thinking blocks** — chain-of-thought output gets a consistent label, colour, and layout; `codeUnindent` strips the common indentation so code in reasoning reads flush.
 - **The bus** (`@pi-archimedes/core/bus`) — a global pub/sub event system: `COST_UPDATE`, `ASK_REQUEST`, `TODOS_UPDATE`, `TODOS_CLEAR`… subagent costs flow to the footer through it, subagent todos to the task board, subagent questions to the ask UI.
 - **Shared utilities** — text truncation and width measurement, colour formatting, settings I/O, and startup profiling.
@@ -44,7 +44,7 @@ Settings live in `~/.pi/agent/settings.json` under `archimedes.core`. The file i
 | `editorSpinBorder` | bool | `true` | Show the animated border spinner while the agent works |
 | `editorSpinStyle` | string | `pendulum` | One of the ten spinner styles |
 | `editorSpinSpeed` | string | `normal` | `slow`, `normal`, or `fast` |
-| `editorSpinLabel` | string | `Working` | Label shown alongside the border spinner; the default is replaced by a random quip per busy episode — set a custom value to pin it (empty still hides it) |
+| `editorSpinLabel` | string | `Working` | Label shown alongside the border spinner; the default is replaced by a random quip per busy episode (re-picked on a subtle random 15–45 s timer while long episodes continue) — set a custom value to pin it (empty still hides it) |
 | `animationStyle` | string | `vertical-up` | Splash-screen reveal style (the nine styles above) |
 | `labelText` | string | `Thinking...` | Prefix before thinking blocks |
 | `labelColor` | string | `255,215,0` | RGB string for the thinking label |

--- a/packages/core/src/editor/index.test.ts
+++ b/packages/core/src/editor/index.test.ts
@@ -73,7 +73,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => {
 vi.mock("./spin-quips.js", () => {
   const baseline = (exclude?: string): string =>
     exclude === "Quip A" ? "Quip B" : "Quip A";
-  return { pickQuip: vi.fn(baseline) };
+  return { pickQuip: vi.fn(baseline), QUIP_ROTATION_MIN_SECS: 15, QUIP_ROTATION_MAX_SECS: 45 };
 });
 
 import {
@@ -567,6 +567,98 @@ describe("spin quips (per-episode selection)", () => {
     expect(shown.slice(5, 27)).toBe(" TwentyCharsQuipQuiz! "); // own leading AND trailing space
     expect(shown.slice(27)).toBe("─".repeat(2)); // trailing = 29 − 1 − 4 − (1 + 20 + 1)
     rowFirmsToDashes(shown, 29);
+  });
+});
+
+// ── 3c. Quip timer rotation (in-episode re-rotation, random 15–45s) ──
+// The in-episode rotation rides the existing spin tick (no new interval):
+// a counter accumulates while busy; at the per-episode random threshold
+// (inclusive 15–45s from the injected `quipRand`, `ceil` ticks, never
+// shorter than requested) the quip is re-picked (`exclude` = current, the
+// same one-re-roll contract). A new episode always re-picks + resets.
+// Idle freezes the counter (no rotation across gaps; the label persists).
+// Forced periods go through `as any` field overrides (no setting reaches
+// them: `SPIN_INTERVALS` max 80 ms × 1.5 (slow) = 120 ms); they must be
+// applied before the first busy tick (the window is drawn lazily there).
+
+describe("spin quips (in-episode timer rotation)", () => {
+  it("window threshold: 300 ms (divides 15000/30000/45000) → exact 15 / 30 / 45 s for the forced rand 0 / 0.5 / 1, within the ceil-form bounds", () => {
+    const draws: Array<[number, number]> = [[0, 50], [0.5, 100], [0.999, 150]];
+    for (const [r, ticksExact] of draws) {
+      const { editor } = makeEditor({ spin: true, spinStyle: "typing", idleSeq: [false] });
+      (editor as any).spinTickMs = 300;
+      (editor as any).quipRand = () => r;
+      tick(editor); // episode start → window drawn
+      const ticks = (editor as any).spinQuipEveryTicks as number;
+      expect(ticks, `rand ${r}`).toBe(ticksExact);
+    }
+  });
+
+  it("window threshold: 2000 ms + rand 1 → ceil(22.5) = 23 ticks = 46 s — the ceil-form bounds hold (never shorter than the request; at most one tick past the max)", () => {
+    const { editor } = makeEditor({ spin: true, spinStyle: "typing", idleSeq: [false] });
+    (editor as any).spinTickMs = 2000;
+    (editor as any).quipRand = () => 1;
+    tick(editor);
+    const ticks = (editor as any).spinQuipEveryTicks as number;
+    expect(ticks).toBe(23);
+    const seconds = (ticks * 2000) / 1000;
+    expect(seconds).toBeGreaterThanOrEqual(15);
+    expect(seconds).toBeLessThan(45 + 2000 / 1000);
+  });
+
+  it("one long busy episode (T = 50, N = 60 ticks @ 300 ms, T < N < 2T): exactly one re-pick (at tick 50, `exclude` = the previous), counter reset, next window re-drawn, border shows the rotation's quip", () => {
+    const { editor } = makeEditor({
+      spin: true,
+      spinStyle: "typing",
+      // The seq feeds isIdle() in [quip block, border spinner] order — two readers per tick.
+      idleSeq: Array(120).fill(false),
+    });
+    (editor as any).spinTickMs = 300;
+    (editor as any).quipRand = () => 0;
+    for (let i = 0; i < 60; i++) tick(editor);
+    expect(pickQuip).toHaveBeenCalledTimes(2); // episode pick + the one rotation
+    expect(pickQuip).toHaveBeenNthCalledWith(2, "Quip A", expect.any(Function));
+    expect((editor as any).spinQuip).toBe("Quip B");
+    expect((editor as any).spinQuipTicks).toBe(9); // 60 − 50, reset after the re-pick
+    expect((editor as any).spinQuipEveryTicks).toBe(50); // re-drawn (rand 0)
+    (editor as any).isIdle = () => false; // render reads isIdle() itself (the seq is exhausted)
+    const run = borderRun(editor.render(60), 60);
+    expect(run).toContain(" Quip B ");
+  });
+
+  it("while idle: the counter is frozen (no cumulative rotation across the gap, 44 + 30 idle < never reached), the pick count doesn't move, and the label survives; the next episode re-picks + resets", () => {
+    const { editor } = makeEditor({
+      spin: true,
+      spinStyle: "typing",
+      // Two readers per tick: 45 busy ticks = 90 falses, 30 idle ticks = 60 trues, 2 busy ticks = 4 falses.
+      idleSeq: [...Array(90).fill(false), ...Array(60).fill(true), false, false, false, false],
+    });
+    (editor as any).spinTickMs = 300;
+    (editor as any).quipRand = () => 0;
+    for (let i = 0; i < 45; i++) tick(editor); // busy → ticks 44 (< T = 50)
+    expect((editor as any).spinQuipTicks).toBe(44);
+    for (let i = 0; i < 30; i++) tick(editor); // idle → frozen
+    expect((editor as any).spinQuipTicks).toBe(44);
+    expect(pickQuip).toHaveBeenCalledTimes(1);
+    expect((editor as any).spinQuip).toBe("Quip A");
+    for (let i = 0; i < 2; i++) tick(editor); // busy again → new episode: pick #2 + reset
+    expect(pickQuip).toHaveBeenCalledTimes(2);
+    expect(pickQuip).toHaveBeenNthCalledWith(2, "Quip A", expect.any(Function));
+    expect((editor as any).spinQuip).toBe("Quip B");
+    expect((editor as any).spinQuipTicks).toBe(1);
+  });
+
+  it("real (unmocked) rand: 10 consecutive episode windows all within [15 s, 45 s + 1 tick period)", () => {
+    for (let i = 0; i < 10; i++) {
+      const { editor } = makeEditor({ spin: true, spinStyle: "typing", idleSeq: [false, true] });
+      tick(editor); // episode start — the default `Math.random` quipRand draws the window
+      const ticks = (editor as any).spinQuipEveryTicks as number;
+      const ms = (editor as any).spinTickMs as number;
+      const seconds = (ticks * ms) / 1000;
+      expect(seconds, `window ${i + 1}`).toBeGreaterThanOrEqual(15);
+      expect(seconds, `window ${i + 1}`).toBeLessThan(45 + ms / 1000);
+      tick(editor); // idle — end of episode
+    }
   });
 });
 

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -23,7 +23,7 @@ import {
 } from "../chrome.js";
 import { isParentBorder, formatKey } from "../text.js";
 import { SPIN_INTERVALS, BorderTypeSpinner } from "./spin.js";
-import { pickQuip } from "./spin-quips.js";
+import { pickQuip, QUIP_ROTATION_MAX_SECS, QUIP_ROTATION_MIN_SECS } from "./spin-quips.js";
 import { SPIN_SPEED_MULT, type CoreConfig, type SpinnerStyle } from "../config.js";
 
 const DOUBLE_PRESS_WINDOW_MS = 500;
@@ -53,6 +53,14 @@ export class HephaestusEditor extends CustomEditor {
   private wasBusy = false;
   /** The border-row spin spinner (mechanism in `BorderTypeSpinner`): the `spinStyle` (raw setting strings normalize — unknown names fall back to typing frames) — created only when `spin` is on, so the off path stays fully inert. The tick period is the style's native tempo × the `spinSpeed` multiplier, 32 ms floor. */
   private readonly borderSpinner: BorderTypeSpinner | undefined;
+  /** The quip rotation tick period in ms — set to the style tempo when `spin` is on; the 32 ms default is inert (`rotationThresholdTicks()` is only reached on busy ticks, which imply spin is on). */
+  private readonly spinTickMs: number = 32;
+  /** In-episode quip rotation — the counter accumulates busy ticks; at the per-episode random threshold it re-picks the quip. Frozen while idle (no re-rotation across gaps); a new episode re-picks + resets. */
+  private spinQuipTicks = 0;
+  /** The current rotation window's threshold in ticks — a per-episode draw (see `rotationThresholdTicks()`); the `0` default is never read before the idle→busy branch assigns it (the counter only increments after that branch has run). */
+  private spinQuipEveryTicks = 0;
+  /** The injected random source for the in-episode quip rotation window (inclusive 15–45 s); tests override via `as any`, the same seam as `isIdle` — the constructor gains no signature change. */
+  private quipRand: () => number = Math.random;
   private readonly onSpinInterval:
     | ((interval: ReturnType<typeof setInterval> | undefined) => void)
     | undefined;
@@ -81,7 +89,7 @@ export class HephaestusEditor extends CustomEditor {
       spinSpeed?: CoreConfig["editorSpinSpeed"];
       /** The `editorSpinStyle` setting — the default style, from the config default (pendulum); raw setting strings are tolerated, but unknown names still normalize to typing frames (the normalizer's fallback, kept distinct from the default). */
       spinStyle?: SpinnerStyle | string;
-      /** Label typed after the window while busy (the `editorSpinLabel` setting): an empty string hides it. The default `"Working"` (and a hand-typed `"Working"`, indistinguishable from it) is replaced by a random quip picked once per busy episode; any other non-empty string is shown verbatim. Non-string values (corrupt config) fall back to `"Working"` — i.e. quip mode. */
+      /** Label typed after the window while busy (the `editorSpinLabel` setting): an empty string hides it. The default `"Working"` (and a hand-typed `"Working"`, indistinguishable from it) is replaced by a random quip picked once per busy episode, re-picked on a subtle random 15–45 s timer while a long episode continues; any other non-empty string is shown verbatim. Non-string values (corrupt config) fall back to `"Working"` — i.e. quip mode. */
       spinLabel?: string;
       /** Lets an out-of-editor scope (core index.ts session hooks) clear the timer. */
       onSpinInterval?: (
@@ -111,11 +119,11 @@ export class HephaestusEditor extends CustomEditor {
     if (spin) {
       // The style's native per-tick tempo × the `editorSpinSpeed` multiplier, 32 ms tick floor (the floor also caps a 30 ms native style under `fast` at 32); unknown raw strings fall back to the typing native (the normalize fallback).
       const nativeMs = SPIN_INTERVALS[spinStyle as SpinnerStyle];
-      const spinTickMs = Math.max(
+      this.spinTickMs = Math.max(
         32,
         (nativeMs ?? SPIN_INTERVALS["typing"]) * (SPIN_SPEED_MULT[spinSpeed] ?? 1),
       );
-      this.spinTimer = setInterval(() => this.tickSpin(), spinTickMs);
+      this.spinTimer = setInterval(() => this.tickSpin(), this.spinTickMs);
       this.onSpinInterval?.(this.spinTimer);
     }
   }
@@ -131,16 +139,35 @@ export class HephaestusEditor extends CustomEditor {
 
   // ── Prompt spin ───────────────────────────────────────
 
-  /** Advances the spin; in quip mode the per-episode selection lands BEFORE the border-spinner repaint. */
+  /** Advances the spin; in quip mode the selection (per-episode pick, and the in-episode re-pick at the computed window's threshold) lands BEFORE the border-spinner repaint. While idle, the rotation counter is frozen (the label remains; no re-rotation across the gap). */
   private tickSpin(): void {
     if (this.labelMode === "quip") {
       const busy = this.spinEnabled && !this.isIdle();
-      if (busy && !this.wasBusy) this.spinQuip = pickQuip(this.spinQuip);
+      if (busy && !this.wasBusy) {
+        // Episode start: fresh quip + reset the rotation window.
+        this.spinQuip = pickQuip(this.spinQuip, this.quipRand);
+        this.spinQuipTicks = 0;
+        this.spinQuipEveryTicks = this.rotationThresholdTicks();
+      } else if (busy) {
+        this.spinQuipTicks += 1;
+        if (this.spinQuipTicks >= this.spinQuipEveryTicks) {
+          // In-episode re-rotation: re-pick (excludes the current), reset the counter, draw the next window.
+          this.spinQuip = pickQuip(this.spinQuip, this.quipRand);
+          this.spinQuipTicks = 0;
+          this.spinQuipEveryTicks = this.rotationThresholdTicks();
+        }
+      }
       this.wasBusy = busy;
     }
     if (this.borderSpinner && this.borderSpinner.tick()) {
       this.tui.requestRender();
     }
+  }
+
+  /** The random 15–45 s window (inclusive, from the injected `quipRand`) in whole ticks — `ceil`'d so the window is never shorter than requested (at most one tick over the max). */
+  private rotationThresholdTicks(): number {
+    const seconds = QUIP_ROTATION_MIN_SECS + Math.floor(this.quipRand() * (QUIP_ROTATION_MAX_SECS - QUIP_ROTATION_MIN_SECS + 1));
+    return Math.ceil((seconds * 1000) / this.spinTickMs);
   }
 
   /** The 4-cell window that replaces a segment of the border (mechanism in `BorderTypeSpinner`): cells fill cell-by-cell left→right, the current step's stage chars rendered in the spin (accent) palette (⠁⠉ / ⠋⠛ / ⠟⠿ / ⡿⣿; EAW: the width-1 shading ░ → █) — the 2×4 dot block grows across the window — the not-yet-reached cells are plain spaces (the border line breaks) — plain " " (U+0020). The empty clear step (step 0) is all spaces; hold steps clamp to the last (fully grown) frame. The window sits one leading space after `┌` at start 0 (right at the corner), and the label follows it typed as `" " + spinLabel + " "` — its own leading and trailing spaces, with the trailing one providing the margin to the trailing dashes. */

--- a/packages/core/src/editor/spin-quips.test.ts
+++ b/packages/core/src/editor/spin-quips.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { SPIN_QUIPS, pickQuip } from "./spin-quips.js";
+import { SPIN_QUIPS, pickQuip, QUIP_ROTATION_MIN_SECS, QUIP_ROTATION_MAX_SECS } from "./spin-quips.js";
 
 // ── SPIN_QUIPS pool invariants ───────────────────────────────────────────────
 
@@ -48,6 +48,18 @@ describe("SPIN_QUIPS", () => {
 
   it("is frozen", () => {
     expect(Object.isFrozen(SPIN_QUIPS)).toBe(true);
+  });
+});
+
+// ── Quip rotation constants ──────────────────────────────────────────────────
+
+describe("QUIP_ROTATION_* constants", () => {
+  it("are the inclusive 15 s / 45 s bounds, min < max, integers", () => {
+    expect(QUIP_ROTATION_MIN_SECS).toBe(15);
+    expect(QUIP_ROTATION_MAX_SECS).toBe(45);
+    expect(QUIP_ROTATION_MIN_SECS).toBeLessThan(QUIP_ROTATION_MAX_SECS);
+    expect(Number.isInteger(QUIP_ROTATION_MIN_SECS)).toBe(true);
+    expect(Number.isInteger(QUIP_ROTATION_MAX_SECS)).toBe(true);
   });
 });
 

--- a/packages/core/src/editor/spin-quips.ts
+++ b/packages/core/src/editor/spin-quips.ts
@@ -31,6 +31,10 @@ export const SPIN_QUIPS: readonly string[] = Object.freeze([
 ]);
 
 /** Uniformly pick a quip; `exclude` (the previous episode's quip) is never returned — if the first draw lands on it, exactly one re-roll restricted to entries ≠ `exclude` (no loops). `rand` is injectable for deterministic tests. */
+/** In-episode quip rotation bounds — the quip is re-picked on a random window drawn inclusive between these seconds (from the editor's injected random source), only while a busy episode continues; a new episode always re-picks and resets the window. */
+export const QUIP_ROTATION_MIN_SECS = 15;
+export const QUIP_ROTATION_MAX_SECS = 45;
+
 export function pickQuip(exclude?: string, rand: () => number = Math.random): string {
   const pick = (customPool: readonly string[]): string =>
     customPool[Math.floor(rand() * customPool.length)]!;


### PR DESCRIPTION
## Summary
- Long busy episodes now **re-rotate the spinner quip on a random 15–45 s timer** (subtle, never predictable) on top of the shipped per-episode pick — a 2-minute build shows a fresh quip roughly every 15–45 s instead of one for the whole run.
- **Zero-config, no new interval** — the rotation rides the existing `spinTimer` tick: a per-episode tick counter accumulates while busy and, at a lazily drawn threshold (inclusive 15–45 s from an injectable rand, `ceil`'d ticks so the window is never shorter than requested), re-picks via the existing `pickQuip(exclude)` contract (no back-to-back repeats).
- Confirmed interactions: a **new episode always re-picks + resets the window** (a gating gap shows a fresh quip); **idle freezes the counter** — the label still persists through gaps and the re-pick count never moves on idle ticks; `spin: false` / custom / empty labels and the narrow-terminal window-only tier are untouched (the quip block is the only place these fields are read).
- `QUIP_ROTATION_MIN_SECS` / `MAX_SECS` exported from `spin-quips.ts`; `spinTickMs` promoted to a field (32 ms inert default when `spin` is off); the rotation's rand injected like the existing `isIdle` test seam — the constructor's signature is unchanged.
- README + glossary document the behavior ("picked per busy episode, re-picked on a random 15–45 s timer while long episodes continue").

## Test plan
- [x] 6 new tests: window bounds (300 ms exact 15/30/45 s draws; 2000 ms `ceil(22.5)` = 23 ticks = 46 s exercising the loose ceiling bound), in-episode re-pick (T = 50, N = 60 → exactly one, `exclude` = previous, counter reset, window re-drawn, border shows the rotated quip), idle freeze (44 + 30 idle ticks — counter frozen, single pick, next episode re-pick + reset), real `Math.random` sanity (10 consecutive windows within [15 s, 45 s + 1 tick period))
- [x] All 42 shipped editor cases + 12 pool cases green (mock factory extended with the new constants)
- [x] `tsc --noEmit` green in all 11 package dirs; `pnpm test` green (75 files / 1384 tests)
- [ ] Manual: 1+ minute busy run — label changes at irregular 15–45 s intervals; idle gap preserves the last label; a new episode changes it immediately